### PR TITLE
Support null values in sort and index

### DIFF
--- a/src/record/field.rs
+++ b/src/record/field.rs
@@ -11,7 +11,7 @@ pub enum Type {
     String,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Ord)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Value {
     Null,
     I32(i32),
@@ -22,8 +22,26 @@ impl PartialOrd for Value {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         match (self, other) {
             (Value::Null, Value::Null) => Some(Ordering::Equal),
+            (Value::Null, _) => Some(Ordering::Greater),
+            (_, Value::Null) => Some(Ordering::Less),
             (Value::I32(a), Value::I32(b)) => a.partial_cmp(b),
             (Value::String(a), Value::String(b)) => a.partial_cmp(b),
+            _ => panic!(
+                "Cannot compare different value variants: {:?} and {:?}. Such comparison should be avoided by the caller.",
+                self, other
+            ),
+        }
+    }
+}
+
+impl Ord for Value {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match (self, other) {
+            (Value::Null, Value::Null) => Ordering::Equal,
+            (Value::Null, _) => Ordering::Greater,
+            (_, Value::Null) => Ordering::Less,
+            (Value::I32(a), Value::I32(b)) => a.cmp(b),
+            (Value::String(a), Value::String(b)) => a.cmp(b),
             _ => panic!(
                 "Cannot compare different value variants: {:?} and {:?}. Such comparison should be avoided by the caller.",
                 self, other


### PR DESCRIPTION
## Summary
- compare `Value::Null` as the largest value
- add null-handling support to `BTreePage`
- treat nulls properly when formatting B-Tree pages
- add tests for null in sorting and indexing

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68517aa1c6408329ad057f2dfd4235e3