### PR TITLE
Add SHOW TABLES command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ The following issues correspond to finished exercises from the book:
 - [Exercise 3.15](https://github.com/flowlight0/simpledb-rs/issues/33): Add diagnostic routines to FileManager
 - [Exercise 6.10](https://github.com/flowlight0/simpledb-rs/issues/66): Add previous and after_last methods to TableScan and RecordPage
 - [Exercise 6.13](https://github.com/flowlight0/simpledb-rs/issues/74): Revise the record manager to handle null field values
+- [Exercise 7.7](https://github.com/flowlight0/simpledb-rs/issues/75): Implement 'SHOW TABLES' command in the client
 - [Exercise 8.11](https://github.com/flowlight0/simpledb-rs/issues/77): Handle null in the query processor
 - [Exercise 8.13](https://github.com/flowlight0/simpledb-rs/issues/69): Implement previous and after_last for more scans
-- [Exercise 9.15](https://github.com/flowlight0/simpledb-rs/issues/79): Introduce "*" character in the select clause
+- [Exercise 9.15](https://github.com/flowlight0/simpledb-rs/issues/79): Introduce "\*" character in the select clause
 - [Exercise 9.18](https://github.com/flowlight0/simpledb-rs/issues/83): More null handling in query processing
 - [Exercise 11.4](https://github.com/flowlight0/simpledb-rs/issues/63): Implement methods 'beforeFirst' and 'absolute(int n)' for ResultSet
 - [Exercise 11.5](https://github.com/flowlight0/simpledb-rs/issues/72): Modify ResultSet to support previous and after_last

--- a/src/client.rs
+++ b/src/client.rs
@@ -140,7 +140,10 @@ fn do_query<W: Write>(
     Ok(())
 }
 
-fn do_show_tables<W: Write>(statement: &mut Statement, writer: &mut W) -> Result<(), anyhow::Error> {
+fn do_show_tables<W: Write>(
+    statement: &mut Statement,
+    writer: &mut W,
+) -> Result<(), anyhow::Error> {
     // Get all table names from tblcat
     let mut result_set = statement.execute_query("select tblname from tblcat")?;
     let mut table_names = Vec::new();
@@ -153,7 +156,10 @@ fn do_show_tables<W: Write>(statement: &mut Statement, writer: &mut W) -> Result
 
     let mut rows = Vec::new();
     for table_name in table_names {
-        let query = format!("select fldname, type, length from fldcat where tblname = '{}'", table_name);
+        let query = format!(
+            "select fldname, type, length from fldcat where tblname = '{}'",
+            table_name
+        );
         let mut rs = statement.execute_query(&query)?;
         let mut parts = Vec::new();
         while rs.next()? {
@@ -215,8 +221,14 @@ fn do_show_tables<W: Write>(statement: &mut Statement, writer: &mut W) -> Result
         };
         let max_lines = std::cmp::max(name_cells.len(), schema_cells.len());
         for i in 0..max_lines {
-            let name_seg = name_cells.get(i).cloned().unwrap_or_else(|| " ".repeat(name_width));
-            let schema_seg = schema_cells.get(i).cloned().unwrap_or_else(|| " ".repeat(schema_width));
+            let name_seg = name_cells
+                .get(i)
+                .cloned()
+                .unwrap_or_else(|| " ".repeat(name_width));
+            let schema_seg = schema_cells
+                .get(i)
+                .cloned()
+                .unwrap_or_else(|| " ".repeat(schema_width));
             write!(writer, "{} {}", name_seg.green(), schema_seg.green())?;
             writeln!(writer)?;
         }
@@ -506,8 +518,12 @@ mod tests {
         expected.push_str(&format!("{}\n", "0 records processed".magenta()));
         expected.push_str(&format!(
             "{} {}\n",
-            format!("{:>width$}", name_header, width = name_width).bold().cyan(),
-            format!("{:>width$}", schema_header, width = schema_width).bold().cyan()
+            format!("{:>width$}", name_header, width = name_width)
+                .bold()
+                .cyan(),
+            format!("{:>width$}", schema_header, width = schema_width)
+                .bold()
+                .cyan()
         ));
         expected.push_str(&format!("{}\n", "-".repeat(total_width).bright_blue()));
         for (name, schema) in rows.drain(..) {


### PR DESCRIPTION
Fix #75 

## Summary
- implement `do_show_tables` in client
- detect `SHOW TABLES` command in client loop
- test showing tables from the interactive client

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6852e3f38ba0832985ff7c305753a14c