### PR TITLE
Resolve #59

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -40,3 +40,29 @@ pub enum ExecutionError {
     #[error("QueryError: {0}")]
     QueryError(#[from] QueryError),
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_error_conversion() {
+        let parse_error: ParseError<usize, Token<'_>, &str> = ParseError::UnrecognizedToken {
+            token: (0, Token(0, "foo"), 3),
+            expected: vec!["bar".to_string()],
+        };
+
+        let query_error = QueryError::from(parse_error);
+        match query_error {
+            QueryError::ParseError(inner) => {
+                assert_eq!(
+                    inner,
+                    ParseError::UnrecognizedToken {
+                        token: (0, "foo".to_string(), 3),
+                        expected: vec!["bar".to_string()],
+                    }
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fix #59 

## Summary
- add unit test for converting ParseError into QueryError

## Testing
- `cargo test -- --test-threads=1`

------
https://chatgpt.com/codex/tasks/task_e_684ef45aad28832991c8bc9f6e672073