### PR TITLE
Implement wasNull for ResultSet

### DIFF
--- a/proto/simpledb.proto
+++ b/proto/simpledb.proto
@@ -87,6 +87,7 @@ message ResultSetGetI32Request {
 
 message ResultSetGetI32Response {
     int32 value = 1;
+    bool was_null = 2;
 }
 
 message ResultSetGetStringRequest {
@@ -96,6 +97,7 @@ message ResultSetGetStringRequest {
 
 message ResultSetGetStringResponse {
     string value = 1;
+    bool was_null = 2;
 }
 
 message ResultSetCloseRequest {

--- a/src/client.rs
+++ b/src/client.rs
@@ -83,13 +83,21 @@ fn do_query<W: Write>(
 
             match column_type {
                 Type::I32 => {
-                    let val = result_set.get_i32(&column_name)?;
-                    let v = format!("{:>width$}", val, width = width);
+                    let val_opt = result_set.get_i32(&column_name)?;
+                    let val_display = match val_opt {
+                        Some(v) => v.to_string(),
+                        None => "NULL".to_string(),
+                    };
+                    let v = format!("{:>width$}", val_display, width = width);
                     write!(writer, "{}", v.yellow())?;
                 }
                 Type::String => {
-                    let val = result_set.get_string(&column_name)?;
-                    let v = format!("{:>width$}", val, width = width);
+                    let val_opt = result_set.get_string(&column_name)?;
+                    let val_display = match val_opt {
+                        Some(v) => v,
+                        None => "NULL".to_string(),
+                    };
+                    let v = format!("{:>width$}", val_display, width = width);
                     write!(writer, "{}", v.green())?;
                 }
             }

--- a/src/driver/embedded.rs
+++ b/src/driver/embedded.rs
@@ -106,21 +106,21 @@ impl ResultSetControl for EmbeddedResultSet {
     }
 
     fn get_i32(&mut self, column_name: &str) -> Result<Option<i32>, anyhow::Error> {
-        let value = self.scan.as_mut().unwrap().get_value(column_name)?;
-        match value {
-            Value::I32(v) => Ok(Some(v)),
-            Value::Null => Ok(None),
-            _ => Err(anyhow::anyhow!("Expected i32 value")),
-        }
+        self.scan
+            .as_mut()
+            .unwrap()
+            .get_i32(column_name)
+            .map_err(|e| anyhow::anyhow!("Error getting i32 from column '{}': {}", column_name, e))
     }
 
     fn get_string(&mut self, column_name: &str) -> Result<Option<String>, anyhow::Error> {
-        let value = self.scan.as_mut().unwrap().get_value(column_name)?;
-        match value {
-            Value::String(v) => Ok(Some(v)),
-            Value::Null => Ok(None),
-            _ => Err(anyhow::anyhow!("Expected string value")),
-        }
+        self.scan
+            .as_mut()
+            .unwrap()
+            .get_string(column_name)
+            .map_err(|e| {
+                anyhow::anyhow!("Error getting string from column '{}': {}", column_name, e)
+            })
     }
 
     fn close(&mut self) -> Result<(), anyhow::Error> {

--- a/src/driver/embedded.rs
+++ b/src/driver/embedded.rs
@@ -9,10 +9,7 @@ use crate::{
     errors::ExecutionError,
     plan::{Plan, PlanControl},
     planner::Planner,
-    record::{
-        field::{Type, Value},
-        schema::Schema,
-    },
+    record::{field::Type, schema::Schema},
     scan::{Scan, ScanControl},
     tx::transaction::Transaction,
 };
@@ -319,7 +316,7 @@ mod tests {
         let db_url = format!("jdbc:simpledb:{}", temp_dir.to_string_lossy());
 
         let driver = EmbeddedDriver::new();
-        let (_db_name, mut connection) = driver.connect(&db_url)?;
+        let (_db_name, connection) = driver.connect(&db_url)?;
 
         let mut statement = connection.create_statement()?;
         statement.execute_update("create table test (A I32, B VARCHAR(20))")?;

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -42,8 +42,8 @@ pub trait ResultSetControl {
     fn before_first(&mut self) -> Result<(), anyhow::Error>;
     fn after_last(&mut self) -> Result<(), anyhow::Error>;
     fn absolute(&mut self, n: usize) -> Result<bool, anyhow::Error>;
-    fn get_i32(&mut self, column_name: &str) -> Result<i32, anyhow::Error>;
-    fn get_string(&mut self, column_name: &str) -> Result<String, anyhow::Error>;
+    fn get_i32(&mut self, column_name: &str) -> Result<Option<i32>, anyhow::Error>;
+    fn get_string(&mut self, column_name: &str) -> Result<Option<String>, anyhow::Error>;
     fn close(&mut self) -> Result<(), anyhow::Error>;
 }
 

--- a/src/driver/network/driver.rs
+++ b/src/driver/network/driver.rs
@@ -175,6 +175,7 @@ mod tests {
         statement.execute_update("create table test (A I32, B VARCHAR(20))")?;
         statement.execute_update("insert into test (A, B) values (1, 'a')")?;
         statement.execute_update("insert into test (A, B) values (2, NULL)")?;
+        statement.execute_update("insert into test (A, B) values (3, 'b')")?;
 
         let mut result_set = statement.execute_query("select B from test")?;
         let metadata = result_set.get_metadata()?;
@@ -185,7 +186,18 @@ mod tests {
         assert_eq!(result_set.get_string("B")?, Some("a".to_string()));
         assert!(result_set.next()?);
         assert_eq!(result_set.get_string("B")?, None);
+        assert!(result_set.next()?);
+        assert_eq!(result_set.get_string("B")?, Some("b".to_string()));
         assert!(!result_set.next()?);
+
+        result_set.after_last()?;
+        assert!(result_set.previous()?);
+        assert_eq!(result_set.get_string("B")?, Some("b".to_string()));
+        assert!(result_set.previous()?);
+        assert_eq!(result_set.get_string("B")?, None);
+        assert!(result_set.previous()?);
+        assert_eq!(result_set.get_string("B")?, Some("a".to_string()));
+        assert!(!result_set.previous()?);
         result_set.close()?;
 
         // Drop the connection instead of explicitly closing to avoid

--- a/src/driver/network/driver.rs
+++ b/src/driver/network/driver.rs
@@ -174,21 +174,18 @@ mod tests {
         let mut statement = connection.create_statement()?;
         statement.execute_update("create table test (A I32, B VARCHAR(20))")?;
         statement.execute_update("insert into test (A, B) values (1, 'a')")?;
-        statement.execute_update("insert into test (A, B) values (2, 'b')")?;
+        statement.execute_update("insert into test (A, B) values (2, NULL)")?;
 
-        let mut result_set = statement.execute_query("select B from test where A = 1")?;
+        let mut result_set = statement.execute_query("select B from test")?;
         let metadata = result_set.get_metadata()?;
         assert_eq!(metadata.get_column_count()?, 1);
         assert_eq!(metadata.get_column_name(0)?, "B");
 
         assert!(result_set.next()?);
-        assert_eq!(result_set.get_string("B")?, "a");
+        assert_eq!(result_set.get_string("B")?, Some("a".to_string()));
+        assert!(result_set.next()?);
+        assert_eq!(result_set.get_string("B")?, None);
         assert!(!result_set.next()?);
-
-        result_set.after_last()?;
-        assert!(result_set.previous()?);
-        assert_eq!(result_set.get_string("B")?, "a");
-        assert!(!result_set.previous()?);
         result_set.close()?;
 
         // Drop the connection instead of explicitly closing to avoid

--- a/src/driver/network/result_set.rs
+++ b/src/driver/network/result_set.rs
@@ -128,7 +128,10 @@ impl ResultSetService for RemoteResultSet {
             Some(v) => (v, false),
             None => (String::new(), true),
         };
-        Ok(Response::new(ResultSetGetStringResponse { value, was_null }))
+        Ok(Response::new(ResultSetGetStringResponse {
+            value,
+            was_null,
+        }))
     }
 
     async fn before_first(

--- a/src/driver/network/result_set.rs
+++ b/src/driver/network/result_set.rs
@@ -104,8 +104,12 @@ impl ResultSetService for RemoteResultSet {
         let embedded_result_set = lock
             .get_mut(&result_set_id)
             .expect(&format!("Unknown result_set_id: {}", result_set_id));
-        let value = embedded_result_set.get_i32(&column_name).unwrap();
-        Ok(Response::new(ResultSetGetI32Response { value }))
+        let value_opt = embedded_result_set.get_i32(&column_name).unwrap();
+        let (value, was_null) = match value_opt {
+            Some(v) => (v, false),
+            None => (0, true),
+        };
+        Ok(Response::new(ResultSetGetI32Response { value, was_null }))
     }
 
     async fn get_string(
@@ -119,8 +123,12 @@ impl ResultSetService for RemoteResultSet {
         let embedded_result_set = lock
             .get_mut(&result_set_id)
             .expect(&format!("Unknown result_set_id: {}", result_set_id));
-        let value = embedded_result_set.get_string(&column_name).unwrap();
-        Ok(Response::new(ResultSetGetStringResponse { value }))
+        let value_opt = embedded_result_set.get_string(&column_name).unwrap();
+        let (value, was_null) = match value_opt {
+            Some(v) => (v, false),
+            None => (String::new(), true),
+        };
+        Ok(Response::new(ResultSetGetStringResponse { value, was_null }))
     }
 
     async fn before_first(
@@ -281,7 +289,7 @@ impl ResultSetControl for NetworkResultSet {
         Ok(response.has_row)
     }
 
-    fn get_i32(&mut self, column_name: &str) -> Result<i32, anyhow::Error> {
+    fn get_i32(&mut self, column_name: &str) -> Result<Option<i32>, anyhow::Error> {
         let mut client = ResultSetServiceClient::new(self.connection.get_channel());
         let request = Request::new(ResultSetGetI32Request {
             id: self.result_set_id,
@@ -292,10 +300,14 @@ impl ResultSetControl for NetworkResultSet {
             .block_on(client.get_i32(request))
             .unwrap()
             .into_inner();
-        Ok(response.value)
+        if response.was_null {
+            Ok(None)
+        } else {
+            Ok(Some(response.value))
+        }
     }
 
-    fn get_string(&mut self, column_name: &str) -> Result<String, anyhow::Error> {
+    fn get_string(&mut self, column_name: &str) -> Result<Option<String>, anyhow::Error> {
         let mut client = ResultSetServiceClient::new(self.connection.get_channel());
         let request = Request::new(ResultSetGetStringRequest {
             id: self.result_set_id,
@@ -306,7 +318,11 @@ impl ResultSetControl for NetworkResultSet {
             .block_on(client.get_string(request))
             .unwrap()
             .into_inner();
-        Ok(response.value)
+        if response.was_null {
+            Ok(None)
+        } else {
+            Ok(Some(response.value))
+        }
     }
 
     fn close(&mut self) -> Result<(), anyhow::Error> {

--- a/src/index/scan/index_join_scan.rs
+++ b/src/index/scan/index_join_scan.rs
@@ -61,7 +61,7 @@ impl ScanControl for IndexJoinScan {
         }
     }
 
-    fn get_i32(&mut self, field_name: &str) -> Result<i32, TransactionError> {
+    fn get_i32(&mut self, field_name: &str) -> Result<Option<i32>, TransactionError> {
         if self.rhs.has_field(field_name) {
             self.rhs.get_i32(field_name)
         } else {
@@ -69,7 +69,7 @@ impl ScanControl for IndexJoinScan {
         }
     }
 
-    fn get_string(&mut self, field_name: &str) -> Result<String, TransactionError> {
+    fn get_string(&mut self, field_name: &str) -> Result<Option<String>, TransactionError> {
         if self.rhs.has_field(field_name) {
             self.rhs.get_string(field_name)
         } else {
@@ -190,7 +190,10 @@ mod tests {
             .collect();
         let mut actual_values = vec![];
         while index_join_scan.next()? {
-            actual_values.push((index_join_scan.get_i32("A")?, index_join_scan.get_i32("C")?));
+            actual_values.push((
+                index_join_scan.get_i32("A")?.unwrap(),
+                index_join_scan.get_i32("C")?.unwrap(),
+            ));
         }
         actual_values.sort();
         assert_eq!(expected_values, actual_values);

--- a/src/index/scan/index_select_scan.rs
+++ b/src/index/scan/index_select_scan.rs
@@ -41,11 +41,11 @@ impl ScanControl for IndexSelectScan {
         Ok(has_next)
     }
 
-    fn get_i32(&mut self, field_name: &str) -> Result<i32, TransactionError> {
+    fn get_i32(&mut self, field_name: &str) -> Result<Option<i32>, TransactionError> {
         self.table_scan.get_i32(field_name)
     }
 
-    fn get_string(&mut self, field_name: &str) -> Result<String, TransactionError> {
+    fn get_string(&mut self, field_name: &str) -> Result<Option<String>, TransactionError> {
         self.table_scan.get_string(field_name)
     }
 
@@ -134,7 +134,7 @@ mod tests {
 
         let mut actual_values = vec![];
         while select_scan.next()? {
-            actual_values.push(select_scan.get_i32("A")?);
+            actual_values.push(select_scan.get_i32("A")?.unwrap());
         }
         actual_values.sort();
 

--- a/src/materialization/group_by_plan.rs
+++ b/src/materialization/group_by_plan.rs
@@ -145,8 +145,8 @@ mod tests {
         scan.before_first()?;
         for i in 0..5 {
             assert!(scan.next()?);
-            assert_eq!(scan.get_i32("A")?, -i);
-            assert_eq!(scan.get_string("B")?, format!("B{}", i % 5));
+            assert_eq!(scan.get_i32("A")?, Some(-i));
+            assert_eq!(scan.get_string("B")?, Some(format!("B{}", i % 5)));
         }
         assert!(!scan.next()?);
 

--- a/src/materialization/group_by_scan.rs
+++ b/src/materialization/group_by_scan.rs
@@ -79,16 +79,18 @@ impl ScanControl for GroupByScan {
         Ok(true)
     }
 
-    fn get_i32(&mut self, field_name: &str) -> Result<i32, TransactionError> {
+    fn get_i32(&mut self, field_name: &str) -> Result<Option<i32>, TransactionError> {
         match self.get_value(field_name)? {
-            Value::I32(i) => Ok(i),
+            Value::I32(i) => Ok(Some(i)),
+            Value::Null => Ok(None),
             _ => panic!("Field {} is not an integer", field_name),
         }
     }
 
-    fn get_string(&mut self, field_name: &str) -> Result<String, TransactionError> {
+    fn get_string(&mut self, field_name: &str) -> Result<Option<String>, TransactionError> {
         match self.get_value(field_name)? {
-            Value::String(s) => Ok(s),
+            Value::String(s) => Ok(Some(s)),
+            Value::Null => Ok(None),
             _ => panic!("Field {} is not a string", field_name),
         }
     }
@@ -169,8 +171,8 @@ mod tests {
         group_by_scan.before_first()?;
         for i in 0..10 {
             assert!(group_by_scan.next()?);
-            assert_eq!(group_by_scan.get_i32("A")?, i);
-            assert_eq!(group_by_scan.get_i32("B")?, i * 5 + 4);
+            assert_eq!(group_by_scan.get_i32("A")?, Some(i));
+            assert_eq!(group_by_scan.get_i32("B")?, Some(i * 5 + 4));
         }
         assert!(!group_by_scan.next()?);
 

--- a/src/materialization/materialize_plan.rs
+++ b/src/materialization/materialize_plan.rs
@@ -119,8 +119,8 @@ mod tests {
             let mut count = 0;
             materialized_scan.before_first()?;
             while materialized_scan.next()? {
-                assert_eq!(materialized_scan.get_i32("A")?, count);
-                assert_eq!(materialized_scan.get_string("B")?, count.to_string());
+                assert_eq!(materialized_scan.get_i32("A")?, Some(count));
+                assert_eq!(materialized_scan.get_string("B")?, Some(count.to_string()));
                 count += 1;
             }
             assert_eq!(count, 20);

--- a/src/materialization/merge_join_plan.rs
+++ b/src/materialization/merge_join_plan.rs
@@ -163,10 +163,10 @@ mod tests {
 
         let mut actual_values = vec![];
         while merge_join_scan.next()? {
-            let a = merge_join_scan.get_i32("A")?;
-            let b = merge_join_scan.get_string("B")?;
-            let c = merge_join_scan.get_i32("C")?;
-            let d = merge_join_scan.get_string("D")?;
+            let a = merge_join_scan.get_i32("A")?.unwrap();
+            let b = merge_join_scan.get_string("B")?.unwrap();
+            let c = merge_join_scan.get_i32("C")?.unwrap();
+            let d = merge_join_scan.get_string("D")?.unwrap();
             actual_values.push((a, b, c, d));
         }
         actual_values.sort();

--- a/src/materialization/merge_join_scan.rs
+++ b/src/materialization/merge_join_scan.rs
@@ -67,7 +67,7 @@ impl ScanControl for MergeJoinScan {
         Ok(false)
     }
 
-    fn get_i32(&mut self, field_name: &str) -> Result<i32, TransactionError> {
+    fn get_i32(&mut self, field_name: &str) -> Result<Option<i32>, TransactionError> {
         if self.s1.has_field(field_name) {
             self.s1.get_i32(field_name)
         } else {
@@ -75,7 +75,7 @@ impl ScanControl for MergeJoinScan {
         }
     }
 
-    fn get_string(&mut self, field_name: &str) -> Result<String, TransactionError> {
+    fn get_string(&mut self, field_name: &str) -> Result<Option<String>, TransactionError> {
         if self.s1.has_field(field_name) {
             self.s1.get_string(field_name)
         } else {

--- a/src/materialization/sort_plan.rs
+++ b/src/materialization/sort_plan.rs
@@ -208,8 +208,8 @@ mod tests {
         sort_scan.before_first()?;
         for i in 0..20 {
             assert!(sort_scan.next()?);
-            assert_eq!(sort_scan.get_i32("A")?, i - 19);
-            assert_eq!(sort_scan.get_string("B")?, format!("B{}", 19 - i));
+            assert_eq!(sort_scan.get_i32("A")?, Some(i - 19));
+            assert_eq!(sort_scan.get_string("B")?, Some(format!("B{}", 19 - i)));
         }
 
         Ok(())
@@ -249,9 +249,9 @@ mod tests {
         sort_scan.before_first()?;
 
         assert!(sort_scan.next()?);
-        assert_eq!(sort_scan.get_i32("A")?, 1);
+        assert_eq!(sort_scan.get_i32("A")?, Some(1));
         assert!(sort_scan.next()?);
-        assert_eq!(sort_scan.get_i32("A")?, 2);
+        assert_eq!(sort_scan.get_i32("A")?, Some(2));
         assert!(sort_scan.next()?);
         assert_eq!(sort_scan.get_value("A")?, Value::Null);
         assert!(!sort_scan.next()?);

--- a/src/materialization/sort_scan.rs
+++ b/src/materialization/sort_scan.rs
@@ -105,13 +105,13 @@ impl ScanControl for SortScan {
         Ok(true)
     }
 
-    fn get_i32(&mut self, field_name: &str) -> Result<i32, TransactionError> {
+    fn get_i32(&mut self, field_name: &str) -> Result<Option<i32>, TransactionError> {
         self.scans[self.current_scan_index.unwrap()]
             .borrow_mut()
             .get_i32(field_name)
     }
 
-    fn get_string(&mut self, field_name: &str) -> Result<String, TransactionError> {
+    fn get_string(&mut self, field_name: &str) -> Result<Option<String>, TransactionError> {
         self.scans[self.current_scan_index.unwrap()]
             .borrow_mut()
             .get_string(field_name)
@@ -182,8 +182,8 @@ mod tests {
         scan.before_first()?;
         for i in 0..20 {
             assert_eq!(scan.next()?, true);
-            assert_eq!(scan.get_i32("A")?, i);
-            assert_eq!(scan.get_string("B")?, i.to_string());
+            assert_eq!(scan.get_i32("A")?, Some(i));
+            assert_eq!(scan.get_string("B")?, Some(i.to_string()));
         }
         assert_eq!(scan.next()?, false);
 
@@ -228,9 +228,9 @@ mod tests {
         scan.before_first()?;
 
         assert!(scan.next()?);
-        assert_eq!(scan.get_i32("A")?, 1);
+        assert_eq!(scan.get_i32("A")?, Some(1));
         assert!(scan.next()?);
-        assert_eq!(scan.get_i32("A")?, 2);
+        assert_eq!(scan.get_i32("A")?, Some(2));
         assert!(scan.next()?);
         assert_eq!(scan.get_value("A")?, Value::Null);
         assert!(!scan.next()?);

--- a/src/metadata/index_manager.rs
+++ b/src/metadata/index_manager.rs
@@ -156,12 +156,12 @@ impl IndexManager {
         let mut scan = TableScan::new(tx.clone(), INDEX_TABLE_NAME, self.layout.clone())?;
 
         while scan.next()? {
-            if scan.get_string(TABLE_NAME_COLUMN)? != table_name {
+            if scan.get_string(TABLE_NAME_COLUMN)? != Some(table_name.to_string()) {
                 continue;
             }
 
-            let index_name = scan.get_string(INDEX_NAME_COLUMN)?;
-            let field_name = scan.get_string(FIELD_NAME_COLUMN)?;
+            let index_name = scan.get_string(INDEX_NAME_COLUMN)?.unwrap();
+            let field_name = scan.get_string(FIELD_NAME_COLUMN)?.unwrap();
 
             let layout = self
                 .table_manager

--- a/src/metadata/stat_manager.rs
+++ b/src/metadata/stat_manager.rs
@@ -95,7 +95,7 @@ impl StatManager {
         let mut tcat_scan = TableScan::new(tx.clone(), "tblcat", tcat_layout.clone())?;
         let mut table_names = vec![];
         while tcat_scan.next()? {
-            let table_name = tcat_scan.get_string("tblname")?;
+            let table_name = tcat_scan.get_string("tblname")?.unwrap();
             table_names.push(table_name);
         }
         drop(tcat_scan);

--- a/src/metadata/table_manager.rs
+++ b/src/metadata/table_manager.rs
@@ -119,17 +119,17 @@ impl TableManager {
         let mut schema = Schema::new();
         let mut fcat = TableScan::new(tx, "fldcat", self.fcat_layout.clone())?;
         while fcat.next()? {
-            if fcat.get_string("tblname")? != table_name {
+            if fcat.get_string("tblname")? != Some(table_name.to_string()) {
                 continue;
             }
-            let field_name = fcat.get_string("fldname")?;
+            let field_name = fcat.get_string("fldname")?.unwrap();
             let type_code = fcat.get_i32("type")?;
             let length = fcat.get_i32("length")?;
             // let offset = fcat.get_i32("offset")?;
             match type_code {
-                0 => schema.add_i32_field(&field_name),
-                1 => schema.add_string_field(&field_name, length as usize),
-                _ => panic!("Unknown type code: {}", type_code),
+                Some(0) => schema.add_i32_field(&field_name),
+                Some(1) => schema.add_string_field(&field_name, length.unwrap() as usize),
+                _ => panic!("Unknown type code: {:?}", type_code),
             }
         }
         if schema.i32_fields.is_empty() && schema.string_fields.is_empty() {

--- a/src/multibuffer/chunk_scan.rs
+++ b/src/multibuffer/chunk_scan.rs
@@ -80,14 +80,28 @@ impl ScanControl for ChunkScan {
         }
     }
 
-    fn get_i32(&mut self, field_name: &str) -> Result<i32, TransactionError> {
-        self.buffers[self.current_record_page_index]
-            .get_i32(self.current_record_slot.index(), field_name)
+    fn get_i32(&mut self, field_name: &str) -> Result<Option<i32>, TransactionError> {
+        if self.buffers[self.current_record_page_index]
+            .is_null(self.current_record_slot.index(), field_name)?
+        {
+            return Ok(None);
+        }
+        Ok(Some(
+            self.buffers[self.current_record_page_index]
+                .get_i32(self.current_record_slot.index(), field_name)?,
+        ))
     }
 
-    fn get_string(&mut self, field_name: &str) -> Result<String, TransactionError> {
-        self.buffers[self.current_record_page_index]
-            .get_string(self.current_record_slot.index(), field_name)
+    fn get_string(&mut self, field_name: &str) -> Result<Option<String>, TransactionError> {
+        if self.buffers[self.current_record_page_index]
+            .is_null(self.current_record_slot.index(), field_name)?
+        {
+            return Ok(None);
+        }
+        Ok(Some(
+            self.buffers[self.current_record_page_index]
+                .get_string(self.current_record_slot.index(), field_name)?,
+        ))
     }
 
     fn get_value(&mut self, field_name: &str) -> Result<Value, TransactionError> {
@@ -97,8 +111,14 @@ impl ScanControl for ChunkScan {
             return Ok(Value::Null);
         }
         match self.layout.schema.get_field_type(field_name) {
-            Type::I32 => Ok(Value::I32(self.get_i32(field_name)?)),
-            Type::String => Ok(Value::String(self.get_string(field_name)?)),
+            Type::I32 => Ok(Value::I32(
+                self.buffers[self.current_record_page_index]
+                    .get_i32(self.current_record_slot.index(), field_name)?,
+            )),
+            Type::String => Ok(Value::String(
+                self.buffers[self.current_record_page_index]
+                    .get_string(self.current_record_slot.index(), field_name)?,
+            )),
         }
     }
 

--- a/src/multibuffer/multibuffer_product_plan.rs
+++ b/src/multibuffer/multibuffer_product_plan.rs
@@ -180,11 +180,11 @@ mod tests {
             for j in 0..table2_size {
                 assert!(product_scan.next()?);
                 actual_values.push((
-                    product_scan.get_i32("A")?,
-                    product_scan.get_string("B")?,
-                    product_scan.get_i32("C")?,
-                    product_scan.get_i32("D")?,
-                    product_scan.get_string("E")?,
+                    product_scan.get_i32("A")?.unwrap(),
+                    product_scan.get_string("B")?.unwrap(),
+                    product_scan.get_i32("C")?.unwrap(),
+                    product_scan.get_i32("D")?.unwrap(),
+                    product_scan.get_string("E")?.unwrap(),
                 ));
                 expected_values.push((i, i.to_string(), i + 2, j, j.to_string()));
             }

--- a/src/multibuffer/multibuffer_product_scan.rs
+++ b/src/multibuffer/multibuffer_product_scan.rs
@@ -92,11 +92,11 @@ impl ScanControl for MultiBufferProductScan {
         Ok(true)
     }
 
-    fn get_i32(&mut self, field_name: &str) -> Result<i32, TransactionError> {
+    fn get_i32(&mut self, field_name: &str) -> Result<Option<i32>, TransactionError> {
         self.product_scan.as_mut().unwrap().get_i32(field_name)
     }
 
-    fn get_string(&mut self, field_name: &str) -> Result<String, TransactionError> {
+    fn get_string(&mut self, field_name: &str) -> Result<Option<String>, TransactionError> {
         self.product_scan.as_mut().unwrap().get_string(field_name)
     }
 

--- a/src/plan/product_plan.rs
+++ b/src/plan/product_plan.rs
@@ -132,11 +132,11 @@ mod tests {
             for j in 0..table2_size {
                 assert!(product_scan.next()?);
                 actual_values.push((
-                    product_scan.get_i32("A")?,
-                    product_scan.get_string("B")?,
-                    product_scan.get_i32("C")?,
-                    product_scan.get_i32("D")?,
-                    product_scan.get_string("E")?,
+                    product_scan.get_i32("A")?.unwrap(),
+                    product_scan.get_string("B")?.unwrap(),
+                    product_scan.get_i32("C")?.unwrap(),
+                    product_scan.get_i32("D")?.unwrap(),
+                    product_scan.get_string("E")?.unwrap(),
                 ));
                 expected_values.push((i, i.to_string(), i + 2, j, j.to_string()))
             }

--- a/src/planner/basic_query_planner.rs
+++ b/src/planner/basic_query_planner.rs
@@ -144,8 +144,8 @@ mod tests {
         scan.before_first()?;
         for i in 0..5 {
             assert!(scan.next()?);
-            assert_eq!(scan.get_string("B")?, "3");
-            assert_eq!(scan.get_i32("C")?, i);
+            assert_eq!(scan.get_string("B")?, Some("3".to_string()));
+            assert_eq!(scan.get_i32("C")?, Some(i));
         }
         drop(scan);
         tx.lock().unwrap().commit()?;

--- a/src/planner/basic_update_planner.rs
+++ b/src/planner/basic_update_planner.rs
@@ -193,7 +193,7 @@ mod tests {
 
         for i in 0..5 {
             assert!(scan.next()?);
-            assert_eq!(scan.get_string("B")?, (i * 2 + 1).to_string());
+            assert_eq!(scan.get_string("B")?, Some((i * 2 + 1).to_string()));
         }
         assert!(!scan.next()?);
 

--- a/src/planner/heuristic_query_planner.rs
+++ b/src/planner/heuristic_query_planner.rs
@@ -215,8 +215,8 @@ mod tests {
             scan.before_first()?;
             for i in 5..10 {
                 assert!(scan.next()?);
-                assert_eq!(scan.get_string("B")?, i.to_string());
-                assert_eq!(scan.get_i32("C")?, i);
+                assert_eq!(scan.get_string("B")?, Some(i.to_string()));
+                assert_eq!(scan.get_i32("C")?, Some(i));
             }
         }
 

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -119,7 +119,7 @@ mod tests {
 
         for i in 0..5 {
             assert!(scan.next()?);
-            assert_eq!(scan.get_string("B")?, (i * 2 + 1).to_string());
+            assert_eq!(scan.get_string("B")?, Some((i * 2 + 1).to_string()));
         }
         assert!(!scan.next()?);
         drop(scan);

--- a/src/proto/simpledb.rs
+++ b/src/proto/simpledb.rs
@@ -83,6 +83,8 @@ pub struct ResultSetGetI32Request {
 pub struct ResultSetGetI32Response {
     #[prost(int32, tag = "1")]
     pub value: i32,
+    #[prost(bool, tag = "2")]
+    pub was_null: bool,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ResultSetGetStringRequest {
@@ -95,6 +97,8 @@ pub struct ResultSetGetStringRequest {
 pub struct ResultSetGetStringResponse {
     #[prost(string, tag = "1")]
     pub value: ::prost::alloc::string::String,
+    #[prost(bool, tag = "2")]
+    pub was_null: bool,
 }
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct ResultSetCloseRequest {

--- a/src/proto/simpledb.rs
+++ b/src/proto/simpledb.rs
@@ -205,10 +205,10 @@ pub mod metadata_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct MetadataServiceClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -252,8 +252,9 @@ pub mod metadata_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             MetadataServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -295,30 +296,42 @@ pub mod metadata_service_client {
             tonic::Response<super::MetadataGetColumnCountResponse>,
             tonic::Status,
         > {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/simpledb.MetadataService/GetColumnCount");
+            let path = http::uri::PathAndQuery::from_static(
+                "/simpledb.MetadataService/GetColumnCount",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "simpledb.MetadataService",
-                "GetColumnCount",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("simpledb.MetadataService", "GetColumnCount"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_column_name(
             &mut self,
             request: impl tonic::IntoRequest<super::MetadataGetColumnNameRequest>,
-        ) -> std::result::Result<tonic::Response<super::MetadataGetColumnNameResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::MetadataGetColumnNameResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/simpledb.MetadataService/GetColumnName");
+            let path = http::uri::PathAndQuery::from_static(
+                "/simpledb.MetadataService/GetColumnName",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("simpledb.MetadataService", "GetColumnName"));
@@ -331,31 +344,44 @@ pub mod metadata_service_client {
             tonic::Response<super::MetadataGetColumnDisplaySizeResponse>,
             tonic::Status,
         > {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/simpledb.MetadataService/GetColumnDisplaySize",
             );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "simpledb.MetadataService",
-                "GetColumnDisplaySize",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("simpledb.MetadataService", "GetColumnDisplaySize"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_column_type(
             &mut self,
             request: impl tonic::IntoRequest<super::MetadataGetColumnTypeRequest>,
-        ) -> std::result::Result<tonic::Response<super::MetadataGetColumnTypeResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::MetadataGetColumnTypeResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/simpledb.MetadataService/GetColumnType");
+            let path = http::uri::PathAndQuery::from_static(
+                "/simpledb.MetadataService/GetColumnType",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("simpledb.MetadataService", "GetColumnType"));
@@ -370,10 +396,10 @@ pub mod result_set_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct ResultSetServiceClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -417,8 +443,9 @@ pub mod result_set_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             ResultSetServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -456,14 +483,22 @@ pub mod result_set_service_client {
         pub async fn get_metadata(
             &mut self,
             request: impl tonic::IntoRequest<super::ResultSetGetMetadataRequest>,
-        ) -> std::result::Result<tonic::Response<super::ResultSetGetMetadataResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::ResultSetGetMetadataResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/simpledb.ResultSetService/GetMetadata");
+            let path = http::uri::PathAndQuery::from_static(
+                "/simpledb.ResultSetService/GetMetadata",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("simpledb.ResultSetService", "GetMetadata"));
@@ -472,13 +507,22 @@ pub mod result_set_service_client {
         pub async fn next(
             &mut self,
             request: impl tonic::IntoRequest<super::ResultSetNextRequest>,
-        ) -> std::result::Result<tonic::Response<super::ResultSetNextResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::ResultSetNextResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/simpledb.ResultSetService/Next");
+            let path = http::uri::PathAndQuery::from_static(
+                "/simpledb.ResultSetService/Next",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("simpledb.ResultSetService", "Next"));
@@ -487,13 +531,22 @@ pub mod result_set_service_client {
         pub async fn previous(
             &mut self,
             request: impl tonic::IntoRequest<super::ResultSetPreviousRequest>,
-        ) -> std::result::Result<tonic::Response<super::ResultSetPreviousResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::ResultSetPreviousResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/simpledb.ResultSetService/Previous");
+            let path = http::uri::PathAndQuery::from_static(
+                "/simpledb.ResultSetService/Previous",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("simpledb.ResultSetService", "Previous"));
@@ -502,13 +555,22 @@ pub mod result_set_service_client {
         pub async fn get_i32(
             &mut self,
             request: impl tonic::IntoRequest<super::ResultSetGetI32Request>,
-        ) -> std::result::Result<tonic::Response<super::ResultSetGetI32Response>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::ResultSetGetI32Response>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/simpledb.ResultSetService/GetI32");
+            let path = http::uri::PathAndQuery::from_static(
+                "/simpledb.ResultSetService/GetI32",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("simpledb.ResultSetService", "GetI32"));
@@ -517,13 +579,22 @@ pub mod result_set_service_client {
         pub async fn get_string(
             &mut self,
             request: impl tonic::IntoRequest<super::ResultSetGetStringRequest>,
-        ) -> std::result::Result<tonic::Response<super::ResultSetGetStringResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::ResultSetGetStringResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/simpledb.ResultSetService/GetString");
+            let path = http::uri::PathAndQuery::from_static(
+                "/simpledb.ResultSetService/GetString",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("simpledb.ResultSetService", "GetString"));
@@ -532,14 +603,22 @@ pub mod result_set_service_client {
         pub async fn before_first(
             &mut self,
             request: impl tonic::IntoRequest<super::ResultSetBeforeFirstRequest>,
-        ) -> std::result::Result<tonic::Response<super::ResultSetBeforeFirstResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::ResultSetBeforeFirstResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/simpledb.ResultSetService/BeforeFirst");
+            let path = http::uri::PathAndQuery::from_static(
+                "/simpledb.ResultSetService/BeforeFirst",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("simpledb.ResultSetService", "BeforeFirst"));
@@ -548,13 +627,22 @@ pub mod result_set_service_client {
         pub async fn after_last(
             &mut self,
             request: impl tonic::IntoRequest<super::ResultSetAfterLastRequest>,
-        ) -> std::result::Result<tonic::Response<super::ResultSetAfterLastResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::ResultSetAfterLastResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/simpledb.ResultSetService/AfterLast");
+            let path = http::uri::PathAndQuery::from_static(
+                "/simpledb.ResultSetService/AfterLast",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("simpledb.ResultSetService", "AfterLast"));
@@ -563,13 +651,22 @@ pub mod result_set_service_client {
         pub async fn absolute(
             &mut self,
             request: impl tonic::IntoRequest<super::ResultSetAbsoluteRequest>,
-        ) -> std::result::Result<tonic::Response<super::ResultSetAbsoluteResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::ResultSetAbsoluteResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/simpledb.ResultSetService/Absolute");
+            let path = http::uri::PathAndQuery::from_static(
+                "/simpledb.ResultSetService/Absolute",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("simpledb.ResultSetService", "Absolute"));
@@ -578,13 +675,22 @@ pub mod result_set_service_client {
         pub async fn close(
             &mut self,
             request: impl tonic::IntoRequest<super::ResultSetCloseRequest>,
-        ) -> std::result::Result<tonic::Response<super::ResultSetCloseResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::ResultSetCloseResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/simpledb.ResultSetService/Close");
+            let path = http::uri::PathAndQuery::from_static(
+                "/simpledb.ResultSetService/Close",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("simpledb.ResultSetService", "Close"));
@@ -599,10 +705,10 @@ pub mod statement_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct StatementServiceClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -646,8 +752,9 @@ pub mod statement_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             StatementServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -685,14 +792,22 @@ pub mod statement_service_client {
         pub async fn execute_query(
             &mut self,
             request: impl tonic::IntoRequest<super::StatementExecuteQueryRequest>,
-        ) -> std::result::Result<tonic::Response<super::StatementExecuteQueryResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::StatementExecuteQueryResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/simpledb.StatementService/ExecuteQuery");
+            let path = http::uri::PathAndQuery::from_static(
+                "/simpledb.StatementService/ExecuteQuery",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("simpledb.StatementService", "ExecuteQuery"));
@@ -705,17 +820,21 @@ pub mod statement_service_client {
             tonic::Response<super::StatementExecuteUpdateResponse>,
             tonic::Status,
         > {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/simpledb.StatementService/ExecuteUpdate");
+            let path = http::uri::PathAndQuery::from_static(
+                "/simpledb.StatementService/ExecuteUpdate",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "simpledb.StatementService",
-                "ExecuteUpdate",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("simpledb.StatementService", "ExecuteUpdate"));
             self.inner.unary(req, path, codec).await
         }
     }
@@ -727,10 +846,10 @@ pub mod connection_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct ConnectionServiceClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -774,8 +893,9 @@ pub mod connection_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             ConnectionServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -817,29 +937,44 @@ pub mod connection_service_client {
             tonic::Response<super::ConnectionCreateStatementResponse>,
             tonic::Status,
         > {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/simpledb.ConnectionService/CreateStatement");
+            let path = http::uri::PathAndQuery::from_static(
+                "/simpledb.ConnectionService/CreateStatement",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "simpledb.ConnectionService",
-                "CreateStatement",
-            ));
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("simpledb.ConnectionService", "CreateStatement"),
+                );
             self.inner.unary(req, path, codec).await
         }
         pub async fn close(
             &mut self,
             request: impl tonic::IntoRequest<super::ConnectionCloseRequest>,
-        ) -> std::result::Result<tonic::Response<super::ConnectionCloseResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::ConnectionCloseResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/simpledb.ConnectionService/Close");
+            let path = http::uri::PathAndQuery::from_static(
+                "/simpledb.ConnectionService/Close",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("simpledb.ConnectionService", "Close"));
@@ -848,13 +983,22 @@ pub mod connection_service_client {
         pub async fn commit(
             &mut self,
             request: impl tonic::IntoRequest<super::ConnectionCommitRequest>,
-        ) -> std::result::Result<tonic::Response<super::ConnectionCommitResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::ConnectionCommitResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/simpledb.ConnectionService/Commit");
+            let path = http::uri::PathAndQuery::from_static(
+                "/simpledb.ConnectionService/Commit",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("simpledb.ConnectionService", "Commit"));
@@ -863,13 +1007,22 @@ pub mod connection_service_client {
         pub async fn rollback(
             &mut self,
             request: impl tonic::IntoRequest<super::ConnectionRollbackRequest>,
-        ) -> std::result::Result<tonic::Response<super::ConnectionRollbackResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::ConnectionRollbackResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/simpledb.ConnectionService/Rollback");
+            let path = http::uri::PathAndQuery::from_static(
+                "/simpledb.ConnectionService/Rollback",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("simpledb.ConnectionService", "Rollback"));
@@ -884,10 +1037,10 @@ pub mod driver_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct DriverServiceClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -931,8 +1084,9 @@ pub mod driver_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             DriverServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -974,17 +1128,21 @@ pub mod driver_service_client {
             tonic::Response<super::DriverCreateConnectionResponse>,
             tonic::Status,
         > {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path =
-                http::uri::PathAndQuery::from_static("/simpledb.DriverService/CreateConnection");
+            let path = http::uri::PathAndQuery::from_static(
+                "/simpledb.DriverService/CreateConnection",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new(
-                "simpledb.DriverService",
-                "CreateConnection",
-            ));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("simpledb.DriverService", "CreateConnection"));
             self.inner.unary(req, path, codec).await
         }
     }
@@ -996,7 +1154,7 @@ pub mod metadata_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with MetadataServiceServer.
@@ -1012,7 +1170,10 @@ pub mod metadata_service_server {
         async fn get_column_name(
             &self,
             request: tonic::Request<super::MetadataGetColumnNameRequest>,
-        ) -> std::result::Result<tonic::Response<super::MetadataGetColumnNameResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::MetadataGetColumnNameResponse>,
+            tonic::Status,
+        >;
         async fn get_column_display_size(
             &self,
             request: tonic::Request<super::MetadataGetColumnDisplaySizeRequest>,
@@ -1023,7 +1184,10 @@ pub mod metadata_service_server {
         async fn get_column_type(
             &self,
             request: tonic::Request<super::MetadataGetColumnTypeRequest>,
-        ) -> std::result::Result<tonic::Response<super::MetadataGetColumnTypeResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::MetadataGetColumnTypeResponse>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
     pub struct MetadataServiceServer<T> {
@@ -1046,7 +1210,10 @@ pub mod metadata_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -1101,19 +1268,23 @@ pub mod metadata_service_server {
                 "/simpledb.MetadataService/GetColumnCount" => {
                     #[allow(non_camel_case_types)]
                     struct GetColumnCountSvc<T: MetadataService>(pub Arc<T>);
-                    impl<T: MetadataService>
-                        tonic::server::UnaryService<super::MetadataGetColumnCountRequest>
-                        for GetColumnCountSvc<T>
-                    {
+                    impl<
+                        T: MetadataService,
+                    > tonic::server::UnaryService<super::MetadataGetColumnCountRequest>
+                    for GetColumnCountSvc<T> {
                         type Response = super::MetadataGetColumnCountResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::MetadataGetColumnCountRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as MetadataService>::get_column_count(&inner, request).await
+                                <T as MetadataService>::get_column_count(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -1143,19 +1314,23 @@ pub mod metadata_service_server {
                 "/simpledb.MetadataService/GetColumnName" => {
                     #[allow(non_camel_case_types)]
                     struct GetColumnNameSvc<T: MetadataService>(pub Arc<T>);
-                    impl<T: MetadataService>
-                        tonic::server::UnaryService<super::MetadataGetColumnNameRequest>
-                        for GetColumnNameSvc<T>
-                    {
+                    impl<
+                        T: MetadataService,
+                    > tonic::server::UnaryService<super::MetadataGetColumnNameRequest>
+                    for GetColumnNameSvc<T> {
                         type Response = super::MetadataGetColumnNameResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::MetadataGetColumnNameRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as MetadataService>::get_column_name(&inner, request).await
+                                <T as MetadataService>::get_column_name(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -1185,19 +1360,28 @@ pub mod metadata_service_server {
                 "/simpledb.MetadataService/GetColumnDisplaySize" => {
                     #[allow(non_camel_case_types)]
                     struct GetColumnDisplaySizeSvc<T: MetadataService>(pub Arc<T>);
-                    impl<T: MetadataService>
-                        tonic::server::UnaryService<super::MetadataGetColumnDisplaySizeRequest>
-                        for GetColumnDisplaySizeSvc<T>
-                    {
+                    impl<
+                        T: MetadataService,
+                    > tonic::server::UnaryService<
+                        super::MetadataGetColumnDisplaySizeRequest,
+                    > for GetColumnDisplaySizeSvc<T> {
                         type Response = super::MetadataGetColumnDisplaySizeResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::MetadataGetColumnDisplaySizeRequest>,
+                            request: tonic::Request<
+                                super::MetadataGetColumnDisplaySizeRequest,
+                            >,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as MetadataService>::get_column_display_size(&inner, request)
+                                <T as MetadataService>::get_column_display_size(
+                                        &inner,
+                                        request,
+                                    )
                                     .await
                             };
                             Box::pin(fut)
@@ -1228,19 +1412,23 @@ pub mod metadata_service_server {
                 "/simpledb.MetadataService/GetColumnType" => {
                     #[allow(non_camel_case_types)]
                     struct GetColumnTypeSvc<T: MetadataService>(pub Arc<T>);
-                    impl<T: MetadataService>
-                        tonic::server::UnaryService<super::MetadataGetColumnTypeRequest>
-                        for GetColumnTypeSvc<T>
-                    {
+                    impl<
+                        T: MetadataService,
+                    > tonic::server::UnaryService<super::MetadataGetColumnTypeRequest>
+                    for GetColumnTypeSvc<T> {
                         type Response = super::MetadataGetColumnTypeResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::MetadataGetColumnTypeRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as MetadataService>::get_column_type(&inner, request).await
+                                <T as MetadataService>::get_column_type(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -1267,19 +1455,23 @@ pub mod metadata_service_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    let mut response = http::Response::new(empty_body());
-                    let headers = response.headers_mut();
-                    headers.insert(
-                        tonic::Status::GRPC_STATUS,
-                        (tonic::Code::Unimplemented as i32).into(),
-                    );
-                    headers.insert(
-                        http::header::CONTENT_TYPE,
-                        tonic::metadata::GRPC_CONTENT_TYPE,
-                    );
-                    Ok(response)
-                }),
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(empty_body());
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
             }
         }
     }
@@ -1308,7 +1500,7 @@ pub mod result_set_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with ResultSetServiceServer.
@@ -1317,39 +1509,66 @@ pub mod result_set_service_server {
         async fn get_metadata(
             &self,
             request: tonic::Request<super::ResultSetGetMetadataRequest>,
-        ) -> std::result::Result<tonic::Response<super::ResultSetGetMetadataResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::ResultSetGetMetadataResponse>,
+            tonic::Status,
+        >;
         async fn next(
             &self,
             request: tonic::Request<super::ResultSetNextRequest>,
-        ) -> std::result::Result<tonic::Response<super::ResultSetNextResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::ResultSetNextResponse>,
+            tonic::Status,
+        >;
         async fn previous(
             &self,
             request: tonic::Request<super::ResultSetPreviousRequest>,
-        ) -> std::result::Result<tonic::Response<super::ResultSetPreviousResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::ResultSetPreviousResponse>,
+            tonic::Status,
+        >;
         async fn get_i32(
             &self,
             request: tonic::Request<super::ResultSetGetI32Request>,
-        ) -> std::result::Result<tonic::Response<super::ResultSetGetI32Response>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::ResultSetGetI32Response>,
+            tonic::Status,
+        >;
         async fn get_string(
             &self,
             request: tonic::Request<super::ResultSetGetStringRequest>,
-        ) -> std::result::Result<tonic::Response<super::ResultSetGetStringResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::ResultSetGetStringResponse>,
+            tonic::Status,
+        >;
         async fn before_first(
             &self,
             request: tonic::Request<super::ResultSetBeforeFirstRequest>,
-        ) -> std::result::Result<tonic::Response<super::ResultSetBeforeFirstResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::ResultSetBeforeFirstResponse>,
+            tonic::Status,
+        >;
         async fn after_last(
             &self,
             request: tonic::Request<super::ResultSetAfterLastRequest>,
-        ) -> std::result::Result<tonic::Response<super::ResultSetAfterLastResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::ResultSetAfterLastResponse>,
+            tonic::Status,
+        >;
         async fn absolute(
             &self,
             request: tonic::Request<super::ResultSetAbsoluteRequest>,
-        ) -> std::result::Result<tonic::Response<super::ResultSetAbsoluteResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::ResultSetAbsoluteResponse>,
+            tonic::Status,
+        >;
         async fn close(
             &self,
             request: tonic::Request<super::ResultSetCloseRequest>,
-        ) -> std::result::Result<tonic::Response<super::ResultSetCloseResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::ResultSetCloseResponse>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
     pub struct ResultSetServiceServer<T> {
@@ -1372,7 +1591,10 @@ pub mod result_set_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -1427,12 +1649,15 @@ pub mod result_set_service_server {
                 "/simpledb.ResultSetService/GetMetadata" => {
                     #[allow(non_camel_case_types)]
                     struct GetMetadataSvc<T: ResultSetService>(pub Arc<T>);
-                    impl<T: ResultSetService>
-                        tonic::server::UnaryService<super::ResultSetGetMetadataRequest>
-                        for GetMetadataSvc<T>
-                    {
+                    impl<
+                        T: ResultSetService,
+                    > tonic::server::UnaryService<super::ResultSetGetMetadataRequest>
+                    for GetMetadataSvc<T> {
                         type Response = super::ResultSetGetMetadataResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ResultSetGetMetadataRequest>,
@@ -1469,18 +1694,23 @@ pub mod result_set_service_server {
                 "/simpledb.ResultSetService/Next" => {
                     #[allow(non_camel_case_types)]
                     struct NextSvc<T: ResultSetService>(pub Arc<T>);
-                    impl<T: ResultSetService>
-                        tonic::server::UnaryService<super::ResultSetNextRequest> for NextSvc<T>
-                    {
+                    impl<
+                        T: ResultSetService,
+                    > tonic::server::UnaryService<super::ResultSetNextRequest>
+                    for NextSvc<T> {
                         type Response = super::ResultSetNextResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ResultSetNextRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut =
-                                async move { <T as ResultSetService>::next(&inner, request).await };
+                            let fut = async move {
+                                <T as ResultSetService>::next(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -1509,12 +1739,15 @@ pub mod result_set_service_server {
                 "/simpledb.ResultSetService/Previous" => {
                     #[allow(non_camel_case_types)]
                     struct PreviousSvc<T: ResultSetService>(pub Arc<T>);
-                    impl<T: ResultSetService>
-                        tonic::server::UnaryService<super::ResultSetPreviousRequest>
-                        for PreviousSvc<T>
-                    {
+                    impl<
+                        T: ResultSetService,
+                    > tonic::server::UnaryService<super::ResultSetPreviousRequest>
+                    for PreviousSvc<T> {
                         type Response = super::ResultSetPreviousResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ResultSetPreviousRequest>,
@@ -1551,12 +1784,15 @@ pub mod result_set_service_server {
                 "/simpledb.ResultSetService/GetI32" => {
                     #[allow(non_camel_case_types)]
                     struct GetI32Svc<T: ResultSetService>(pub Arc<T>);
-                    impl<T: ResultSetService>
-                        tonic::server::UnaryService<super::ResultSetGetI32Request>
-                        for GetI32Svc<T>
-                    {
+                    impl<
+                        T: ResultSetService,
+                    > tonic::server::UnaryService<super::ResultSetGetI32Request>
+                    for GetI32Svc<T> {
                         type Response = super::ResultSetGetI32Response;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ResultSetGetI32Request>,
@@ -1593,12 +1829,15 @@ pub mod result_set_service_server {
                 "/simpledb.ResultSetService/GetString" => {
                     #[allow(non_camel_case_types)]
                     struct GetStringSvc<T: ResultSetService>(pub Arc<T>);
-                    impl<T: ResultSetService>
-                        tonic::server::UnaryService<super::ResultSetGetStringRequest>
-                        for GetStringSvc<T>
-                    {
+                    impl<
+                        T: ResultSetService,
+                    > tonic::server::UnaryService<super::ResultSetGetStringRequest>
+                    for GetStringSvc<T> {
                         type Response = super::ResultSetGetStringResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ResultSetGetStringRequest>,
@@ -1635,12 +1874,15 @@ pub mod result_set_service_server {
                 "/simpledb.ResultSetService/BeforeFirst" => {
                     #[allow(non_camel_case_types)]
                     struct BeforeFirstSvc<T: ResultSetService>(pub Arc<T>);
-                    impl<T: ResultSetService>
-                        tonic::server::UnaryService<super::ResultSetBeforeFirstRequest>
-                        for BeforeFirstSvc<T>
-                    {
+                    impl<
+                        T: ResultSetService,
+                    > tonic::server::UnaryService<super::ResultSetBeforeFirstRequest>
+                    for BeforeFirstSvc<T> {
                         type Response = super::ResultSetBeforeFirstResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ResultSetBeforeFirstRequest>,
@@ -1677,12 +1919,15 @@ pub mod result_set_service_server {
                 "/simpledb.ResultSetService/AfterLast" => {
                     #[allow(non_camel_case_types)]
                     struct AfterLastSvc<T: ResultSetService>(pub Arc<T>);
-                    impl<T: ResultSetService>
-                        tonic::server::UnaryService<super::ResultSetAfterLastRequest>
-                        for AfterLastSvc<T>
-                    {
+                    impl<
+                        T: ResultSetService,
+                    > tonic::server::UnaryService<super::ResultSetAfterLastRequest>
+                    for AfterLastSvc<T> {
                         type Response = super::ResultSetAfterLastResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ResultSetAfterLastRequest>,
@@ -1719,12 +1964,15 @@ pub mod result_set_service_server {
                 "/simpledb.ResultSetService/Absolute" => {
                     #[allow(non_camel_case_types)]
                     struct AbsoluteSvc<T: ResultSetService>(pub Arc<T>);
-                    impl<T: ResultSetService>
-                        tonic::server::UnaryService<super::ResultSetAbsoluteRequest>
-                        for AbsoluteSvc<T>
-                    {
+                    impl<
+                        T: ResultSetService,
+                    > tonic::server::UnaryService<super::ResultSetAbsoluteRequest>
+                    for AbsoluteSvc<T> {
                         type Response = super::ResultSetAbsoluteResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ResultSetAbsoluteRequest>,
@@ -1761,11 +2009,15 @@ pub mod result_set_service_server {
                 "/simpledb.ResultSetService/Close" => {
                     #[allow(non_camel_case_types)]
                     struct CloseSvc<T: ResultSetService>(pub Arc<T>);
-                    impl<T: ResultSetService>
-                        tonic::server::UnaryService<super::ResultSetCloseRequest> for CloseSvc<T>
-                    {
+                    impl<
+                        T: ResultSetService,
+                    > tonic::server::UnaryService<super::ResultSetCloseRequest>
+                    for CloseSvc<T> {
                         type Response = super::ResultSetCloseResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ResultSetCloseRequest>,
@@ -1799,19 +2051,23 @@ pub mod result_set_service_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    let mut response = http::Response::new(empty_body());
-                    let headers = response.headers_mut();
-                    headers.insert(
-                        tonic::Status::GRPC_STATUS,
-                        (tonic::Code::Unimplemented as i32).into(),
-                    );
-                    headers.insert(
-                        http::header::CONTENT_TYPE,
-                        tonic::metadata::GRPC_CONTENT_TYPE,
-                    );
-                    Ok(response)
-                }),
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(empty_body());
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
             }
         }
     }
@@ -1840,7 +2096,7 @@ pub mod statement_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with StatementServiceServer.
@@ -1849,7 +2105,10 @@ pub mod statement_service_server {
         async fn execute_query(
             &self,
             request: tonic::Request<super::StatementExecuteQueryRequest>,
-        ) -> std::result::Result<tonic::Response<super::StatementExecuteQueryResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::StatementExecuteQueryResponse>,
+            tonic::Status,
+        >;
         async fn execute_update(
             &self,
             request: tonic::Request<super::StatementExecuteUpdateRequest>,
@@ -1879,7 +2138,10 @@ pub mod statement_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -1934,19 +2196,23 @@ pub mod statement_service_server {
                 "/simpledb.StatementService/ExecuteQuery" => {
                     #[allow(non_camel_case_types)]
                     struct ExecuteQuerySvc<T: StatementService>(pub Arc<T>);
-                    impl<T: StatementService>
-                        tonic::server::UnaryService<super::StatementExecuteQueryRequest>
-                        for ExecuteQuerySvc<T>
-                    {
+                    impl<
+                        T: StatementService,
+                    > tonic::server::UnaryService<super::StatementExecuteQueryRequest>
+                    for ExecuteQuerySvc<T> {
                         type Response = super::StatementExecuteQueryResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::StatementExecuteQueryRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as StatementService>::execute_query(&inner, request).await
+                                <T as StatementService>::execute_query(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -1976,19 +2242,23 @@ pub mod statement_service_server {
                 "/simpledb.StatementService/ExecuteUpdate" => {
                     #[allow(non_camel_case_types)]
                     struct ExecuteUpdateSvc<T: StatementService>(pub Arc<T>);
-                    impl<T: StatementService>
-                        tonic::server::UnaryService<super::StatementExecuteUpdateRequest>
-                        for ExecuteUpdateSvc<T>
-                    {
+                    impl<
+                        T: StatementService,
+                    > tonic::server::UnaryService<super::StatementExecuteUpdateRequest>
+                    for ExecuteUpdateSvc<T> {
                         type Response = super::StatementExecuteUpdateResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::StatementExecuteUpdateRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as StatementService>::execute_update(&inner, request).await
+                                <T as StatementService>::execute_update(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -2015,19 +2285,23 @@ pub mod statement_service_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    let mut response = http::Response::new(empty_body());
-                    let headers = response.headers_mut();
-                    headers.insert(
-                        tonic::Status::GRPC_STATUS,
-                        (tonic::Code::Unimplemented as i32).into(),
-                    );
-                    headers.insert(
-                        http::header::CONTENT_TYPE,
-                        tonic::metadata::GRPC_CONTENT_TYPE,
-                    );
-                    Ok(response)
-                }),
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(empty_body());
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
             }
         }
     }
@@ -2056,7 +2330,7 @@ pub mod connection_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with ConnectionServiceServer.
@@ -2072,15 +2346,24 @@ pub mod connection_service_server {
         async fn close(
             &self,
             request: tonic::Request<super::ConnectionCloseRequest>,
-        ) -> std::result::Result<tonic::Response<super::ConnectionCloseResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::ConnectionCloseResponse>,
+            tonic::Status,
+        >;
         async fn commit(
             &self,
             request: tonic::Request<super::ConnectionCommitRequest>,
-        ) -> std::result::Result<tonic::Response<super::ConnectionCommitResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::ConnectionCommitResponse>,
+            tonic::Status,
+        >;
         async fn rollback(
             &self,
             request: tonic::Request<super::ConnectionRollbackRequest>,
-        ) -> std::result::Result<tonic::Response<super::ConnectionRollbackResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::ConnectionRollbackResponse>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
     pub struct ConnectionServiceServer<T> {
@@ -2103,7 +2386,10 @@ pub mod connection_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -2158,19 +2444,26 @@ pub mod connection_service_server {
                 "/simpledb.ConnectionService/CreateStatement" => {
                     #[allow(non_camel_case_types)]
                     struct CreateStatementSvc<T: ConnectionService>(pub Arc<T>);
-                    impl<T: ConnectionService>
-                        tonic::server::UnaryService<super::ConnectionCreateStatementRequest>
-                        for CreateStatementSvc<T>
-                    {
+                    impl<
+                        T: ConnectionService,
+                    > tonic::server::UnaryService<
+                        super::ConnectionCreateStatementRequest,
+                    > for CreateStatementSvc<T> {
                         type Response = super::ConnectionCreateStatementResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::ConnectionCreateStatementRequest>,
+                            request: tonic::Request<
+                                super::ConnectionCreateStatementRequest,
+                            >,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as ConnectionService>::create_statement(&inner, request).await
+                                <T as ConnectionService>::create_statement(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -2200,11 +2493,15 @@ pub mod connection_service_server {
                 "/simpledb.ConnectionService/Close" => {
                     #[allow(non_camel_case_types)]
                     struct CloseSvc<T: ConnectionService>(pub Arc<T>);
-                    impl<T: ConnectionService>
-                        tonic::server::UnaryService<super::ConnectionCloseRequest> for CloseSvc<T>
-                    {
+                    impl<
+                        T: ConnectionService,
+                    > tonic::server::UnaryService<super::ConnectionCloseRequest>
+                    for CloseSvc<T> {
                         type Response = super::ConnectionCloseResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ConnectionCloseRequest>,
@@ -2241,12 +2538,15 @@ pub mod connection_service_server {
                 "/simpledb.ConnectionService/Commit" => {
                     #[allow(non_camel_case_types)]
                     struct CommitSvc<T: ConnectionService>(pub Arc<T>);
-                    impl<T: ConnectionService>
-                        tonic::server::UnaryService<super::ConnectionCommitRequest>
-                        for CommitSvc<T>
-                    {
+                    impl<
+                        T: ConnectionService,
+                    > tonic::server::UnaryService<super::ConnectionCommitRequest>
+                    for CommitSvc<T> {
                         type Response = super::ConnectionCommitResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ConnectionCommitRequest>,
@@ -2283,12 +2583,15 @@ pub mod connection_service_server {
                 "/simpledb.ConnectionService/Rollback" => {
                     #[allow(non_camel_case_types)]
                     struct RollbackSvc<T: ConnectionService>(pub Arc<T>);
-                    impl<T: ConnectionService>
-                        tonic::server::UnaryService<super::ConnectionRollbackRequest>
-                        for RollbackSvc<T>
-                    {
+                    impl<
+                        T: ConnectionService,
+                    > tonic::server::UnaryService<super::ConnectionRollbackRequest>
+                    for RollbackSvc<T> {
                         type Response = super::ConnectionRollbackResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ConnectionRollbackRequest>,
@@ -2322,19 +2625,23 @@ pub mod connection_service_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    let mut response = http::Response::new(empty_body());
-                    let headers = response.headers_mut();
-                    headers.insert(
-                        tonic::Status::GRPC_STATUS,
-                        (tonic::Code::Unimplemented as i32).into(),
-                    );
-                    headers.insert(
-                        http::header::CONTENT_TYPE,
-                        tonic::metadata::GRPC_CONTENT_TYPE,
-                    );
-                    Ok(response)
-                }),
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(empty_body());
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
             }
         }
     }
@@ -2363,7 +2670,7 @@ pub mod driver_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with DriverServiceServer.
@@ -2398,7 +2705,10 @@ pub mod driver_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -2453,19 +2763,23 @@ pub mod driver_service_server {
                 "/simpledb.DriverService/CreateConnection" => {
                     #[allow(non_camel_case_types)]
                     struct CreateConnectionSvc<T: DriverService>(pub Arc<T>);
-                    impl<T: DriverService>
-                        tonic::server::UnaryService<super::DriverCreateConnectionRequest>
-                        for CreateConnectionSvc<T>
-                    {
+                    impl<
+                        T: DriverService,
+                    > tonic::server::UnaryService<super::DriverCreateConnectionRequest>
+                    for CreateConnectionSvc<T> {
                         type Response = super::DriverCreateConnectionResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::DriverCreateConnectionRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as DriverService>::create_connection(&inner, request).await
+                                <T as DriverService>::create_connection(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -2492,19 +2806,23 @@ pub mod driver_service_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    let mut response = http::Response::new(empty_body());
-                    let headers = response.headers_mut();
-                    headers.insert(
-                        tonic::Status::GRPC_STATUS,
-                        (tonic::Code::Unimplemented as i32).into(),
-                    );
-                    headers.insert(
-                        http::header::CONTENT_TYPE,
-                        tonic::metadata::GRPC_CONTENT_TYPE,
-                    );
-                    Ok(response)
-                }),
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(empty_body());
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
             }
         }
     }

--- a/src/proto/simpledb.rs
+++ b/src/proto/simpledb.rs
@@ -205,10 +205,10 @@ pub mod metadata_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value,
+        clippy::let_unit_value
     )]
-    use tonic::codegen::*;
     use tonic::codegen::http::Uri;
+    use tonic::codegen::*;
     #[derive(Debug, Clone)]
     pub struct MetadataServiceClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -252,9 +252,8 @@ pub mod metadata_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             MetadataServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -296,42 +295,30 @@ pub mod metadata_service_client {
             tonic::Response<super::MetadataGetColumnCountResponse>,
             tonic::Status,
         > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/simpledb.MetadataService/GetColumnCount",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/simpledb.MetadataService/GetColumnCount");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("simpledb.MetadataService", "GetColumnCount"));
+            req.extensions_mut().insert(GrpcMethod::new(
+                "simpledb.MetadataService",
+                "GetColumnCount",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_column_name(
             &mut self,
             request: impl tonic::IntoRequest<super::MetadataGetColumnNameRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::MetadataGetColumnNameResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::MetadataGetColumnNameResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/simpledb.MetadataService/GetColumnName",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/simpledb.MetadataService/GetColumnName");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("simpledb.MetadataService", "GetColumnName"));
@@ -344,44 +331,31 @@ pub mod metadata_service_client {
             tonic::Response<super::MetadataGetColumnDisplaySizeResponse>,
             tonic::Status,
         > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/simpledb.MetadataService/GetColumnDisplaySize",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("simpledb.MetadataService", "GetColumnDisplaySize"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "simpledb.MetadataService",
+                "GetColumnDisplaySize",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn get_column_type(
             &mut self,
             request: impl tonic::IntoRequest<super::MetadataGetColumnTypeRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::MetadataGetColumnTypeResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::MetadataGetColumnTypeResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/simpledb.MetadataService/GetColumnType",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/simpledb.MetadataService/GetColumnType");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("simpledb.MetadataService", "GetColumnType"));
@@ -396,10 +370,10 @@ pub mod result_set_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value,
+        clippy::let_unit_value
     )]
-    use tonic::codegen::*;
     use tonic::codegen::http::Uri;
+    use tonic::codegen::*;
     #[derive(Debug, Clone)]
     pub struct ResultSetServiceClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -443,9 +417,8 @@ pub mod result_set_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             ResultSetServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -483,22 +456,14 @@ pub mod result_set_service_client {
         pub async fn get_metadata(
             &mut self,
             request: impl tonic::IntoRequest<super::ResultSetGetMetadataRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ResultSetGetMetadataResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::ResultSetGetMetadataResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/simpledb.ResultSetService/GetMetadata",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/simpledb.ResultSetService/GetMetadata");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("simpledb.ResultSetService", "GetMetadata"));
@@ -507,22 +472,13 @@ pub mod result_set_service_client {
         pub async fn next(
             &mut self,
             request: impl tonic::IntoRequest<super::ResultSetNextRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ResultSetNextResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::ResultSetNextResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/simpledb.ResultSetService/Next",
-            );
+            let path = http::uri::PathAndQuery::from_static("/simpledb.ResultSetService/Next");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("simpledb.ResultSetService", "Next"));
@@ -531,22 +487,13 @@ pub mod result_set_service_client {
         pub async fn previous(
             &mut self,
             request: impl tonic::IntoRequest<super::ResultSetPreviousRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ResultSetPreviousResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::ResultSetPreviousResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/simpledb.ResultSetService/Previous",
-            );
+            let path = http::uri::PathAndQuery::from_static("/simpledb.ResultSetService/Previous");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("simpledb.ResultSetService", "Previous"));
@@ -555,22 +502,13 @@ pub mod result_set_service_client {
         pub async fn get_i32(
             &mut self,
             request: impl tonic::IntoRequest<super::ResultSetGetI32Request>,
-        ) -> std::result::Result<
-            tonic::Response<super::ResultSetGetI32Response>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::ResultSetGetI32Response>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/simpledb.ResultSetService/GetI32",
-            );
+            let path = http::uri::PathAndQuery::from_static("/simpledb.ResultSetService/GetI32");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("simpledb.ResultSetService", "GetI32"));
@@ -579,22 +517,13 @@ pub mod result_set_service_client {
         pub async fn get_string(
             &mut self,
             request: impl tonic::IntoRequest<super::ResultSetGetStringRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ResultSetGetStringResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::ResultSetGetStringResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/simpledb.ResultSetService/GetString",
-            );
+            let path = http::uri::PathAndQuery::from_static("/simpledb.ResultSetService/GetString");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("simpledb.ResultSetService", "GetString"));
@@ -603,22 +532,14 @@ pub mod result_set_service_client {
         pub async fn before_first(
             &mut self,
             request: impl tonic::IntoRequest<super::ResultSetBeforeFirstRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ResultSetBeforeFirstResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::ResultSetBeforeFirstResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/simpledb.ResultSetService/BeforeFirst",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/simpledb.ResultSetService/BeforeFirst");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("simpledb.ResultSetService", "BeforeFirst"));
@@ -627,22 +548,13 @@ pub mod result_set_service_client {
         pub async fn after_last(
             &mut self,
             request: impl tonic::IntoRequest<super::ResultSetAfterLastRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ResultSetAfterLastResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::ResultSetAfterLastResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/simpledb.ResultSetService/AfterLast",
-            );
+            let path = http::uri::PathAndQuery::from_static("/simpledb.ResultSetService/AfterLast");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("simpledb.ResultSetService", "AfterLast"));
@@ -651,22 +563,13 @@ pub mod result_set_service_client {
         pub async fn absolute(
             &mut self,
             request: impl tonic::IntoRequest<super::ResultSetAbsoluteRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ResultSetAbsoluteResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::ResultSetAbsoluteResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/simpledb.ResultSetService/Absolute",
-            );
+            let path = http::uri::PathAndQuery::from_static("/simpledb.ResultSetService/Absolute");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("simpledb.ResultSetService", "Absolute"));
@@ -675,22 +578,13 @@ pub mod result_set_service_client {
         pub async fn close(
             &mut self,
             request: impl tonic::IntoRequest<super::ResultSetCloseRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ResultSetCloseResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::ResultSetCloseResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/simpledb.ResultSetService/Close",
-            );
+            let path = http::uri::PathAndQuery::from_static("/simpledb.ResultSetService/Close");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("simpledb.ResultSetService", "Close"));
@@ -705,10 +599,10 @@ pub mod statement_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value,
+        clippy::let_unit_value
     )]
-    use tonic::codegen::*;
     use tonic::codegen::http::Uri;
+    use tonic::codegen::*;
     #[derive(Debug, Clone)]
     pub struct StatementServiceClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -752,9 +646,8 @@ pub mod statement_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             StatementServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -792,22 +685,14 @@ pub mod statement_service_client {
         pub async fn execute_query(
             &mut self,
             request: impl tonic::IntoRequest<super::StatementExecuteQueryRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::StatementExecuteQueryResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::StatementExecuteQueryResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/simpledb.StatementService/ExecuteQuery",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/simpledb.StatementService/ExecuteQuery");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("simpledb.StatementService", "ExecuteQuery"));
@@ -820,21 +705,17 @@ pub mod statement_service_client {
             tonic::Response<super::StatementExecuteUpdateResponse>,
             tonic::Status,
         > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/simpledb.StatementService/ExecuteUpdate",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/simpledb.StatementService/ExecuteUpdate");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("simpledb.StatementService", "ExecuteUpdate"));
+            req.extensions_mut().insert(GrpcMethod::new(
+                "simpledb.StatementService",
+                "ExecuteUpdate",
+            ));
             self.inner.unary(req, path, codec).await
         }
     }
@@ -846,10 +727,10 @@ pub mod connection_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value,
+        clippy::let_unit_value
     )]
-    use tonic::codegen::*;
     use tonic::codegen::http::Uri;
+    use tonic::codegen::*;
     #[derive(Debug, Clone)]
     pub struct ConnectionServiceClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -893,9 +774,8 @@ pub mod connection_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             ConnectionServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -937,44 +817,29 @@ pub mod connection_service_client {
             tonic::Response<super::ConnectionCreateStatementResponse>,
             tonic::Status,
         > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/simpledb.ConnectionService/CreateStatement",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/simpledb.ConnectionService/CreateStatement");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new("simpledb.ConnectionService", "CreateStatement"),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "simpledb.ConnectionService",
+                "CreateStatement",
+            ));
             self.inner.unary(req, path, codec).await
         }
         pub async fn close(
             &mut self,
             request: impl tonic::IntoRequest<super::ConnectionCloseRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ConnectionCloseResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::ConnectionCloseResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/simpledb.ConnectionService/Close",
-            );
+            let path = http::uri::PathAndQuery::from_static("/simpledb.ConnectionService/Close");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("simpledb.ConnectionService", "Close"));
@@ -983,22 +848,13 @@ pub mod connection_service_client {
         pub async fn commit(
             &mut self,
             request: impl tonic::IntoRequest<super::ConnectionCommitRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ConnectionCommitResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::ConnectionCommitResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/simpledb.ConnectionService/Commit",
-            );
+            let path = http::uri::PathAndQuery::from_static("/simpledb.ConnectionService/Commit");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("simpledb.ConnectionService", "Commit"));
@@ -1007,22 +863,13 @@ pub mod connection_service_client {
         pub async fn rollback(
             &mut self,
             request: impl tonic::IntoRequest<super::ConnectionRollbackRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ConnectionRollbackResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::ConnectionRollbackResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/simpledb.ConnectionService/Rollback",
-            );
+            let path = http::uri::PathAndQuery::from_static("/simpledb.ConnectionService/Rollback");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("simpledb.ConnectionService", "Rollback"));
@@ -1037,10 +884,10 @@ pub mod driver_service_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value,
+        clippy::let_unit_value
     )]
-    use tonic::codegen::*;
     use tonic::codegen::http::Uri;
+    use tonic::codegen::*;
     #[derive(Debug, Clone)]
     pub struct DriverServiceClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -1084,9 +931,8 @@ pub mod driver_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             DriverServiceClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -1128,21 +974,17 @@ pub mod driver_service_client {
             tonic::Response<super::DriverCreateConnectionResponse>,
             tonic::Status,
         > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/simpledb.DriverService/CreateConnection",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/simpledb.DriverService/CreateConnection");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("simpledb.DriverService", "CreateConnection"));
+            req.extensions_mut().insert(GrpcMethod::new(
+                "simpledb.DriverService",
+                "CreateConnection",
+            ));
             self.inner.unary(req, path, codec).await
         }
     }
@@ -1154,7 +996,7 @@ pub mod metadata_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value,
+        clippy::let_unit_value
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with MetadataServiceServer.
@@ -1170,10 +1012,7 @@ pub mod metadata_service_server {
         async fn get_column_name(
             &self,
             request: tonic::Request<super::MetadataGetColumnNameRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::MetadataGetColumnNameResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::MetadataGetColumnNameResponse>, tonic::Status>;
         async fn get_column_display_size(
             &self,
             request: tonic::Request<super::MetadataGetColumnDisplaySizeRequest>,
@@ -1184,10 +1023,7 @@ pub mod metadata_service_server {
         async fn get_column_type(
             &self,
             request: tonic::Request<super::MetadataGetColumnTypeRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::MetadataGetColumnTypeResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::MetadataGetColumnTypeResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct MetadataServiceServer<T> {
@@ -1210,10 +1046,7 @@ pub mod metadata_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -1268,23 +1101,19 @@ pub mod metadata_service_server {
                 "/simpledb.MetadataService/GetColumnCount" => {
                     #[allow(non_camel_case_types)]
                     struct GetColumnCountSvc<T: MetadataService>(pub Arc<T>);
-                    impl<
-                        T: MetadataService,
-                    > tonic::server::UnaryService<super::MetadataGetColumnCountRequest>
-                    for GetColumnCountSvc<T> {
+                    impl<T: MetadataService>
+                        tonic::server::UnaryService<super::MetadataGetColumnCountRequest>
+                        for GetColumnCountSvc<T>
+                    {
                         type Response = super::MetadataGetColumnCountResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::MetadataGetColumnCountRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as MetadataService>::get_column_count(&inner, request)
-                                    .await
+                                <T as MetadataService>::get_column_count(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1314,23 +1143,19 @@ pub mod metadata_service_server {
                 "/simpledb.MetadataService/GetColumnName" => {
                     #[allow(non_camel_case_types)]
                     struct GetColumnNameSvc<T: MetadataService>(pub Arc<T>);
-                    impl<
-                        T: MetadataService,
-                    > tonic::server::UnaryService<super::MetadataGetColumnNameRequest>
-                    for GetColumnNameSvc<T> {
+                    impl<T: MetadataService>
+                        tonic::server::UnaryService<super::MetadataGetColumnNameRequest>
+                        for GetColumnNameSvc<T>
+                    {
                         type Response = super::MetadataGetColumnNameResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::MetadataGetColumnNameRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as MetadataService>::get_column_name(&inner, request)
-                                    .await
+                                <T as MetadataService>::get_column_name(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1360,28 +1185,19 @@ pub mod metadata_service_server {
                 "/simpledb.MetadataService/GetColumnDisplaySize" => {
                     #[allow(non_camel_case_types)]
                     struct GetColumnDisplaySizeSvc<T: MetadataService>(pub Arc<T>);
-                    impl<
-                        T: MetadataService,
-                    > tonic::server::UnaryService<
-                        super::MetadataGetColumnDisplaySizeRequest,
-                    > for GetColumnDisplaySizeSvc<T> {
+                    impl<T: MetadataService>
+                        tonic::server::UnaryService<super::MetadataGetColumnDisplaySizeRequest>
+                        for GetColumnDisplaySizeSvc<T>
+                    {
                         type Response = super::MetadataGetColumnDisplaySizeResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
-                            request: tonic::Request<
-                                super::MetadataGetColumnDisplaySizeRequest,
-                            >,
+                            request: tonic::Request<super::MetadataGetColumnDisplaySizeRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as MetadataService>::get_column_display_size(
-                                        &inner,
-                                        request,
-                                    )
+                                <T as MetadataService>::get_column_display_size(&inner, request)
                                     .await
                             };
                             Box::pin(fut)
@@ -1412,23 +1228,19 @@ pub mod metadata_service_server {
                 "/simpledb.MetadataService/GetColumnType" => {
                     #[allow(non_camel_case_types)]
                     struct GetColumnTypeSvc<T: MetadataService>(pub Arc<T>);
-                    impl<
-                        T: MetadataService,
-                    > tonic::server::UnaryService<super::MetadataGetColumnTypeRequest>
-                    for GetColumnTypeSvc<T> {
+                    impl<T: MetadataService>
+                        tonic::server::UnaryService<super::MetadataGetColumnTypeRequest>
+                        for GetColumnTypeSvc<T>
+                    {
                         type Response = super::MetadataGetColumnTypeResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::MetadataGetColumnTypeRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as MetadataService>::get_column_type(&inner, request)
-                                    .await
+                                <T as MetadataService>::get_column_type(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1455,23 +1267,19 @@ pub mod metadata_service_server {
                     };
                     Box::pin(fut)
                 }
-                _ => {
-                    Box::pin(async move {
-                        let mut response = http::Response::new(empty_body());
-                        let headers = response.headers_mut();
-                        headers
-                            .insert(
-                                tonic::Status::GRPC_STATUS,
-                                (tonic::Code::Unimplemented as i32).into(),
-                            );
-                        headers
-                            .insert(
-                                http::header::CONTENT_TYPE,
-                                tonic::metadata::GRPC_CONTENT_TYPE,
-                            );
-                        Ok(response)
-                    })
-                }
+                _ => Box::pin(async move {
+                    let mut response = http::Response::new(empty_body());
+                    let headers = response.headers_mut();
+                    headers.insert(
+                        tonic::Status::GRPC_STATUS,
+                        (tonic::Code::Unimplemented as i32).into(),
+                    );
+                    headers.insert(
+                        http::header::CONTENT_TYPE,
+                        tonic::metadata::GRPC_CONTENT_TYPE,
+                    );
+                    Ok(response)
+                }),
             }
         }
     }
@@ -1500,7 +1308,7 @@ pub mod result_set_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value,
+        clippy::let_unit_value
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with ResultSetServiceServer.
@@ -1509,66 +1317,39 @@ pub mod result_set_service_server {
         async fn get_metadata(
             &self,
             request: tonic::Request<super::ResultSetGetMetadataRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ResultSetGetMetadataResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::ResultSetGetMetadataResponse>, tonic::Status>;
         async fn next(
             &self,
             request: tonic::Request<super::ResultSetNextRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ResultSetNextResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::ResultSetNextResponse>, tonic::Status>;
         async fn previous(
             &self,
             request: tonic::Request<super::ResultSetPreviousRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ResultSetPreviousResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::ResultSetPreviousResponse>, tonic::Status>;
         async fn get_i32(
             &self,
             request: tonic::Request<super::ResultSetGetI32Request>,
-        ) -> std::result::Result<
-            tonic::Response<super::ResultSetGetI32Response>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::ResultSetGetI32Response>, tonic::Status>;
         async fn get_string(
             &self,
             request: tonic::Request<super::ResultSetGetStringRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ResultSetGetStringResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::ResultSetGetStringResponse>, tonic::Status>;
         async fn before_first(
             &self,
             request: tonic::Request<super::ResultSetBeforeFirstRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ResultSetBeforeFirstResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::ResultSetBeforeFirstResponse>, tonic::Status>;
         async fn after_last(
             &self,
             request: tonic::Request<super::ResultSetAfterLastRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ResultSetAfterLastResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::ResultSetAfterLastResponse>, tonic::Status>;
         async fn absolute(
             &self,
             request: tonic::Request<super::ResultSetAbsoluteRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ResultSetAbsoluteResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::ResultSetAbsoluteResponse>, tonic::Status>;
         async fn close(
             &self,
             request: tonic::Request<super::ResultSetCloseRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ResultSetCloseResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::ResultSetCloseResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct ResultSetServiceServer<T> {
@@ -1591,10 +1372,7 @@ pub mod result_set_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -1649,15 +1427,12 @@ pub mod result_set_service_server {
                 "/simpledb.ResultSetService/GetMetadata" => {
                     #[allow(non_camel_case_types)]
                     struct GetMetadataSvc<T: ResultSetService>(pub Arc<T>);
-                    impl<
-                        T: ResultSetService,
-                    > tonic::server::UnaryService<super::ResultSetGetMetadataRequest>
-                    for GetMetadataSvc<T> {
+                    impl<T: ResultSetService>
+                        tonic::server::UnaryService<super::ResultSetGetMetadataRequest>
+                        for GetMetadataSvc<T>
+                    {
                         type Response = super::ResultSetGetMetadataResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ResultSetGetMetadataRequest>,
@@ -1694,23 +1469,18 @@ pub mod result_set_service_server {
                 "/simpledb.ResultSetService/Next" => {
                     #[allow(non_camel_case_types)]
                     struct NextSvc<T: ResultSetService>(pub Arc<T>);
-                    impl<
-                        T: ResultSetService,
-                    > tonic::server::UnaryService<super::ResultSetNextRequest>
-                    for NextSvc<T> {
+                    impl<T: ResultSetService>
+                        tonic::server::UnaryService<super::ResultSetNextRequest> for NextSvc<T>
+                    {
                         type Response = super::ResultSetNextResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ResultSetNextRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                <T as ResultSetService>::next(&inner, request).await
-                            };
+                            let fut =
+                                async move { <T as ResultSetService>::next(&inner, request).await };
                             Box::pin(fut)
                         }
                     }
@@ -1739,15 +1509,12 @@ pub mod result_set_service_server {
                 "/simpledb.ResultSetService/Previous" => {
                     #[allow(non_camel_case_types)]
                     struct PreviousSvc<T: ResultSetService>(pub Arc<T>);
-                    impl<
-                        T: ResultSetService,
-                    > tonic::server::UnaryService<super::ResultSetPreviousRequest>
-                    for PreviousSvc<T> {
+                    impl<T: ResultSetService>
+                        tonic::server::UnaryService<super::ResultSetPreviousRequest>
+                        for PreviousSvc<T>
+                    {
                         type Response = super::ResultSetPreviousResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ResultSetPreviousRequest>,
@@ -1784,15 +1551,12 @@ pub mod result_set_service_server {
                 "/simpledb.ResultSetService/GetI32" => {
                     #[allow(non_camel_case_types)]
                     struct GetI32Svc<T: ResultSetService>(pub Arc<T>);
-                    impl<
-                        T: ResultSetService,
-                    > tonic::server::UnaryService<super::ResultSetGetI32Request>
-                    for GetI32Svc<T> {
+                    impl<T: ResultSetService>
+                        tonic::server::UnaryService<super::ResultSetGetI32Request>
+                        for GetI32Svc<T>
+                    {
                         type Response = super::ResultSetGetI32Response;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ResultSetGetI32Request>,
@@ -1829,15 +1593,12 @@ pub mod result_set_service_server {
                 "/simpledb.ResultSetService/GetString" => {
                     #[allow(non_camel_case_types)]
                     struct GetStringSvc<T: ResultSetService>(pub Arc<T>);
-                    impl<
-                        T: ResultSetService,
-                    > tonic::server::UnaryService<super::ResultSetGetStringRequest>
-                    for GetStringSvc<T> {
+                    impl<T: ResultSetService>
+                        tonic::server::UnaryService<super::ResultSetGetStringRequest>
+                        for GetStringSvc<T>
+                    {
                         type Response = super::ResultSetGetStringResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ResultSetGetStringRequest>,
@@ -1874,15 +1635,12 @@ pub mod result_set_service_server {
                 "/simpledb.ResultSetService/BeforeFirst" => {
                     #[allow(non_camel_case_types)]
                     struct BeforeFirstSvc<T: ResultSetService>(pub Arc<T>);
-                    impl<
-                        T: ResultSetService,
-                    > tonic::server::UnaryService<super::ResultSetBeforeFirstRequest>
-                    for BeforeFirstSvc<T> {
+                    impl<T: ResultSetService>
+                        tonic::server::UnaryService<super::ResultSetBeforeFirstRequest>
+                        for BeforeFirstSvc<T>
+                    {
                         type Response = super::ResultSetBeforeFirstResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ResultSetBeforeFirstRequest>,
@@ -1919,15 +1677,12 @@ pub mod result_set_service_server {
                 "/simpledb.ResultSetService/AfterLast" => {
                     #[allow(non_camel_case_types)]
                     struct AfterLastSvc<T: ResultSetService>(pub Arc<T>);
-                    impl<
-                        T: ResultSetService,
-                    > tonic::server::UnaryService<super::ResultSetAfterLastRequest>
-                    for AfterLastSvc<T> {
+                    impl<T: ResultSetService>
+                        tonic::server::UnaryService<super::ResultSetAfterLastRequest>
+                        for AfterLastSvc<T>
+                    {
                         type Response = super::ResultSetAfterLastResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ResultSetAfterLastRequest>,
@@ -1964,15 +1719,12 @@ pub mod result_set_service_server {
                 "/simpledb.ResultSetService/Absolute" => {
                     #[allow(non_camel_case_types)]
                     struct AbsoluteSvc<T: ResultSetService>(pub Arc<T>);
-                    impl<
-                        T: ResultSetService,
-                    > tonic::server::UnaryService<super::ResultSetAbsoluteRequest>
-                    for AbsoluteSvc<T> {
+                    impl<T: ResultSetService>
+                        tonic::server::UnaryService<super::ResultSetAbsoluteRequest>
+                        for AbsoluteSvc<T>
+                    {
                         type Response = super::ResultSetAbsoluteResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ResultSetAbsoluteRequest>,
@@ -2009,15 +1761,11 @@ pub mod result_set_service_server {
                 "/simpledb.ResultSetService/Close" => {
                     #[allow(non_camel_case_types)]
                     struct CloseSvc<T: ResultSetService>(pub Arc<T>);
-                    impl<
-                        T: ResultSetService,
-                    > tonic::server::UnaryService<super::ResultSetCloseRequest>
-                    for CloseSvc<T> {
+                    impl<T: ResultSetService>
+                        tonic::server::UnaryService<super::ResultSetCloseRequest> for CloseSvc<T>
+                    {
                         type Response = super::ResultSetCloseResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ResultSetCloseRequest>,
@@ -2051,23 +1799,19 @@ pub mod result_set_service_server {
                     };
                     Box::pin(fut)
                 }
-                _ => {
-                    Box::pin(async move {
-                        let mut response = http::Response::new(empty_body());
-                        let headers = response.headers_mut();
-                        headers
-                            .insert(
-                                tonic::Status::GRPC_STATUS,
-                                (tonic::Code::Unimplemented as i32).into(),
-                            );
-                        headers
-                            .insert(
-                                http::header::CONTENT_TYPE,
-                                tonic::metadata::GRPC_CONTENT_TYPE,
-                            );
-                        Ok(response)
-                    })
-                }
+                _ => Box::pin(async move {
+                    let mut response = http::Response::new(empty_body());
+                    let headers = response.headers_mut();
+                    headers.insert(
+                        tonic::Status::GRPC_STATUS,
+                        (tonic::Code::Unimplemented as i32).into(),
+                    );
+                    headers.insert(
+                        http::header::CONTENT_TYPE,
+                        tonic::metadata::GRPC_CONTENT_TYPE,
+                    );
+                    Ok(response)
+                }),
             }
         }
     }
@@ -2096,7 +1840,7 @@ pub mod statement_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value,
+        clippy::let_unit_value
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with StatementServiceServer.
@@ -2105,10 +1849,7 @@ pub mod statement_service_server {
         async fn execute_query(
             &self,
             request: tonic::Request<super::StatementExecuteQueryRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::StatementExecuteQueryResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::StatementExecuteQueryResponse>, tonic::Status>;
         async fn execute_update(
             &self,
             request: tonic::Request<super::StatementExecuteUpdateRequest>,
@@ -2138,10 +1879,7 @@ pub mod statement_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -2196,23 +1934,19 @@ pub mod statement_service_server {
                 "/simpledb.StatementService/ExecuteQuery" => {
                     #[allow(non_camel_case_types)]
                     struct ExecuteQuerySvc<T: StatementService>(pub Arc<T>);
-                    impl<
-                        T: StatementService,
-                    > tonic::server::UnaryService<super::StatementExecuteQueryRequest>
-                    for ExecuteQuerySvc<T> {
+                    impl<T: StatementService>
+                        tonic::server::UnaryService<super::StatementExecuteQueryRequest>
+                        for ExecuteQuerySvc<T>
+                    {
                         type Response = super::StatementExecuteQueryResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::StatementExecuteQueryRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as StatementService>::execute_query(&inner, request)
-                                    .await
+                                <T as StatementService>::execute_query(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -2242,23 +1976,19 @@ pub mod statement_service_server {
                 "/simpledb.StatementService/ExecuteUpdate" => {
                     #[allow(non_camel_case_types)]
                     struct ExecuteUpdateSvc<T: StatementService>(pub Arc<T>);
-                    impl<
-                        T: StatementService,
-                    > tonic::server::UnaryService<super::StatementExecuteUpdateRequest>
-                    for ExecuteUpdateSvc<T> {
+                    impl<T: StatementService>
+                        tonic::server::UnaryService<super::StatementExecuteUpdateRequest>
+                        for ExecuteUpdateSvc<T>
+                    {
                         type Response = super::StatementExecuteUpdateResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::StatementExecuteUpdateRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as StatementService>::execute_update(&inner, request)
-                                    .await
+                                <T as StatementService>::execute_update(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -2285,23 +2015,19 @@ pub mod statement_service_server {
                     };
                     Box::pin(fut)
                 }
-                _ => {
-                    Box::pin(async move {
-                        let mut response = http::Response::new(empty_body());
-                        let headers = response.headers_mut();
-                        headers
-                            .insert(
-                                tonic::Status::GRPC_STATUS,
-                                (tonic::Code::Unimplemented as i32).into(),
-                            );
-                        headers
-                            .insert(
-                                http::header::CONTENT_TYPE,
-                                tonic::metadata::GRPC_CONTENT_TYPE,
-                            );
-                        Ok(response)
-                    })
-                }
+                _ => Box::pin(async move {
+                    let mut response = http::Response::new(empty_body());
+                    let headers = response.headers_mut();
+                    headers.insert(
+                        tonic::Status::GRPC_STATUS,
+                        (tonic::Code::Unimplemented as i32).into(),
+                    );
+                    headers.insert(
+                        http::header::CONTENT_TYPE,
+                        tonic::metadata::GRPC_CONTENT_TYPE,
+                    );
+                    Ok(response)
+                }),
             }
         }
     }
@@ -2330,7 +2056,7 @@ pub mod connection_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value,
+        clippy::let_unit_value
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with ConnectionServiceServer.
@@ -2346,24 +2072,15 @@ pub mod connection_service_server {
         async fn close(
             &self,
             request: tonic::Request<super::ConnectionCloseRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ConnectionCloseResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::ConnectionCloseResponse>, tonic::Status>;
         async fn commit(
             &self,
             request: tonic::Request<super::ConnectionCommitRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ConnectionCommitResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::ConnectionCommitResponse>, tonic::Status>;
         async fn rollback(
             &self,
             request: tonic::Request<super::ConnectionRollbackRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ConnectionRollbackResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::ConnectionRollbackResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct ConnectionServiceServer<T> {
@@ -2386,10 +2103,7 @@ pub mod connection_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -2444,26 +2158,19 @@ pub mod connection_service_server {
                 "/simpledb.ConnectionService/CreateStatement" => {
                     #[allow(non_camel_case_types)]
                     struct CreateStatementSvc<T: ConnectionService>(pub Arc<T>);
-                    impl<
-                        T: ConnectionService,
-                    > tonic::server::UnaryService<
-                        super::ConnectionCreateStatementRequest,
-                    > for CreateStatementSvc<T> {
+                    impl<T: ConnectionService>
+                        tonic::server::UnaryService<super::ConnectionCreateStatementRequest>
+                        for CreateStatementSvc<T>
+                    {
                         type Response = super::ConnectionCreateStatementResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
-                            request: tonic::Request<
-                                super::ConnectionCreateStatementRequest,
-                            >,
+                            request: tonic::Request<super::ConnectionCreateStatementRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as ConnectionService>::create_statement(&inner, request)
-                                    .await
+                                <T as ConnectionService>::create_statement(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -2493,15 +2200,11 @@ pub mod connection_service_server {
                 "/simpledb.ConnectionService/Close" => {
                     #[allow(non_camel_case_types)]
                     struct CloseSvc<T: ConnectionService>(pub Arc<T>);
-                    impl<
-                        T: ConnectionService,
-                    > tonic::server::UnaryService<super::ConnectionCloseRequest>
-                    for CloseSvc<T> {
+                    impl<T: ConnectionService>
+                        tonic::server::UnaryService<super::ConnectionCloseRequest> for CloseSvc<T>
+                    {
                         type Response = super::ConnectionCloseResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ConnectionCloseRequest>,
@@ -2538,15 +2241,12 @@ pub mod connection_service_server {
                 "/simpledb.ConnectionService/Commit" => {
                     #[allow(non_camel_case_types)]
                     struct CommitSvc<T: ConnectionService>(pub Arc<T>);
-                    impl<
-                        T: ConnectionService,
-                    > tonic::server::UnaryService<super::ConnectionCommitRequest>
-                    for CommitSvc<T> {
+                    impl<T: ConnectionService>
+                        tonic::server::UnaryService<super::ConnectionCommitRequest>
+                        for CommitSvc<T>
+                    {
                         type Response = super::ConnectionCommitResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ConnectionCommitRequest>,
@@ -2583,15 +2283,12 @@ pub mod connection_service_server {
                 "/simpledb.ConnectionService/Rollback" => {
                     #[allow(non_camel_case_types)]
                     struct RollbackSvc<T: ConnectionService>(pub Arc<T>);
-                    impl<
-                        T: ConnectionService,
-                    > tonic::server::UnaryService<super::ConnectionRollbackRequest>
-                    for RollbackSvc<T> {
+                    impl<T: ConnectionService>
+                        tonic::server::UnaryService<super::ConnectionRollbackRequest>
+                        for RollbackSvc<T>
+                    {
                         type Response = super::ConnectionRollbackResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ConnectionRollbackRequest>,
@@ -2625,23 +2322,19 @@ pub mod connection_service_server {
                     };
                     Box::pin(fut)
                 }
-                _ => {
-                    Box::pin(async move {
-                        let mut response = http::Response::new(empty_body());
-                        let headers = response.headers_mut();
-                        headers
-                            .insert(
-                                tonic::Status::GRPC_STATUS,
-                                (tonic::Code::Unimplemented as i32).into(),
-                            );
-                        headers
-                            .insert(
-                                http::header::CONTENT_TYPE,
-                                tonic::metadata::GRPC_CONTENT_TYPE,
-                            );
-                        Ok(response)
-                    })
-                }
+                _ => Box::pin(async move {
+                    let mut response = http::Response::new(empty_body());
+                    let headers = response.headers_mut();
+                    headers.insert(
+                        tonic::Status::GRPC_STATUS,
+                        (tonic::Code::Unimplemented as i32).into(),
+                    );
+                    headers.insert(
+                        http::header::CONTENT_TYPE,
+                        tonic::metadata::GRPC_CONTENT_TYPE,
+                    );
+                    Ok(response)
+                }),
             }
         }
     }
@@ -2670,7 +2363,7 @@ pub mod driver_service_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value,
+        clippy::let_unit_value
     )]
     use tonic::codegen::*;
     /// Generated trait containing gRPC methods that should be implemented for use with DriverServiceServer.
@@ -2705,10 +2398,7 @@ pub mod driver_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -2763,23 +2453,19 @@ pub mod driver_service_server {
                 "/simpledb.DriverService/CreateConnection" => {
                     #[allow(non_camel_case_types)]
                     struct CreateConnectionSvc<T: DriverService>(pub Arc<T>);
-                    impl<
-                        T: DriverService,
-                    > tonic::server::UnaryService<super::DriverCreateConnectionRequest>
-                    for CreateConnectionSvc<T> {
+                    impl<T: DriverService>
+                        tonic::server::UnaryService<super::DriverCreateConnectionRequest>
+                        for CreateConnectionSvc<T>
+                    {
                         type Response = super::DriverCreateConnectionResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::DriverCreateConnectionRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as DriverService>::create_connection(&inner, request)
-                                    .await
+                                <T as DriverService>::create_connection(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -2806,23 +2492,19 @@ pub mod driver_service_server {
                     };
                     Box::pin(fut)
                 }
-                _ => {
-                    Box::pin(async move {
-                        let mut response = http::Response::new(empty_body());
-                        let headers = response.headers_mut();
-                        headers
-                            .insert(
-                                tonic::Status::GRPC_STATUS,
-                                (tonic::Code::Unimplemented as i32).into(),
-                            );
-                        headers
-                            .insert(
-                                http::header::CONTENT_TYPE,
-                                tonic::metadata::GRPC_CONTENT_TYPE,
-                            );
-                        Ok(response)
-                    })
-                }
+                _ => Box::pin(async move {
+                    let mut response = http::Response::new(empty_body());
+                    let headers = response.headers_mut();
+                    headers.insert(
+                        tonic::Status::GRPC_STATUS,
+                        (tonic::Code::Unimplemented as i32).into(),
+                    );
+                    headers.insert(
+                        http::header::CONTENT_TYPE,
+                        tonic::metadata::GRPC_CONTENT_TYPE,
+                    );
+                    Ok(response)
+                }),
             }
         }
     }

--- a/src/scan/mod.rs
+++ b/src/scan/mod.rs
@@ -59,8 +59,8 @@ pub trait ScanControl {
     fn previous(&mut self) -> Result<bool, TransactionError> {
         unimplemented!("Backward scanning is not supported")
     }
-    fn get_i32(&mut self, field_name: &str) -> Result<i32, TransactionError>;
-    fn get_string(&mut self, field_name: &str) -> Result<String, TransactionError>;
+    fn get_i32(&mut self, field_name: &str) -> Result<Option<i32>, TransactionError>;
+    fn get_string(&mut self, field_name: &str) -> Result<Option<String>, TransactionError>;
     fn get_value(&mut self, field_name: &str) -> Result<Value, TransactionError>;
     fn has_field(&self, field_name: &str) -> bool;
 

--- a/src/scan/product_scan.rs
+++ b/src/scan/product_scan.rs
@@ -52,7 +52,7 @@ impl ScanControl for ProductScan {
         }
     }
 
-    fn get_i32(&mut self, field_name: &str) -> Result<i32, TransactionError> {
+    fn get_i32(&mut self, field_name: &str) -> Result<Option<i32>, TransactionError> {
         if self.scan1.has_field(field_name) {
             self.scan1.get_i32(field_name)
         } else {
@@ -60,7 +60,7 @@ impl ScanControl for ProductScan {
         }
     }
 
-    fn get_string(&mut self, field_name: &str) -> Result<String, TransactionError> {
+    fn get_string(&mut self, field_name: &str) -> Result<Option<String>, TransactionError> {
         if self.scan1.has_field(field_name) {
             self.scan1.get_string(field_name)
         } else {
@@ -135,11 +135,11 @@ mod tests {
         for i in 0..10 {
             for j in 0..10 {
                 assert!(product_scan.next()?);
-                assert_eq!(product_scan.get_i32("A")?, i);
-                assert_eq!(product_scan.get_string("B")?, i.to_string());
-                assert_eq!(product_scan.get_i32("C")?, i + 2);
-                assert_eq!(product_scan.get_i32("D")?, j);
-                assert_eq!(product_scan.get_string("E")?, j.to_string());
+                assert_eq!(product_scan.get_i32("A")?, Some(i));
+                assert_eq!(product_scan.get_string("B")?, Some(i.to_string()));
+                assert_eq!(product_scan.get_i32("C")?, Some(i + 2));
+                assert_eq!(product_scan.get_i32("D")?, Some(j));
+                assert_eq!(product_scan.get_string("E")?, Some(j.to_string()));
             }
         }
         assert!(!product_scan.next()?);
@@ -184,8 +184,8 @@ mod tests {
         let mut expected = vec![(2, 1), (2, 0), (1, 1), (1, 0), (0, 1), (0, 0)];
         for (a, d) in expected.drain(..) {
             assert!(scan.previous()?);
-            assert_eq!(scan.get_i32("A")?, a);
-            assert_eq!(scan.get_i32("D")?, d);
+            assert_eq!(scan.get_i32("A")?, Some(a));
+            assert_eq!(scan.get_i32("D")?, Some(d));
         }
         assert!(!scan.previous()?);
         drop(scan);

--- a/src/scan/project_scan.rs
+++ b/src/scan/project_scan.rs
@@ -37,12 +37,12 @@ impl ScanControl for ProjectScan {
         self.base_scan.next()
     }
 
-    fn get_i32(&mut self, field_name: &str) -> Result<i32, TransactionError> {
+    fn get_i32(&mut self, field_name: &str) -> Result<Option<i32>, TransactionError> {
         assert!(self.fields.contains(&field_name.to_string()));
         self.base_scan.get_i32(field_name)
     }
 
-    fn get_string(&mut self, field_name: &str) -> Result<String, TransactionError> {
+    fn get_string(&mut self, field_name: &str) -> Result<Option<String>, TransactionError> {
         assert!(self.fields.contains(&field_name.to_string()));
         self.base_scan.get_string(field_name)
     }
@@ -103,8 +103,8 @@ mod tests {
             assert!(project_scan.has_field("A"));
             assert!(!project_scan.has_field("B"));
             assert!(project_scan.has_field("C"));
-            assert_eq!(project_scan.get_i32("A")?, i);
-            assert_eq!(project_scan.get_i32("C")?, i + 2);
+            assert_eq!(project_scan.get_i32("A")?, Some(i));
+            assert_eq!(project_scan.get_i32("C")?, Some(i + 2));
         }
         drop(project_scan);
         tx.lock().unwrap().commit()?;
@@ -138,8 +138,8 @@ mod tests {
         scan.after_last()?;
         for i in (0..10).rev() {
             assert!(scan.previous()?);
-            assert_eq!(scan.get_i32("A")?, i);
-            assert_eq!(scan.get_i32("C")?, i + 1);
+            assert_eq!(scan.get_i32("A")?, Some(i));
+            assert_eq!(scan.get_i32("C")?, Some(i + 1));
         }
         assert!(!scan.previous()?);
         drop(scan);

--- a/src/scan/select_scan.rs
+++ b/src/scan/select_scan.rs
@@ -43,11 +43,11 @@ impl ScanControl for SelectScan {
         Ok(false)
     }
 
-    fn get_i32(&mut self, field_name: &str) -> Result<i32, TransactionError> {
+    fn get_i32(&mut self, field_name: &str) -> Result<Option<i32>, TransactionError> {
         self.base_scan.get_i32(field_name)
     }
 
-    fn get_string(&mut self, field_name: &str) -> Result<String, TransactionError> {
+    fn get_string(&mut self, field_name: &str) -> Result<Option<String>, TransactionError> {
         self.base_scan.get_string(field_name)
     }
 
@@ -136,9 +136,9 @@ mod tests {
         for i in 0..50 {
             if i % 3 == 1 && i % 4 == 2 {
                 assert!(select_scan.next()?);
-                assert_eq!(select_scan.get_i32("A")?, 1);
-                assert_eq!(select_scan.get_string("B")?, "2");
-                assert_eq!(select_scan.get_i32("C")?, i);
+                assert_eq!(select_scan.get_i32("A")?, Some(1));
+                assert_eq!(select_scan.get_string("B")?, Some("2".to_string()));
+                assert_eq!(select_scan.get_i32("C")?, Some(i));
                 select_scan.set_i32("C", i * 2)?;
             }
         }
@@ -151,9 +151,9 @@ mod tests {
         for i in 0..50 {
             table_scan.next()?;
             if i % 3 == 1 && i % 4 == 2 {
-                assert_eq!(table_scan.get_i32("C")?, i * 2);
+                assert_eq!(table_scan.get_i32("C")?, Some(i * 2));
             } else {
-                assert_eq!(table_scan.get_i32("C")?, i);
+                assert_eq!(table_scan.get_i32("C")?, Some(i));
             }
         }
         drop(table_scan);
@@ -190,7 +190,7 @@ mod tests {
         let expected: Vec<usize> = (0..10).rev().filter(|i| i % 3 == 1).collect();
         for _ in expected {
             assert!(scan.previous()?);
-            assert_eq!(scan.get_i32("A")?, 1);
+            assert_eq!(scan.get_i32("A")?, Some(1));
         }
         assert!(!scan.previous()?);
         drop(scan);


### PR DESCRIPTION
Fix https://github.com/flowlight0/simpledb-rs/issues/85

## Summary
- return `Option` from `ResultSet` getters
- adjust drivers and client CLI for Option return values
- update tests accordingly

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6852770b7d148329a8eb3d671d3f857d