### PR TITLE
Implement null field support

### DIFF
--- a/src/record/layout.rs
+++ b/src/record/layout.rs
@@ -6,29 +6,39 @@ use super::schema::{Schema, MAX_STRING_LENGTH_BYTES};
 pub struct Layout {
     pub schema: Schema,
     field_name_to_offsets: HashMap<String, usize>,
+    field_name_to_bit_locations: HashMap<String, u8>,
     pub slot_size: usize,
 }
 
 impl Layout {
     pub fn new(schema: Schema) -> Self {
-        let mut field_offsets = vec![];
+        assert!(
+            schema.i32_fields.len() + schema.string_fields.len() < 32,
+            "Layout supports at most 31 fields"
+        );
         let mut field_name_to_offsets = HashMap::new();
-        // 4 bytes is used for representing vacant or occupied slot.
+        let mut field_name_to_bit_locations = HashMap::new();
+        // 4 bytes is used for representing vacant or occupied slot and null bits.
         let mut offset = 4;
+        let mut bit = 1u8;
         for field_name in &schema.i32_fields {
-            field_offsets.push(offset);
             field_name_to_offsets.insert(field_name.to_string(), offset);
+            field_name_to_bit_locations.insert(field_name.to_string(), bit);
             offset += 4;
+            bit += 1;
         }
 
         for i in 0..schema.string_fields.len() {
-            field_offsets.push(offset);
-            field_name_to_offsets.insert(schema.string_fields[i].to_string(), offset);
+            let name = schema.string_fields[i].to_string();
+            field_name_to_offsets.insert(name.clone(), offset);
+            field_name_to_bit_locations.insert(name, bit);
             offset += MAX_STRING_LENGTH_BYTES + schema.string_max_lengths[i];
+            bit += 1;
         }
         Layout {
             schema,
             field_name_to_offsets,
+            field_name_to_bit_locations,
             slot_size: offset,
         }
     }
@@ -57,6 +67,13 @@ impl Layout {
 
     pub fn get_offset(&self, field_name: &str) -> usize {
         *self.field_name_to_offsets.get(field_name).unwrap()
+    }
+
+    pub fn bit_location(&self, field_name: &str) -> u8 {
+        *self
+            .field_name_to_bit_locations
+            .get(field_name)
+            .unwrap()
     }
 
     pub fn has_field(&self, field_name: &str) -> bool {

--- a/src/record/layout.rs
+++ b/src/record/layout.rs
@@ -10,11 +10,14 @@ pub struct Layout {
     pub slot_size: usize,
 }
 
+const MAX_NUM_FIELDS: usize = 31;
+
 impl Layout {
     pub fn new(schema: Schema) -> Self {
         assert!(
-            schema.i32_fields.len() + schema.string_fields.len() < 32,
-            "Layout supports at most 31 fields"
+            schema.i32_fields.len() + schema.string_fields.len() <= MAX_NUM_FIELDS,
+            "Layout supports at most {} fields",
+            MAX_NUM_FIELDS
         );
         let mut field_name_to_offsets = HashMap::new();
         let mut field_name_to_bit_locations = HashMap::new();
@@ -69,11 +72,8 @@ impl Layout {
         *self.field_name_to_offsets.get(field_name).unwrap()
     }
 
-    pub fn bit_location(&self, field_name: &str) -> u8 {
-        *self
-            .field_name_to_bit_locations
-            .get(field_name)
-            .unwrap()
+    pub fn null_bit_location(&self, field_name: &str) -> u8 {
+        *self.field_name_to_bit_locations.get(field_name).unwrap()
     }
 
     pub fn has_field(&self, field_name: &str) -> bool {


### PR DESCRIPTION
Fix #74 

## Summary
- track null flags in `RecordPage`
  - add bit storage mapping in `Layout`
- expose null operations in `TableScan`
- test null handling

## Testing
- `cargo test`
- `cargo fmt -- --check` *(fails: could not download rustfmt)*

------
https://chatgpt.com/codex/tasks/task_e_685148df1e788329bc385292a1150e4e