### PR TITLE
Fix error message typo

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -9,7 +9,7 @@ pub enum TransactionError {
     #[error("BufferAbortError")]
     BufferAbortError,
 
-    #[error("TooSmallBlockoError: (block_size: {0}, record_size: {1})")]
+    #[error("TooSmallBlockError: (block_size: {0}, record_size: {1})")]
     TooSmallBlockError(usize, usize),
 
     #[error("IO error: {0}")]


### PR DESCRIPTION
## Summary
- fix `TooSmallBlockError` message typo

## Testing
- `cargo test --quiet` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_684d2009cfe8832995e5c2eaa4aa22a6