### PR TITLE
Apply projection after sort in query planners

### DIFF
--- a/src/planner/basic_query_planner.rs
+++ b/src/planner/basic_query_planner.rs
@@ -68,14 +68,14 @@ impl QueryPlanner for BasicQueryPlanner {
         }
 
         // Step 5
-        if let Some(fields) = &query.fields {
-            plan = Plan::from(ProjectPlan::new(plan, fields.clone()));
-        }
-
-        // Step 6
         if let Some(order_fields) = &query.order_by {
             let comparator = Arc::new(RecordComparator::new(order_fields));
             plan = Plan::from(SortPlan::new(plan, tx.clone(), comparator));
+        }
+
+        // Step 6
+        if let Some(fields) = &query.fields {
+            plan = Plan::from(ProjectPlan::new(plan, fields.clone()));
         }
 
         Ok(plan)

--- a/src/planner/heuristic_query_planner.rs
+++ b/src/planner/heuristic_query_planner.rs
@@ -137,15 +137,15 @@ impl QueryPlanner for HeuristicQueryPlanner {
             current_plan = Plan::from(ExtendPlan::new(current_plan, expr.clone(), alias));
         }
 
-        // Step 5, Project on the field names
-        if let Some(fields) = &query.fields {
-            current_plan = Plan::from(ProjectPlan::new(current_plan, fields.clone()));
-        }
-
-        // Step 6, apply ordering if specified
+        // Step 5, apply ordering if specified
         if let Some(order_fields) = &query.order_by {
             let comparator = Arc::new(RecordComparator::new(order_fields));
             current_plan = Plan::from(SortPlan::new(current_plan, tx.clone(), comparator));
+        }
+
+        // Step 6, Project on the field names
+        if let Some(fields) = &query.fields {
+            current_plan = Plan::from(ProjectPlan::new(current_plan, fields.clone()));
         }
 
         Ok(current_plan)


### PR DESCRIPTION
## Summary
- sort records before projecting in the `BasicQueryPlanner`
- sort records before projecting in the `HeuristicQueryPlanner`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68566e5bc45c8329be8ed0e127075ae0