### PR TITLE
Refactor schema type codes

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -166,10 +166,10 @@ fn do_show_tables<W: Write>(
             let fname = rs.get_string("fldname")?.unwrap_or_default();
             let tcode = rs.get_i32("type")?.unwrap_or(0);
             let length = rs.get_i32("length")?.unwrap_or(0);
-            let type_str = match tcode {
-                0 => "I32".to_string(),
-                1 => format!("VARCHAR({})", length),
-                _ => format!("{}", tcode),
+            let type_str = match Type::from_code(tcode) {
+                Ok(Type::I32) => "I32".to_string(),
+                Ok(Type::String) => format!("VARCHAR({})", length),
+                Err(_) => format!("{}", tcode),
             };
             parts.push(format!("{} {}", fname, type_str));
         }

--- a/src/record/field.rs
+++ b/src/record/field.rs
@@ -1,5 +1,7 @@
 use std::cmp::Ordering;
 
+use anyhow::{anyhow, Error};
+
 #[derive(Debug, PartialEq, Eq)]
 pub enum Spec {
     I32,
@@ -9,6 +11,37 @@ pub enum Spec {
 pub enum Type {
     I32,
     String,
+}
+
+impl Type {
+    pub fn to_code(self) -> i32 {
+        match self {
+            Type::I32 => 0,
+            Type::String => 1,
+        }
+    }
+
+    pub fn from_code(code: i32) -> Result<Self, Error> {
+        match code {
+            0 => Ok(Type::I32),
+            1 => Ok(Type::String),
+            _ => Err(anyhow!("Unknown type code: {}", code)),
+        }
+    }
+}
+
+impl From<Type> for i32 {
+    fn from(t: Type) -> Self {
+        t.to_code()
+    }
+}
+
+impl TryFrom<i32> for Type {
+    type Error = Error;
+
+    fn try_from(value: i32) -> Result<Self, Self::Error> {
+        Type::from_code(value)
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/record/layout.rs
+++ b/src/record/layout.rs
@@ -46,15 +46,6 @@ impl Layout {
         }
     }
 
-    pub fn get_type_code(&self, field_name: &str) -> i32 {
-        // TODO: write cleaner code here.
-        if self.schema.i32_field_to_index.contains_key(field_name) {
-            0
-        } else {
-            1
-        }
-    }
-
     pub fn get_length(&self, field_name: &str) -> usize {
         // TODO: write cleaner code here.
         if self.schema.i32_field_to_index.contains_key(field_name) {


### PR DESCRIPTION
Fix https://github.com/flowlight0/simpledb-rs/issues/11

## Summary
- centralize type code conversions with methods on `Type`
- use the new helpers when reading/writing field definitions
- update network metadata service to send/receive standardized codes
- simplify the table info printed by the client
- drop `Layout::get_type_code` in favor of direct conversions

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_685373ef771c8329b548d182e1d7c8eb