### PR TITLE
Fix VARCHAR display width

### DIFF
--- a/src/driver/embedded.rs
+++ b/src/driver/embedded.rs
@@ -36,7 +36,10 @@ impl MetadataControl for EmbeddedMetadata {
         let name = self.get_column_name(index)?;
         let size = match self.get_column_type(index)? {
             Type::I32 => 12,
-            Type::String => name.len(),
+            Type::String => self
+                .schema
+                .get_string_field_max_length(&name)
+                .unwrap_or(name.len()),
         };
         Ok(max(size, name.len()))
     }

--- a/src/driver/embedded.rs
+++ b/src/driver/embedded.rs
@@ -9,7 +9,10 @@ use crate::{
     errors::ExecutionError,
     plan::{Plan, PlanControl},
     planner::Planner,
-    record::{field::Type, schema::Schema},
+    record::{
+        field::{Spec, Type},
+        schema::Schema,
+    },
     scan::{Scan, ScanControl},
     tx::transaction::Transaction,
 };
@@ -34,12 +37,9 @@ impl MetadataControl for EmbeddedMetadata {
 
     fn get_column_display_size(&self, index: usize) -> Result<usize, anyhow::Error> {
         let name = self.get_column_name(index)?;
-        let size = match self.get_column_type(index)? {
-            Type::I32 => 12,
-            Type::String => self
-                .schema
-                .get_string_field_max_length(&name)
-                .unwrap_or(name.len()),
+        let size = match self.schema.get_field_spec(&name) {
+            Spec::I32 => 12,
+            Spec::VarChar(max_length) => max_length,
         };
         Ok(max(size, name.len()))
     }

--- a/src/record/schema.rs
+++ b/src/record/schema.rs
@@ -95,10 +95,4 @@ impl Schema {
         fields.extend(self.string_fields.clone());
         fields
     }
-
-    pub fn get_string_field_max_length(&self, field_name: &str) -> Option<usize> {
-        self.string_field_to_index
-            .get(field_name)
-            .map(|idx| self.string_max_lengths[*idx])
-    }
 }

--- a/src/record/schema.rs
+++ b/src/record/schema.rs
@@ -95,4 +95,10 @@ impl Schema {
         fields.extend(self.string_fields.clone());
         fields
     }
+
+    pub fn get_string_field_max_length(&self, field_name: &str) -> Option<usize> {
+        self.string_field_to_index
+            .get(field_name)
+            .map(|idx| self.string_max_lengths[*idx])
+    }
 }


### PR DESCRIPTION
## Summary
- adjust display width for VARCHAR columns using schema info
- expose max length of VARCHAR fields in Schema

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6852a66875b08329a9b3f5caf349c60b