### PR TITLE
Partially implement log records

### DIFF
--- a/src/block_id.rs
+++ b/src/block_id.rs
@@ -5,6 +5,9 @@ pub struct BlockId<'a> {
 
 impl<'a> BlockId<'a> {
     pub fn new(file_name: &'a str, block_slot: usize) -> Self {
-        BlockId { file_name, block_slot }
+        BlockId {
+            file_name,
+            block_slot,
+        }
     }
 }

--- a/src/file_manager.rs
+++ b/src/file_manager.rs
@@ -7,7 +7,7 @@ use crate::{block_id::BlockId, page::Page};
 
 pub struct FileManager {
     directory: PathBuf,
-    block_size: usize,
+    pub block_size: usize,
     opened_files: RwLock<HashMap<String, Arc<Mutex<File>>>>,
 }
 
@@ -27,7 +27,9 @@ impl FileManager {
     pub fn write(&mut self, block_id: &BlockId, page: &Page) -> Result<()> {
         let binding = self.load_and_cache_file(block_id);
         let mut file = binding.lock().unwrap();
-        file.seek(SeekFrom::Start((block_id.block_slot * self.block_size) as u64))?;
+        file.seek(SeekFrom::Start(
+            (block_id.block_slot * self.block_size) as u64,
+        ))?;
         file.write(page.byte_buffer.as_slice())?;
         Ok(())
     }
@@ -35,7 +37,9 @@ impl FileManager {
     pub fn read(&mut self, block_id: &BlockId, page: &mut Page) -> Result<()> {
         let binding = self.load_and_cache_file(block_id);
         let mut file = binding.lock().unwrap();
-        file.seek(SeekFrom::Start((block_id.block_slot * self.block_size) as u64))?;
+        file.seek(SeekFrom::Start(
+            (block_id.block_slot * self.block_size) as u64,
+        ))?;
         file.read_exact(&mut page.byte_buffer)?;
         Ok(())
     }
@@ -61,11 +65,19 @@ impl FileManager {
             .read(true)
             .write(true)
             .create(true)
-             .open(file_path)
+            .open(file_path)
             .unwrap();
         let value = Arc::new(Mutex::new(file));
         hash_map.insert(block_id.file_name.to_string(), value.clone());
         return value;
+    }
+
+    pub fn get_num_blocks(&self, file_name: &str) -> usize {
+        todo!()
+    }
+
+    pub fn append_block<'a>(&mut self, file_name: &'a str) -> BlockId<'a> {
+        todo!()
     }
 }
 

--- a/src/file_manager.rs
+++ b/src/file_manager.rs
@@ -25,7 +25,7 @@ impl FileManager {
     }
 
     pub fn write(&mut self, block_id: &BlockId, page: &Page) -> Result<()> {
-        let binding = self.load_and_cache_file(block_id);
+        let binding = self.load_and_cache_file(block_id.file_name);
         let mut file = binding.lock().unwrap();
         file.seek(SeekFrom::Start(
             (block_id.block_slot * self.block_size) as u64,
@@ -35,7 +35,7 @@ impl FileManager {
     }
 
     pub fn read(&mut self, block_id: &BlockId, page: &mut Page) -> Result<()> {
-        let binding = self.load_and_cache_file(block_id);
+        let binding = self.load_and_cache_file(block_id.file_name);
         let mut file = binding.lock().unwrap();
         file.seek(SeekFrom::Start(
             (block_id.block_slot * self.block_size) as u64,
@@ -44,23 +44,34 @@ impl FileManager {
         Ok(())
     }
 
-    fn load_and_cache_file(&mut self, block_id: &BlockId) -> Arc<Mutex<File>> {
-        if let Some(file) = self
-            .opened_files
-            .try_read()
-            .unwrap()
-            .get(block_id.file_name)
-        {
+    pub fn get_num_blocks(&mut self, file_name: &str) -> usize {
+        let binding = self.load_and_cache_file(file_name);
+        let file = binding.lock().unwrap();
+        file.metadata().unwrap().len() as usize / self.block_size
+    }
+
+    pub fn append_block<'a>(&mut self, file_name: &'a str) -> Result<BlockId<'a>> {
+        let binding = self.load_and_cache_file(file_name);
+        let mut file = binding.lock().unwrap();
+        let num_blocks = file.metadata().unwrap().len() as usize / self.block_size;
+        let new_block_id = BlockId::new(file_name, num_blocks);
+        let new_block_contents = vec![0; self.block_size];
+        file.write(new_block_contents.as_slice())?;
+        Ok(new_block_id)
+    }
+
+    fn load_and_cache_file(&mut self, file_name: &str) -> Arc<Mutex<File>> {
+        if let Some(file) = self.opened_files.try_read().unwrap().get(file_name) {
             return file.clone();
         }
 
         // Check if the file is added before acquiring the write lock
         let mut hash_map = self.opened_files.try_write().unwrap();
-        if hash_map.contains_key(block_id.file_name) {
-            return hash_map.get(block_id.file_name).unwrap().clone();
+        if hash_map.contains_key(file_name) {
+            return hash_map.get(file_name).unwrap().clone();
         }
 
-        let file_path = self.directory.join(block_id.file_name);
+        let file_path = self.get_path(file_name);
         let file = std::fs::OpenOptions::new()
             .read(true)
             .write(true)
@@ -68,16 +79,12 @@ impl FileManager {
             .open(file_path)
             .unwrap();
         let value = Arc::new(Mutex::new(file));
-        hash_map.insert(block_id.file_name.to_string(), value.clone());
+        hash_map.insert(file_name.to_string(), value.clone());
         return value;
     }
 
-    pub fn get_num_blocks(&self, file_name: &str) -> usize {
-        todo!()
-    }
-
-    pub fn append_block<'a>(&mut self, file_name: &'a str) -> BlockId<'a> {
-        todo!()
+    fn get_path(&self, file_name: &str) -> PathBuf {
+        self.directory.join(file_name)
     }
 }
 
@@ -102,6 +109,21 @@ mod tests {
         let mut page1 = Page::new(file_manager.block_size);
         file_manager.read(&block_id, &mut page1)?;
         assert_eq!(page1.get_i32(80), 100);
+        Ok(())
+    }
+
+    #[test]
+    fn test_append_blocks() -> Result<()> {
+        let temp_dir = tempfile::tempdir().unwrap().into_path().join("directory");
+        let block_size = 256;
+        let mut file_manager = FileManager::new(temp_dir, block_size);
+
+        assert_eq!(file_manager.get_num_blocks("testfile"), 0);
+        for i in 0..10 {
+            let block_id = file_manager.append_block("testfile")?;
+            assert_eq!(block_id.block_slot, i);
+            assert_eq!(file_manager.get_num_blocks("testfile"), i + 1);
+        }
         Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
-mod page;
-mod file_manager;
 mod block_id;
+mod file_manager;
+mod log;
+mod page;

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,9 +1,16 @@
-use std::io::Result;
+use std::{io::Result, mem, sync::Mutex};
 
 use crate::{block_id::BlockId, file_manager::FileManager, page::Page};
 
 enum LogRecord {
     Start,
+}
+impl LogRecord {
+    fn to_bytes(&self) -> &[u8] {
+        match self {
+            LogRecord::Start => &['S' as u8],
+        }
+    }
 }
 
 struct LogManager {
@@ -11,6 +18,9 @@ struct LogManager {
     log_file: String,
     log_page: Page,
     current_block_slot: usize,
+    append_lock: Mutex<()>,
+    latest_log_sequence_number: usize,
+    last_saved_log_sequence_number: usize,
 }
 
 /// The log manager is responsible for writing log records to the log file.
@@ -23,35 +33,85 @@ impl LogManager {
         let mut log_page = Page::new(file_manager.block_size);
 
         let log_file_for_block_id = log_file.clone();
-        let current_block = if num_blocks == 0 {
+        let current_block_slot = if num_blocks == 0 {
             // Create the first block of the file
-            let current_block = file_manager.append_block(&log_file_for_block_id);
+            let current_block_slot = file_manager.append_block(&log_file_for_block_id)?;
 
             // Currently, page cannot store usize values
             log_page.set_i32(0, file_manager.block_size as i32);
-            file_manager.write(&current_block, &log_page)?;
-            current_block
+            file_manager.write(
+                &BlockId::new(&log_file_for_block_id, current_block_slot),
+                &log_page,
+            )?;
+            current_block_slot
         } else {
             // Read the last block of the file
             let current_block = BlockId::new(&log_file_for_block_id, num_blocks - 1);
             file_manager.read(&current_block, &mut log_page)?;
-            current_block
+            current_block.block_slot
         };
 
         Ok(Self {
             file_manager,
             log_file,
             log_page,
-            current_block_slot: current_block.block_slot,
+            current_block_slot,
+            append_lock: Mutex::new(()),
+            latest_log_sequence_number: 0,
+            last_saved_log_sequence_number: 0,
         })
     }
 
-    pub fn append_record(&mut self, log_record: &LogRecord) -> Result<()> {
-        unimplemented!()
+    pub fn append_record(&mut self, log_record: &LogRecord) -> Result<usize> {
+        let _lock = self.append_lock.lock().unwrap();
+        let mut boundary = self.log_page.get_i32(0) as usize;
+        let record_bytes = log_record.to_bytes();
+        let record_size = record_bytes.len();
+        let boundary_size = mem::size_of::<i32>();
+
+        if boundary < record_size + boundary_size {
+            // The record does not fit in the current block
+
+            // Save the current page into the file
+            self.file_manager.write(
+                &BlockId::new(&self.log_file, self.current_block_slot),
+                &self.log_page,
+            )?;
+            self.last_saved_log_sequence_number = self.latest_log_sequence_number;
+
+            // Create a new block
+            let new_block_slot = self.file_manager.append_block(&self.log_file)?;
+            self.log_page
+                .set_i32(0, self.file_manager.block_size as i32);
+            self.file_manager.write(
+                &BlockId::new(&self.log_file, new_block_slot),
+                &mut self.log_page,
+            )?;
+            self.current_block_slot = new_block_slot;
+            boundary = self.log_page.get_i32(0) as usize;
+        }
+
+        let record_position = boundary - record_size;
+        self.log_page.set_bytes(record_position, record_bytes);
+        self.log_page.set_i32(0, record_position as i32);
+        self.latest_log_sequence_number += 1;
+        Ok(self.latest_log_sequence_number)
     }
 
-    pub fn flush(&mut self) -> Result<()> {
-        unimplemented!()
+    pub fn flush(&mut self, least_log_sequence_number: usize) -> Result<()> {
+        if least_log_sequence_number >= self.last_saved_log_sequence_number {
+            self.do_flush()?;
+        }
+        Ok(())
+    }
+
+    fn do_flush(&mut self) -> Result<()> {
+        self.file_manager.write(
+            &BlockId::new(&self.log_file, self.current_block_slot),
+            &self.log_page,
+        )?;
+        self.last_saved_log_sequence_number = self.latest_log_sequence_number;
+        Ok(())
     }
 }
 
@@ -64,7 +124,7 @@ mod tests {
         let file_manager = FileManager::new("data".into(), 1024);
         let mut log_manager = LogManager::new(file_manager, "log".into())?;
         log_manager.append_record(&LogRecord::Start)?;
-        log_manager.flush()?;
+        log_manager.flush(1)?;
         Ok(())
     }
 }

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,0 +1,70 @@
+use std::io::Result;
+
+use crate::{block_id::BlockId, file_manager::FileManager, page::Page};
+
+enum LogRecord {
+    Start,
+}
+
+struct LogManager {
+    file_manager: FileManager,
+    log_file: String,
+    log_page: Page,
+    current_block_slot: usize,
+}
+
+/// The log manager is responsible for writing log records to the log file.
+/// The log file is a sequence of blocks, and the log manager appends log records to the last block.
+/// The log records are written to the log file from right to left.
+/// The first byte of the block contains the offset to the most recent log record.
+impl LogManager {
+    pub fn new(mut file_manager: FileManager, log_file: String) -> Result<Self> {
+        let num_blocks = file_manager.get_num_blocks(&log_file);
+        let mut log_page = Page::new(file_manager.block_size);
+
+        let log_file_for_block_id = log_file.clone();
+        let current_block = if num_blocks == 0 {
+            // Create the first block of the file
+            let current_block = file_manager.append_block(&log_file_for_block_id);
+
+            // Currently, page cannot store usize values
+            log_page.set_i32(0, file_manager.block_size as i32);
+            file_manager.write(&current_block, &log_page)?;
+            current_block
+        } else {
+            // Read the last block of the file
+            let current_block = BlockId::new(&log_file_for_block_id, num_blocks - 1);
+            file_manager.read(&current_block, &mut log_page)?;
+            current_block
+        };
+
+        Ok(Self {
+            file_manager,
+            log_file,
+            log_page,
+            current_block_slot: current_block.block_slot,
+        })
+    }
+
+    pub fn append_record(&mut self, log_record: &LogRecord) -> Result<()> {
+        unimplemented!()
+    }
+
+    pub fn flush(&mut self) -> Result<()> {
+        unimplemented!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_log_manager() -> Result<()> {
+        let file_manager = FileManager::new("data".into(), 1024);
+        let mut log_manager = LogManager::new(file_manager, "log".into())?;
+        log_manager.append_record(&LogRecord::Start)?;
+        log_manager.flush()?;
+        Ok(())
+    }
+}

--- a/src/page.rs
+++ b/src/page.rs
@@ -8,7 +8,7 @@ impl Page {
             byte_buffer: vec![0; block_size],
         }
     }
-    
+
     pub fn set_i32(&mut self, offset: usize, value: i32) -> () {
         let bytes = value.to_le_bytes();
         self.byte_buffer[offset..offset + 4].copy_from_slice(&bytes);
@@ -21,6 +21,10 @@ impl Page {
             self.byte_buffer[offset + 2],
             self.byte_buffer[offset + 3],
         ])
+    }
+
+    pub fn set_bytes(&mut self, offset: usize, bytes: &[u8]) -> () {
+        self.byte_buffer[offset..offset + bytes.len()].copy_from_slice(bytes);
     }
 }
 


### PR DESCRIPTION
The current log manager supports only "START" log record. The remaining records will be supporting when implementing transaction. 