### PR TITLE
Format generated code in build step

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,12 +1,26 @@
-use std::{env, path::PathBuf};
+use std::{env, path::PathBuf, process::Command};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let out_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap()).join("src/proto");
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR")?;
+    let out_dir = PathBuf::from(&manifest_dir).join("src/proto");
     tonic_build::configure()
-        .out_dir(out_dir)
+        .out_dir(&out_dir)
         .compile_protos(&["proto/simpledb.proto"], &["proto"])?;
 
     lalrpop::Configuration::new()
         .generate_in_source_tree()
-        .process()
+        .process()?;
+
+    // Format auto-generated sources.
+    Command::new("cargo")
+        .current_dir(&manifest_dir)
+        .args([
+            "fmt",
+            "--",
+            "src/proto/simpledb.rs",
+            "src/parser/grammar.rs",
+        ])
+        .status()?;
+
+    Ok(())
 }


### PR DESCRIPTION
## Summary
- run `cargo fmt` on auto-generated parser and proto files after build

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6852a47a4a5c832984dd522604d4e71c