### PR TITLE
Add network driver integration test

### DIFF
--- a/src/driver/network/driver.rs
+++ b/src/driver/network/driver.rs
@@ -113,3 +113,88 @@ impl DriverControl for NetworkDriver {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::proto::simpledb::{
+        connection_service_server::ConnectionServiceServer,
+        driver_service_server::DriverServiceServer,
+        metadata_service_server::MetadataServiceServer,
+        result_set_service_server::ResultSetServiceServer,
+        statement_service_server::StatementServiceServer,
+    };
+    use crate::driver::{
+        ConnectionControl, MetadataControl, ResultSetControl, StatementControl,
+    };
+    use std::thread;
+    use std::time::Duration;
+    use tokio::runtime::Runtime;
+    use tokio::sync::oneshot;
+    use tonic::transport::Server;
+
+    #[test]
+    fn test_network_driver_basic_flow() -> Result<(), anyhow::Error> {
+        let temp_dir = tempfile::tempdir()?.into_path();
+
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+
+        let _server_thread = {
+            let temp_dir = temp_dir.clone();
+            thread::spawn(move || {
+                std::env::set_current_dir(temp_dir).unwrap();
+                let rt = Runtime::new().unwrap();
+                rt.block_on(async move {
+                    let addr = "127.0.0.1:50051".parse().unwrap();
+
+                    let remote_driver = RemoteDriver::new();
+                    let remote_connection = remote_driver.create_remote_connection();
+                    let remote_statement = remote_connection.create_remote_statement();
+                    let remote_result_set = remote_statement.create_remote_result_set();
+                    let remote_metadata = remote_result_set.create_remote_metadata();
+
+                    Server::builder()
+                        .add_service(DriverServiceServer::new(remote_driver))
+                        .add_service(ConnectionServiceServer::new(remote_connection))
+                        .add_service(StatementServiceServer::new(remote_statement))
+                        .add_service(ResultSetServiceServer::new(remote_result_set))
+                        .add_service(MetadataServiceServer::new(remote_metadata))
+                        .serve_with_shutdown(addr, async {
+                            shutdown_rx.await.ok();
+                        })
+                        .await
+                        .unwrap();
+                });
+            })
+        };
+
+        // give the server a moment to start
+        thread::sleep(Duration::from_millis(100));
+
+        let driver = NetworkDriver::new();
+        let (_db_name, connection) = driver.connect("jdbc:simpledb://127.0.0.1")?;
+
+        let mut statement = connection.create_statement()?;
+        statement.execute_update("create table test (A I32, B VARCHAR(20))")?;
+        statement.execute_update("insert into test (A, B) values (1, 'a')")?;
+        statement.execute_update("insert into test (A, B) values (2, 'b')")?;
+
+        let mut result_set = statement.execute_query("select B from test where A = 1")?;
+        let metadata = result_set.get_metadata()?;
+        assert_eq!(metadata.get_column_count()?, 1);
+        assert_eq!(metadata.get_column_name(0)?, "B");
+
+        assert!(result_set.next()?);
+        assert_eq!(result_set.get_string("B")?, "a");
+        assert!(!result_set.next()?);
+        result_set.close()?;
+
+        // Drop the connection instead of explicitly closing to avoid
+        // blocking on the server side during the test.
+        drop(connection);
+
+        shutdown_tx.send(()).ok();
+        // Allow the server to shut down asynchronously.
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary
- add a basic network driver flow test that starts a gRPC server and runs queries

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684f2920cd0483299d0bbc073db647f8