### PR TITLE
Implement GROUP BY clause support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The following issues correspond to finished exercises from the book:
 - [Exercise 11.6](https://github.com/flowlight0/simpledb-rs/issues/85): Implement wasNull method for ResultSet
 - [Exercise 13.15](https://github.com/flowlight0/simpledb-rs/issues/110): Support "ORDER BY" clause
 - [Exercise 13.16](https://github.com/flowlight0/simpledb-rs/issues/112): Implement more aggregation functions
+- [Exercise 13.7](https://github.com/flowlight0/simpledb-rs/issues/127): Support "GROUP BY" clause
 
 ## Interactive Client
 

--- a/src/materialization/aggregation_function.rs
+++ b/src/materialization/aggregation_function.rs
@@ -24,3 +24,25 @@ pub trait AggregationFnControl {
     fn get_field_name(&self) -> &str;
     fn get_value(&self) -> Option<Value>;
 }
+
+impl AggregationFn {
+    pub fn with_alias(self, alias: &str) -> Self {
+        match self {
+            AggregationFn::Max(f) => AggregationFn::Max(f.with_alias(alias)),
+            AggregationFn::Count(f) => AggregationFn::Count(f.with_alias(alias)),
+            AggregationFn::Min(f) => AggregationFn::Min(f.with_alias(alias)),
+            AggregationFn::Sum(f) => AggregationFn::Sum(f.with_alias(alias)),
+            AggregationFn::Avg(f) => AggregationFn::Avg(f.with_alias(alias)),
+        }
+    }
+
+    pub fn input_field_name(&self) -> &str {
+        match self {
+            AggregationFn::Max(f) => f.input_field_name(),
+            AggregationFn::Count(f) => f.input_field_name(),
+            AggregationFn::Min(f) => f.input_field_name(),
+            AggregationFn::Sum(f) => f.input_field_name(),
+            AggregationFn::Avg(f) => f.input_field_name(),
+        }
+    }
+}

--- a/src/materialization/aggregation_function.rs
+++ b/src/materialization/aggregation_function.rs
@@ -7,7 +7,7 @@ use super::{
     sum_function::SumFn,
 };
 
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[enum_dispatch]
 pub enum AggregationFn {
     Max(MaxFn),

--- a/src/materialization/aggregation_function.rs
+++ b/src/materialization/aggregation_function.rs
@@ -24,25 +24,3 @@ pub trait AggregationFnControl {
     fn get_field_name(&self) -> &str;
     fn get_value(&self) -> Option<Value>;
 }
-
-impl AggregationFn {
-    pub fn with_alias(self, alias: &str) -> Self {
-        match self {
-            AggregationFn::Max(f) => AggregationFn::Max(f.with_alias(alias)),
-            AggregationFn::Count(f) => AggregationFn::Count(f.with_alias(alias)),
-            AggregationFn::Min(f) => AggregationFn::Min(f.with_alias(alias)),
-            AggregationFn::Sum(f) => AggregationFn::Sum(f.with_alias(alias)),
-            AggregationFn::Avg(f) => AggregationFn::Avg(f.with_alias(alias)),
-        }
-    }
-
-    pub fn input_field_name(&self) -> &str {
-        match self {
-            AggregationFn::Max(f) => f.input_field_name(),
-            AggregationFn::Count(f) => f.input_field_name(),
-            AggregationFn::Min(f) => f.input_field_name(),
-            AggregationFn::Sum(f) => f.input_field_name(),
-            AggregationFn::Avg(f) => f.input_field_name(),
-        }
-    }
-}

--- a/src/materialization/avg_function.rs
+++ b/src/materialization/avg_function.rs
@@ -11,6 +11,7 @@ pub struct AvgFn {
     sum: i64,
     count: i32,
     field_name: String,
+    alias: Option<String>,
 }
 
 impl AvgFn {
@@ -19,7 +20,17 @@ impl AvgFn {
             sum: 0,
             count: 0,
             field_name: field_name.to_string(),
+            alias: None,
         }
+    }
+
+    pub fn with_alias(mut self, alias: &str) -> Self {
+        self.alias = Some(alias.to_string());
+        self
+    }
+
+    pub fn input_field_name(&self) -> &str {
+        &self.field_name
     }
 }
 
@@ -51,7 +62,7 @@ impl AggregationFnControl for AvgFn {
     }
 
     fn get_field_name(&self) -> &str {
-        &self.field_name
+        self.alias.as_deref().unwrap_or(&self.field_name)
     }
 
     fn get_value(&self) -> Option<Value> {

--- a/src/materialization/avg_function.rs
+++ b/src/materialization/avg_function.rs
@@ -6,7 +6,7 @@ use crate::{
 
 use super::aggregation_function::AggregationFnControl;
 
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AvgFn {
     sum: i64,
     count: i32,

--- a/src/materialization/avg_function.rs
+++ b/src/materialization/avg_function.rs
@@ -11,7 +11,6 @@ pub struct AvgFn {
     sum: i64,
     count: i32,
     field_name: String,
-    alias: Option<String>,
 }
 
 impl AvgFn {
@@ -20,17 +19,7 @@ impl AvgFn {
             sum: 0,
             count: 0,
             field_name: field_name.to_string(),
-            alias: None,
         }
-    }
-
-    pub fn with_alias(mut self, alias: &str) -> Self {
-        self.alias = Some(alias.to_string());
-        self
-    }
-
-    pub fn input_field_name(&self) -> &str {
-        &self.field_name
     }
 }
 
@@ -62,7 +51,7 @@ impl AggregationFnControl for AvgFn {
     }
 
     fn get_field_name(&self) -> &str {
-        self.alias.as_deref().unwrap_or(&self.field_name)
+        &self.field_name
     }
 
     fn get_value(&self) -> Option<Value> {

--- a/src/materialization/count_function.rs
+++ b/src/materialization/count_function.rs
@@ -10,6 +10,7 @@ use super::aggregation_function::AggregationFnControl;
 pub struct CountFn {
     count: i32,
     field_name: String,
+    alias: Option<String>,
 }
 
 impl CountFn {
@@ -17,7 +18,17 @@ impl CountFn {
         Self {
             count: 0,
             field_name: field_name.to_string(),
+            alias: None,
         }
+    }
+
+    pub fn with_alias(mut self, alias: &str) -> Self {
+        self.alias = Some(alias.to_string());
+        self
+    }
+
+    pub fn input_field_name(&self) -> &str {
+        &self.field_name
     }
 }
 
@@ -40,7 +51,7 @@ impl AggregationFnControl for CountFn {
     }
 
     fn get_field_name(&self) -> &str {
-        &self.field_name
+        self.alias.as_deref().unwrap_or(&self.field_name)
     }
 
     fn get_value(&self) -> Option<Value> {

--- a/src/materialization/count_function.rs
+++ b/src/materialization/count_function.rs
@@ -10,7 +10,6 @@ use super::aggregation_function::AggregationFnControl;
 pub struct CountFn {
     count: i32,
     field_name: String,
-    alias: Option<String>,
 }
 
 impl CountFn {
@@ -18,17 +17,7 @@ impl CountFn {
         Self {
             count: 0,
             field_name: field_name.to_string(),
-            alias: None,
         }
-    }
-
-    pub fn with_alias(mut self, alias: &str) -> Self {
-        self.alias = Some(alias.to_string());
-        self
-    }
-
-    pub fn input_field_name(&self) -> &str {
-        &self.field_name
     }
 }
 
@@ -51,7 +40,7 @@ impl AggregationFnControl for CountFn {
     }
 
     fn get_field_name(&self) -> &str {
-        self.alias.as_deref().unwrap_or(&self.field_name)
+        &self.field_name
     }
 
     fn get_value(&self) -> Option<Value> {

--- a/src/materialization/count_function.rs
+++ b/src/materialization/count_function.rs
@@ -6,7 +6,7 @@ use crate::{
 
 use super::aggregation_function::AggregationFnControl;
 
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CountFn {
     count: i32,
     field_name: String,

--- a/src/materialization/group_by_plan.rs
+++ b/src/materialization/group_by_plan.rs
@@ -36,7 +36,8 @@ impl GroupByPlan {
         }
         for aggregation_fn in &aggregation_functions {
             let field_name = aggregation_fn.get_field_name();
-            schema.add_field(&field_name, &plan.schema().get_field_spec(field_name));
+            let input_name = aggregation_fn.input_field_name();
+            schema.add_field(&field_name, &plan.schema().get_field_spec(input_name));
         }
 
         let comparator = Arc::new(RecordComparator::new(&group_fields));

--- a/src/materialization/group_by_plan.rs
+++ b/src/materialization/group_by_plan.rs
@@ -36,8 +36,7 @@ impl GroupByPlan {
         }
         for aggregation_fn in &aggregation_functions {
             let field_name = aggregation_fn.get_field_name();
-            let input_name = aggregation_fn.input_field_name();
-            schema.add_field(&field_name, &plan.schema().get_field_spec(input_name));
+            schema.add_field(&field_name, &plan.schema().get_field_spec(field_name));
         }
 
         let comparator = Arc::new(RecordComparator::new(&group_fields));

--- a/src/materialization/max_function.rs
+++ b/src/materialization/max_function.rs
@@ -6,7 +6,7 @@ use crate::{
 
 use super::aggregation_function::AggregationFnControl;
 
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct MaxFn {
     max_value: Option<Value>,
     field_name: String,

--- a/src/materialization/max_function.rs
+++ b/src/materialization/max_function.rs
@@ -10,6 +10,7 @@ use super::aggregation_function::AggregationFnControl;
 pub struct MaxFn {
     max_value: Option<Value>,
     field_name: String,
+    alias: Option<String>,
 }
 
 impl MaxFn {
@@ -17,7 +18,17 @@ impl MaxFn {
         MaxFn {
             max_value: None,
             field_name: field_name.to_string(),
+            alias: None,
         }
+    }
+
+    pub fn with_alias(mut self, alias: &str) -> Self {
+        self.alias = Some(alias.to_string());
+        self
+    }
+
+    pub fn input_field_name(&self) -> &str {
+        &self.field_name
     }
 }
 
@@ -48,7 +59,7 @@ impl AggregationFnControl for MaxFn {
     }
 
     fn get_field_name(&self) -> &str {
-        &self.field_name
+        self.alias.as_deref().unwrap_or(&self.field_name)
     }
 
     fn get_value(&self) -> Option<Value> {

--- a/src/materialization/max_function.rs
+++ b/src/materialization/max_function.rs
@@ -10,7 +10,6 @@ use super::aggregation_function::AggregationFnControl;
 pub struct MaxFn {
     max_value: Option<Value>,
     field_name: String,
-    alias: Option<String>,
 }
 
 impl MaxFn {
@@ -18,17 +17,7 @@ impl MaxFn {
         MaxFn {
             max_value: None,
             field_name: field_name.to_string(),
-            alias: None,
         }
-    }
-
-    pub fn with_alias(mut self, alias: &str) -> Self {
-        self.alias = Some(alias.to_string());
-        self
-    }
-
-    pub fn input_field_name(&self) -> &str {
-        &self.field_name
     }
 }
 
@@ -59,7 +48,7 @@ impl AggregationFnControl for MaxFn {
     }
 
     fn get_field_name(&self) -> &str {
-        self.alias.as_deref().unwrap_or(&self.field_name)
+        &self.field_name
     }
 
     fn get_value(&self) -> Option<Value> {

--- a/src/materialization/min_function.rs
+++ b/src/materialization/min_function.rs
@@ -6,7 +6,7 @@ use crate::{
 
 use super::aggregation_function::AggregationFnControl;
 
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct MinFn {
     min_value: Option<Value>,
     field_name: String,

--- a/src/materialization/min_function.rs
+++ b/src/materialization/min_function.rs
@@ -10,6 +10,7 @@ use super::aggregation_function::AggregationFnControl;
 pub struct MinFn {
     min_value: Option<Value>,
     field_name: String,
+    alias: Option<String>,
 }
 
 impl MinFn {
@@ -17,7 +18,17 @@ impl MinFn {
         Self {
             min_value: None,
             field_name: field_name.to_string(),
+            alias: None,
         }
+    }
+
+    pub fn with_alias(mut self, alias: &str) -> Self {
+        self.alias = Some(alias.to_string());
+        self
+    }
+
+    pub fn input_field_name(&self) -> &str {
+        &self.field_name
     }
 }
 
@@ -48,7 +59,7 @@ impl AggregationFnControl for MinFn {
     }
 
     fn get_field_name(&self) -> &str {
-        &self.field_name
+        self.alias.as_deref().unwrap_or(&self.field_name)
     }
 
     fn get_value(&self) -> Option<Value> {

--- a/src/materialization/min_function.rs
+++ b/src/materialization/min_function.rs
@@ -10,7 +10,6 @@ use super::aggregation_function::AggregationFnControl;
 pub struct MinFn {
     min_value: Option<Value>,
     field_name: String,
-    alias: Option<String>,
 }
 
 impl MinFn {
@@ -18,17 +17,7 @@ impl MinFn {
         Self {
             min_value: None,
             field_name: field_name.to_string(),
-            alias: None,
         }
-    }
-
-    pub fn with_alias(mut self, alias: &str) -> Self {
-        self.alias = Some(alias.to_string());
-        self
-    }
-
-    pub fn input_field_name(&self) -> &str {
-        &self.field_name
     }
 }
 
@@ -59,7 +48,7 @@ impl AggregationFnControl for MinFn {
     }
 
     fn get_field_name(&self) -> &str {
-        self.alias.as_deref().unwrap_or(&self.field_name)
+        &self.field_name
     }
 
     fn get_value(&self) -> Option<Value> {

--- a/src/materialization/sum_function.rs
+++ b/src/materialization/sum_function.rs
@@ -11,6 +11,7 @@ pub struct SumFn {
     sum: i64,
     field_name: String,
     has_value: bool,
+    alias: Option<String>,
 }
 
 impl SumFn {
@@ -19,7 +20,17 @@ impl SumFn {
             sum: 0,
             field_name: field_name.to_string(),
             has_value: false,
+            alias: None,
         }
+    }
+
+    pub fn with_alias(mut self, alias: &str) -> Self {
+        self.alias = Some(alias.to_string());
+        self
+    }
+
+    pub fn input_field_name(&self) -> &str {
+        &self.field_name
     }
 }
 
@@ -51,7 +62,7 @@ impl AggregationFnControl for SumFn {
     }
 
     fn get_field_name(&self) -> &str {
-        &self.field_name
+        self.alias.as_deref().unwrap_or(&self.field_name)
     }
 
     fn get_value(&self) -> Option<Value> {

--- a/src/materialization/sum_function.rs
+++ b/src/materialization/sum_function.rs
@@ -11,7 +11,6 @@ pub struct SumFn {
     sum: i64,
     field_name: String,
     has_value: bool,
-    alias: Option<String>,
 }
 
 impl SumFn {
@@ -20,17 +19,7 @@ impl SumFn {
             sum: 0,
             field_name: field_name.to_string(),
             has_value: false,
-            alias: None,
         }
-    }
-
-    pub fn with_alias(mut self, alias: &str) -> Self {
-        self.alias = Some(alias.to_string());
-        self
-    }
-
-    pub fn input_field_name(&self) -> &str {
-        &self.field_name
     }
 }
 
@@ -62,7 +51,7 @@ impl AggregationFnControl for SumFn {
     }
 
     fn get_field_name(&self) -> &str {
-        self.alias.as_deref().unwrap_or(&self.field_name)
+        &self.field_name
     }
 
     fn get_value(&self) -> Option<Value> {

--- a/src/materialization/sum_function.rs
+++ b/src/materialization/sum_function.rs
@@ -6,7 +6,7 @@ use crate::{
 
 use super::aggregation_function::AggregationFnControl;
 
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SumFn {
     sum: i64,
     field_name: String,

--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -113,6 +113,7 @@ FieldList: Option<Vec<statement::SelectField>> = {
 SelectField: statement::SelectField = {
     <e:Expression> AS <alias:IdToken> => statement::SelectField::Expression(e, Some(alias)),
     <e:Expression> => statement::SelectField::Expression(e, None),
+    <a:AggregationFn> AS <alias:IdToken> => statement::SelectField::Aggregation(a.with_alias(&alias)),
     <a:AggregationFn> => statement::SelectField::Aggregation(a),
 };
 

--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -3,6 +3,15 @@ use super::statement;
 use super::predicate;
 use super::expression;
 use crate::record::field::{Spec, Value};
+use crate::materialization::{
+    aggregation_function::AggregationFn,
+    aggregation_function::AggregationFnControl,
+    avg_function::AvgFn,
+    count_function::CountFn,
+    max_function::MaxFn,
+    min_function::MinFn,
+    sum_function::SumFn,
+};
 
 grammar;
 
@@ -20,6 +29,12 @@ match {
     r"(?i)TABLE" => TABLE,
     r"(?i)VIEW" => VIEW,
     r"(?i)INDEX" => INDEX,
+    r"(?i)GROUP" => GROUP,
+    r"(?i)MAX" => MAX,
+    r"(?i)MIN" => MIN,
+    r"(?i)SUM" => SUM,
+    r"(?i)COUNT" => COUNT,
+    r"(?i)AVG" => AVG,
     r"(?i)ORDER" => ORDER,
     r"(?i)BY" => BY,
     r"(?i)ON" => ON,
@@ -53,44 +68,69 @@ pub Statement: statement::Statement = {
 }
 
 pub Query: statement::QueryData = {
-    SELECT <fs:FieldList> FROM <ts:Comma<IdToken>> <p:OptPredicate> <o:OptOrderBy> => match fs {
+    SELECT <fs:FieldList> FROM <ts:Comma<IdToken>> <p:OptPredicate> <g:OptGroupBy> <o:OptOrderBy> => match fs {
         Some(fields) => {
-            let output_fields = fields
-                .iter()
-                .map(|(expr, alias)| match (expr, alias) {
-                    (_, Some(a)) => a.clone(),
-                    (expression::Expression::Field(f), None) => f.clone(),
-                    _ => panic!("expression without alias"),
-                })
-                .collect();
-            let extend_fields = fields
-                .into_iter()
-                .filter_map(|(expr, alias)| alias.map(|a| (expr, a)))
-                .collect();
-            statement::QueryData::new_with_order_and_extend(
-                output_fields,
+            let mut output_fields = Vec::new();
+            let mut extend_fields = Vec::new();
+            let mut aggregation_functions = Vec::new();
+            for field in fields.into_iter() {
+                match field {
+                    statement::SelectField::Expression(expr, alias) => match alias {
+                        Some(a) => {
+                            output_fields.push(a.clone());
+                            extend_fields.push((expr, a));
+                        }
+                        None => match expr.try_get_field() {
+                            Some(f) => output_fields.push(f.to_string()),
+                            None => panic!("expression without alias"),
+                        },
+                    },
+                    statement::SelectField::Aggregation(af) => {
+                        output_fields.push(af.get_field_name().to_string());
+                        aggregation_functions.push(af);
+                    }
+                }
+            }
+            statement::QueryData::new_full(
+                Some(output_fields),
                 ts,
                 p,
+                g,
                 o,
                 extend_fields,
+                aggregation_functions,
             )
         }
-        None => statement::QueryData::new_all_with_order(ts, p, o),
+        None => statement::QueryData::new_full(None, ts, p, g, o, Vec::new(), Vec::new()),
     },
 }
 
-FieldList: Option<Vec<(expression::Expression, Option<String>)>> = {
+FieldList: Option<Vec<statement::SelectField>> = {
     STAR => None,
     <fs:Comma<SelectField>> => Some(fs),
 };
 
-SelectField: (expression::Expression, Option<String>) = {
-    <e:Expression> AS <alias:IdToken> => (e, Some(alias)),
-    <f:IdToken> => (expression::Expression::Field(f.clone()), None),
+SelectField: statement::SelectField = {
+    <e:Expression> AS <alias:IdToken> => statement::SelectField::Expression(e, Some(alias)),
+    <e:Expression> => statement::SelectField::Expression(e, None),
+    <a:AggregationFn> => statement::SelectField::Aggregation(a),
+};
+
+AggregationFn: AggregationFn = {
+    MAX LPAREN <f:IdToken> RPAREN => AggregationFn::from(MaxFn::new(&f)),
+    MIN LPAREN <f:IdToken> RPAREN => AggregationFn::from(MinFn::new(&f)),
+    SUM LPAREN <f:IdToken> RPAREN => AggregationFn::from(SumFn::new(&f)),
+    COUNT LPAREN <f:IdToken> RPAREN => AggregationFn::from(CountFn::new(&f)),
+    AVG LPAREN <f:IdToken> RPAREN => AggregationFn::from(AvgFn::new(&f)),
 };
 
 OptPredicate: Option<predicate::Predicate> = {
     WHERE <p:Predicate> => Some(p),
+    => None,
+};
+
+OptGroupBy: Option<Vec<String>> = {
+    GROUP BY <os:Comma<IdToken>> => Some(os),
     => None,
 };
 

--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -85,8 +85,15 @@ pub Query: statement::QueryData = {
                             None => panic!("expression without alias"),
                         },
                     },
-                    statement::SelectField::Aggregation(af) => {
-                        output_fields.push(af.get_field_name().to_string());
+                    statement::SelectField::Aggregation(af, alias) => {
+                        let field_name = af.get_field_name().to_string();
+                        match alias {
+                            Some(a) => {
+                                output_fields.push(a.clone());
+                                extend_fields.push((expression::Expression::Field(field_name), a));
+                            }
+                            None => output_fields.push(field_name),
+                        }
                         aggregation_functions.push(af);
                     }
                 }
@@ -113,8 +120,8 @@ FieldList: Option<Vec<statement::SelectField>> = {
 SelectField: statement::SelectField = {
     <e:Expression> AS <alias:IdToken> => statement::SelectField::Expression(e, Some(alias)),
     <e:Expression> => statement::SelectField::Expression(e, None),
-    <a:AggregationFn> AS <alias:IdToken> => statement::SelectField::Aggregation(a.with_alias(&alias)),
-    <a:AggregationFn> => statement::SelectField::Aggregation(a),
+    <a:AggregationFn> AS <alias:IdToken> => statement::SelectField::Aggregation(a, Some(alias)),
+    <a:AggregationFn> => statement::SelectField::Aggregation(a, None),
 };
 
 AggregationFn: AggregationFn = {

--- a/src/parser/grammar.rs
+++ b/src/parser/grammar.rs
@@ -1,8 +1,13 @@
 // auto-generated: "lalrpop 0.22.0"
-// sha3: 42cb9b044c6c2cf6e531c50e8ac57eba540a091e9a9e502952ac40803802b9d0
+// sha3: 0da152653bc476df143bab3d1a852ee1c16078df0606b2c318c99488ed8c7a5b
 use super::expression;
 use super::predicate;
 use super::statement;
+use crate::materialization::{
+    aggregation_function::AggregationFn, aggregation_function::AggregationFnControl,
+    avg_function::AvgFn, count_function::CountFn, max_function::MaxFn, min_function::MinFn,
+    sum_function::SumFn,
+};
 use crate::record::field::{Spec, Value};
 use std::str::FromStr;
 #[allow(unused_extern_crates)]
@@ -21,6 +26,15 @@ mod __parse__Predicate {
     use super::super::predicate;
     use super::super::expression;
     use crate::record::field::{Spec, Value};
+    use crate::materialization::{
+    aggregation_function::AggregationFn,
+    aggregation_function::AggregationFnControl,
+    avg_function::AvgFn,
+    count_function::CountFn,
+    max_function::MaxFn,
+    min_function::MinFn,
+    sum_function::SumFn,
+};
     #[allow(unused_extern_crates)]
     extern crate lalrpop_util as __lalrpop_util;
     #[allow(unused_imports)]
@@ -38,99 +52,100 @@ mod __parse__Predicate {
         Variant4(alloc::vec::Vec<statement::FieldDefinition>),
         Variant5(String),
         Variant6(alloc::vec::Vec<String>),
-        Variant7((expression::Expression, Option<String>)),
-        Variant8(alloc::vec::Vec<(expression::Expression, Option<String>)>),
+        Variant7(statement::SelectField),
+        Variant8(alloc::vec::Vec<statement::SelectField>),
         Variant9(predicate::Term),
         Variant10(alloc::vec::Vec<predicate::Term>),
         Variant11(expression::Expression),
-        Variant12(Vec<predicate::Term>),
-        Variant13(Vec<Value>),
-        Variant14(Vec<statement::FieldDefinition>),
-        Variant15(Vec<String>),
-        Variant16(Vec<(expression::Expression, Option<String>)>),
-        Variant17(statement::CreateCommand),
-        Variant18(Option<Vec<(expression::Expression, Option<String>)>>),
-        Variant19(Spec),
-        Variant20(i32),
-        Variant21(Option<Vec<String>>),
-        Variant22(Option<predicate::Predicate>),
-        Variant23(predicate::Predicate),
-        Variant24(statement::QueryData),
-        Variant25(statement::Statement),
-        Variant26(statement::UpdateCommand),
+        Variant12(AggregationFn),
+        Variant13(Vec<predicate::Term>),
+        Variant14(Vec<Value>),
+        Variant15(Vec<statement::FieldDefinition>),
+        Variant16(Vec<String>),
+        Variant17(Vec<statement::SelectField>),
+        Variant18(statement::CreateCommand),
+        Variant19(Option<Vec<statement::SelectField>>),
+        Variant20(Spec),
+        Variant21(i32),
+        Variant22(Option<Vec<String>>),
+        Variant23(Option<predicate::Predicate>),
+        Variant24(predicate::Predicate),
+        Variant25(statement::QueryData),
+        Variant26(statement::Statement),
+        Variant27(statement::UpdateCommand),
     }
     const __ACTION: &[i8] = &[
         // State 0
-        0, 20, 22, 19, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 21, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 20, 22, 19, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 21, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 1
-        0, 20, 22, 19, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 21, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 20, 22, 19, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 21, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 2
-        0, 20, 22, 19, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 21, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 20, 22, 19, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 21, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 3
-        0, 20, 22, 19, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 21, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 20, 22, 19, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 21, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 4
-        0, 20, 22, 19, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 21, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 20, 22, 19, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 21, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 5
-        0, 20, 22, 19, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 21, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 20, 22, 19, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 21, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 6
-        0, 20, 22, 19, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 21, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 20, 22, 19, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 21, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 7
-        0, 20, 22, 19, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 21, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 20, 22, 19, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 21, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 8
-        0, 0, 0, 0, 4, 0, -45, 0, 5, 0, 0, -45, -45, 0, 0, 0, 0, 0, 0, 0, 0, 0, -45, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 4, 0, -50, 0, 5, 0, 0, -50, -50, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -50, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 9
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 10
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 11
-        0, 0, 0, 0, -60, 0, -60, -60, -60, 0, -60, -60, -60, 0, 0, 0, 0, 0, 0, 0, 0, 0, -60, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -65, 0, -65, -65, -65, 0, -65, -65, -65, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -65, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 12
-        0, 0, 0, 0, -48, 0, -48, -48, -48, 0, -48, -48, -48, 0, 0, 0, 0, 0, 0, 0, 0, 0, -48, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -53, 0, -53, -53, -53, 0, -53, -53, -53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 13
-        0, 0, 0, 0, -50, 0, -50, -50, -50, 0, -50, -50, -50, 0, 0, 0, 0, 0, 0, 0, 0, 0, -50, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -55, 0, -55, -55, -55, 0, -55, -55, -55, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -55, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 14
-        0, 0, 0, 0, -28, 0, -28, 8, -28, 0, 7, -28, -28, 0, 0, 0, 0, 0, 0, 0, 0, 0, -28, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -28, 0, -28, 8, -28, 0, 7, -28, -28, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -28, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 15
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 16
-        0, 0, 0, 0, -49, 0, -49, -49, -49, 0, -49, -49, -49, 0, 0, 0, 0, 0, 0, 0, 0, 0, -49, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -54, 0, -54, -54, -54, 0, -54, -54, -54, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -54, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 17
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 18
-        0, 0, 0, 0, -56, 0, -56, -56, -56, 0, -56, -56, -56, 0, 0, 0, 0, 0, 0, 0, 0, 0, -56, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -61, 0, -61, -61, -61, 0, -61, -61, -61, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -61, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 19
-        0, 0, 0, 0, -57, 0, -57, -57, -57, 0, -57, -57, -57, 0, 0, 0, 0, 0, 0, 0, 0, 0, -57, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -62, 0, -62, -62, -62, 0, -62, -62, -62, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -62, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 20
-        0, 0, 0, 0, -47, 0, -47, -47, -47, 0, -47, -47, -47, 0, 0, 0, 0, 0, 0, 0, 0, 0, -47, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -52, 0, -52, -52, -52, 0, -52, -52, -52, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -52, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 21
-        0, 0, 0, 0, -71, 0, -71, -71, -71, 0, -71, -71, -71, 0, 0, 0, 0, 0, 0, 0, 0, 0, -71, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -79, 0, -79, -79, -79, 0, -79, -79, -79, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -79, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 22
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 27, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 27, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 23
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 31, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 31, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 24
-        0, -24, -24, -24, 0, -24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -24, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, -24, -24, -24, 0, -24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 25
-        0, 0, 0, 0, 0, 0, 34, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 34, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 26
-        0, -25, -25, -25, 0, -25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -25, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, -25, -25, -25, 0, -25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 27
-        0, 0, 0, 0, -27, 0, -27, 8, -27, 0, 7, -27, -27, 0, 0, 0, 0, 0, 0, 0, 0, 0, -27, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -27, 0, -27, 8, -27, 0, 7, -27, -27, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -27, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 28
-        0, 0, 0, 0, -26, 0, -26, 8, -26, 0, 7, -26, -26, 0, 0, 0, 0, 0, 0, 0, 0, 0, -26, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -26, 0, -26, 8, -26, 0, 7, -26, -26, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -26, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 29
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -73, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -81, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 30
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -72, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 31
-        0, 0, 0, 0, -59, 0, -59, -59, -59, 0, -59, -59, -59, 0, 0, 0, 0, 0, 0, 0, 0, 0, -59, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -64, 0, -64, -64, -64, 0, -64, -64, -64, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -64, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 32
-        0, 0, 0, 0, -58, 0, -58, -58, -58, 0, -58, -58, -58, 0, 0, 0, 0, 0, 0, 0, 0, 0, -58, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -63, 0, -63, -63, -63, 0, -63, -63, -63, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -63, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 33
-        0, 0, 0, 0, -46, 0, -46, -46, -46, 0, -46, -46, -46, 0, 0, 0, 0, 0, 0, 0, 0, 0, -46, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -51, 0, -51, -51, -51, 0, -51, -51, -51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     ];
     fn __action(state: i8, integer: usize) -> i8 {
-        __ACTION[(state as usize) * 34 + integer]
+        __ACTION[(state as usize) * 40 + integer]
     }
     const __EOF_ACTION: &[i8] = &[
         // State 0
@@ -150,35 +165,35 @@ mod __parse__Predicate {
         // State 7
         0,
         // State 8
-        -45,
+        -50,
         // State 9
-        -65,
+        -72,
         // State 10
         0,
         // State 11
-        -60,
+        -65,
         // State 12
-        -48,
+        -53,
         // State 13
-        -50,
+        -55,
         // State 14
         -28,
         // State 15
-        -80,
+        -88,
         // State 16
-        -49,
+        -54,
         // State 17
-        -29,
+        -34,
         // State 18
-        -56,
+        -61,
         // State 19
-        -57,
+        -62,
         // State 20
-        -47,
+        -52,
         // State 21
-        -71,
+        -79,
         // State 22
-        -30,
+        -35,
         // State 23
         0,
         // State 24
@@ -192,41 +207,41 @@ mod __parse__Predicate {
         // State 28
         -26,
         // State 29
-        -73,
+        -81,
         // State 30
-        -72,
+        -80,
         // State 31
-        -59,
+        -64,
         // State 32
-        -58,
+        -63,
         // State 33
-        -46,
+        -51,
     ];
     fn __goto(state: i8, nt: usize) -> i8 {
         match nt {
             14 => 1,
             15 => 8,
-            16 => 9,
-            23 => match state {
+            17 => 9,
+            24 => match state {
                 2 => 25,
                 5 => 29,
                 _ => 10,
             },
-            24 => match state {
+            25 => match state {
                 6 => 31,
                 7 => 32,
                 _ => 11,
             },
-            28 => 12,
-            29 => 13,
-            30 => match state {
+            29 => 12,
+            30 => 13,
+            31 => match state {
                 3 => 27,
                 4 => 28,
                 _ => 14,
             },
-            33 => 15,
-            37 => 16,
-            38 => match state {
+            35 => 15,
+            39 => 16,
+            40 => match state {
                 1 => 22,
                 _ => 17,
             },
@@ -248,21 +263,27 @@ mod __parse__Predicate {
         r###"EQ"###,
         r###"AND"###,
         r###"AS"###,
+        r###"AVG"###,
         r###"BY"###,
+        r###"COUNT"###,
         r###"CREATE"###,
         r###"DELETE"###,
         r###"FROM"###,
+        r###"GROUP"###,
         r###"I32"###,
         r###"INDEX"###,
         r###"INSERT"###,
         r###"INTO"###,
         r###"IS"###,
+        r###"MAX"###,
+        r###"MIN"###,
         r###"MODIFY"###,
         r###"NULL"###,
         r###"ON"###,
         r###"ORDER"###,
         r###"SELECT"###,
         r###"SET"###,
+        r###"SUM"###,
         r###"TABLE"###,
         r###"VALUES"###,
         r###"VARCHAR"###,
@@ -336,7 +357,7 @@ mod __parse__Predicate {
 
         #[inline]
         fn error_action(&self, state: i8) -> i8 {
-            __action(state, 34 - 1)
+            __action(state, 40 - 1)
         }
 
         #[inline]
@@ -438,6 +459,12 @@ mod __parse__Predicate {
             Token(31, _) if true => Some(31),
             Token(32, _) if true => Some(32),
             Token(33, _) if true => Some(33),
+            Token(34, _) if true => Some(34),
+            Token(35, _) if true => Some(35),
+            Token(36, _) if true => Some(36),
+            Token(37, _) if true => Some(37),
+            Token(38, _) if true => Some(38),
+            Token(39, _) if true => Some(39),
             _ => None,
         }
     }
@@ -450,8 +477,8 @@ mod __parse__Predicate {
     ) -> __Symbol<'input>
     {
         #[allow(clippy::manual_range_patterns)]match __token_index {
-            0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20 | 21 | 22 | 23 | 24 | 25 | 26 | 27 | 28 | 29 | 30 | 31 | 32 | 33 => match __token {
-                Token(0, __tok0) | Token(1, __tok0) | Token(2, __tok0) | Token(3, __tok0) | Token(4, __tok0) | Token(5, __tok0) | Token(6, __tok0) | Token(7, __tok0) | Token(8, __tok0) | Token(9, __tok0) | Token(10, __tok0) | Token(11, __tok0) | Token(12, __tok0) | Token(13, __tok0) | Token(14, __tok0) | Token(15, __tok0) | Token(16, __tok0) | Token(17, __tok0) | Token(18, __tok0) | Token(19, __tok0) | Token(20, __tok0) | Token(21, __tok0) | Token(22, __tok0) | Token(23, __tok0) | Token(24, __tok0) | Token(25, __tok0) | Token(26, __tok0) | Token(27, __tok0) | Token(28, __tok0) | Token(29, __tok0) | Token(30, __tok0) | Token(31, __tok0) | Token(32, __tok0) | Token(33, __tok0) if true => __Symbol::Variant0(__tok0),
+            0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20 | 21 | 22 | 23 | 24 | 25 | 26 | 27 | 28 | 29 | 30 | 31 | 32 | 33 | 34 | 35 | 36 | 37 | 38 | 39 => match __token {
+                Token(0, __tok0) | Token(1, __tok0) | Token(2, __tok0) | Token(3, __tok0) | Token(4, __tok0) | Token(5, __tok0) | Token(6, __tok0) | Token(7, __tok0) | Token(8, __tok0) | Token(9, __tok0) | Token(10, __tok0) | Token(11, __tok0) | Token(12, __tok0) | Token(13, __tok0) | Token(14, __tok0) | Token(15, __tok0) | Token(16, __tok0) | Token(17, __tok0) | Token(18, __tok0) | Token(19, __tok0) | Token(20, __tok0) | Token(21, __tok0) | Token(22, __tok0) | Token(23, __tok0) | Token(24, __tok0) | Token(25, __tok0) | Token(26, __tok0) | Token(27, __tok0) | Token(28, __tok0) | Token(29, __tok0) | Token(30, __tok0) | Token(31, __tok0) | Token(32, __tok0) | Token(33, __tok0) | Token(34, __tok0) | Token(35, __tok0) | Token(36, __tok0) | Token(37, __tok0) | Token(38, __tok0) | Token(39, __tok0) if true => __Symbol::Variant0(__tok0),
                 _ => unreachable!(),
             },
             _ => unreachable!(),
@@ -635,128 +662,128 @@ mod __parse__Predicate {
             }
             28 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
+                    states_to_pop: 4,
                     nonterminal_produced: 16,
                 }
             }
             29 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 2,
+                    states_to_pop: 4,
                     nonterminal_produced: 16,
                 }
             }
             30 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 17,
+                    states_to_pop: 4,
+                    nonterminal_produced: 16,
                 }
             }
             31 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 2,
-                    nonterminal_produced: 17,
+                    states_to_pop: 4,
+                    nonterminal_produced: 16,
                 }
             }
             32 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 18,
+                    states_to_pop: 4,
+                    nonterminal_produced: 16,
                 }
             }
             33 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 2,
-                    nonterminal_produced: 18,
+                    states_to_pop: 1,
+                    nonterminal_produced: 17,
                 }
             }
             34 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 19,
+                    states_to_pop: 2,
+                    nonterminal_produced: 17,
                 }
             }
             35 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 2,
-                    nonterminal_produced: 19,
+                    states_to_pop: 1,
+                    nonterminal_produced: 18,
                 }
             }
             36 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 20,
+                    states_to_pop: 2,
+                    nonterminal_produced: 18,
                 }
             }
             37 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 2,
-                    nonterminal_produced: 20,
+                    states_to_pop: 1,
+                    nonterminal_produced: 19,
                 }
             }
             38 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 21,
+                    states_to_pop: 2,
+                    nonterminal_produced: 19,
                 }
             }
             39 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
-                    nonterminal_produced: 21,
+                    nonterminal_produced: 20,
                 }
             }
             40 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 2,
+                    nonterminal_produced: 20,
+                }
+            }
+            41 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
                     nonterminal_produced: 21,
                 }
             }
-            41 => {
-                __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 6,
-                    nonterminal_produced: 22,
-                }
-            }
             42 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 5,
-                    nonterminal_produced: 22,
+                    states_to_pop: 2,
+                    nonterminal_produced: 21,
                 }
             }
             43 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 8,
+                    states_to_pop: 1,
                     nonterminal_produced: 22,
                 }
             }
             44 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
-                    nonterminal_produced: 23,
+                    nonterminal_produced: 22,
                 }
             }
             45 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 3,
-                    nonterminal_produced: 24,
+                    states_to_pop: 1,
+                    nonterminal_produced: 22,
                 }
             }
             46 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 24,
+                    states_to_pop: 6,
+                    nonterminal_produced: 23,
                 }
             }
             47 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 24,
+                    states_to_pop: 5,
+                    nonterminal_produced: 23,
                 }
             }
             48 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 24,
+                    states_to_pop: 8,
+                    nonterminal_produced: 23,
                 }
             }
             49 => {
@@ -767,170 +794,170 @@ mod __parse__Predicate {
             }
             50 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 2,
+                    states_to_pop: 3,
                     nonterminal_produced: 25,
                 }
             }
             51 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
-                    nonterminal_produced: 26,
+                    nonterminal_produced: 25,
                 }
             }
             52 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
-                    nonterminal_produced: 26,
+                    nonterminal_produced: 25,
                 }
             }
             53 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
-                    nonterminal_produced: 27,
+                    nonterminal_produced: 25,
                 }
             }
             54 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 4,
-                    nonterminal_produced: 27,
+                    states_to_pop: 1,
+                    nonterminal_produced: 25,
                 }
             }
             55 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 28,
+                    states_to_pop: 2,
+                    nonterminal_produced: 26,
                 }
             }
             56 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
-                    nonterminal_produced: 29,
+                    nonterminal_produced: 27,
                 }
             }
             57 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 3,
-                    nonterminal_produced: 30,
+                    states_to_pop: 1,
+                    nonterminal_produced: 27,
                 }
             }
             58 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 3,
-                    nonterminal_produced: 30,
+                    states_to_pop: 1,
+                    nonterminal_produced: 28,
                 }
             }
             59 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 4,
+                    nonterminal_produced: 28,
+                }
+            }
+            60 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 1,
+                    nonterminal_produced: 29,
+                }
+            }
+            61 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
                     nonterminal_produced: 30,
                 }
             }
-            60 => {
+            62 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 3,
                     nonterminal_produced: 31,
                 }
             }
-            61 => {
-                __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 0,
-                    nonterminal_produced: 31,
-                }
-            }
-            62 => {
-                __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 2,
-                    nonterminal_produced: 32,
-                }
-            }
             63 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 0,
-                    nonterminal_produced: 32,
+                    states_to_pop: 3,
+                    nonterminal_produced: 31,
                 }
             }
             64 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
-                    nonterminal_produced: 33,
+                    nonterminal_produced: 31,
                 }
             }
             65 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 6,
-                    nonterminal_produced: 34,
+                    states_to_pop: 3,
+                    nonterminal_produced: 32,
                 }
             }
             66 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 3,
-                    nonterminal_produced: 35,
+                    states_to_pop: 0,
+                    nonterminal_produced: 32,
                 }
             }
             67 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 35,
+                    states_to_pop: 3,
+                    nonterminal_produced: 33,
                 }
             }
             68 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 36,
+                    states_to_pop: 0,
+                    nonterminal_produced: 33,
                 }
             }
             69 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 36,
+                    states_to_pop: 2,
+                    nonterminal_produced: 34,
                 }
             }
             70 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 0,
+                    nonterminal_produced: 34,
+                }
+            }
+            71 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 1,
+                    nonterminal_produced: 35,
+                }
+            }
+            72 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 7,
+                    nonterminal_produced: 36,
+                }
+            }
+            73 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 3,
+                    nonterminal_produced: 37,
+                }
+            }
+            74 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
                     nonterminal_produced: 37,
                 }
             }
-            71 => {
-                __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 3,
-                    nonterminal_produced: 38,
-                }
-            }
-            72 => {
-                __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 3,
-                    nonterminal_produced: 38,
-                }
-            }
-            73 => {
-                __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 10,
-                    nonterminal_produced: 39,
-                }
-            }
-            74 => {
-                __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 3,
-                    nonterminal_produced: 39,
-                }
-            }
             75 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 5,
-                    nonterminal_produced: 39,
+                    states_to_pop: 1,
+                    nonterminal_produced: 37,
                 }
             }
             76 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 6,
-                    nonterminal_produced: 39,
+                    states_to_pop: 1,
+                    nonterminal_produced: 38,
                 }
             }
             77 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 8,
-                    nonterminal_produced: 39,
+                    states_to_pop: 1,
+                    nonterminal_produced: 38,
                 }
             }
             78 => {
@@ -939,29 +966,77 @@ mod __parse__Predicate {
                     nonterminal_produced: 39,
                 }
             }
-            79 => __state_machine::SimulatedReduce::Accept,
+            79 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 3,
+                    nonterminal_produced: 40,
+                }
+            }
             80 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 3,
+                    nonterminal_produced: 40,
+                }
+            }
+            81 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 10,
+                    nonterminal_produced: 41,
+                }
+            }
+            82 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 3,
+                    nonterminal_produced: 41,
+                }
+            }
+            83 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 5,
+                    nonterminal_produced: 41,
+                }
+            }
+            84 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 6,
+                    nonterminal_produced: 41,
+                }
+            }
+            85 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 8,
+                    nonterminal_produced: 41,
+                }
+            }
+            86 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
                     nonterminal_produced: 41,
                 }
             }
-            81 => {
-                __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 42,
-                }
-            }
-            82 => {
+            87 => __state_machine::SimulatedReduce::Accept,
+            88 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
                     nonterminal_produced: 43,
                 }
             }
-            83 => {
+            89 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
                     nonterminal_produced: 44,
+                }
+            }
+            90 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 1,
+                    nonterminal_produced: 45,
+                }
+            }
+            91 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 1,
+                    nonterminal_produced: 46,
                 }
             }
             _ => panic!("invalid reduction index {}", __reduce_index)
@@ -1283,12 +1358,7 @@ mod __parse__Predicate {
                 __reduce78(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
             }
             79 => {
-                // __Predicate = Predicate => ActionFn(3);
-                let __sym0 = __pop_Variant23(__symbols);
-                let __start = __sym0.0;
-                let __end = __sym0.2;
-                let __nt = super::__action3::<>(input, __sym0);
-                return Some(Ok(__nt));
+                __reduce79(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
             }
             80 => {
                 __reduce80(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
@@ -1301,6 +1371,35 @@ mod __parse__Predicate {
             }
             83 => {
                 __reduce83(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
+            }
+            84 => {
+                __reduce84(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
+            }
+            85 => {
+                __reduce85(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
+            }
+            86 => {
+                __reduce86(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
+            }
+            87 => {
+                // __Predicate = Predicate => ActionFn(3);
+                let __sym0 = __pop_Variant24(__symbols);
+                let __start = __sym0.0;
+                let __end = __sym0.2;
+                let __nt = super::__action3::<>(input, __sym0);
+                return Some(Ok(__nt));
+            }
+            88 => {
+                __reduce88(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
+            }
+            89 => {
+                __reduce89(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
+            }
+            90 => {
+                __reduce90(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
+            }
+            91 => {
+                __reduce91(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
             }
             _ => panic!("invalid action code {}", __action)
         };
@@ -1315,36 +1414,14 @@ mod __parse__Predicate {
     fn __symbol_type_mismatch() -> ! {
         panic!("symbol type mismatch")
     }
-    fn __pop_Variant7<
+    fn __pop_Variant12<
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, (expression::Expression, Option<String>), usize)
+    ) -> (usize, AggregationFn, usize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant7(__v), __r)) => (__l, __v, __r),
-            _ => __symbol_type_mismatch()
-        }
-    }
-    fn __pop_Variant18<
-      'input,
-    >(
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, Option<Vec<(expression::Expression, Option<String>)>>, usize)
-     {
-        match __symbols.pop() {
-            Some((__l, __Symbol::Variant18(__v), __r)) => (__l, __v, __r),
-            _ => __symbol_type_mismatch()
-        }
-    }
-    fn __pop_Variant21<
-      'input,
-    >(
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, Option<Vec<String>>, usize)
-     {
-        match __symbols.pop() {
-            Some((__l, __Symbol::Variant21(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant12(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -1352,7 +1429,7 @@ mod __parse__Predicate {
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, Option<predicate::Predicate>, usize)
+    ) -> (usize, Option<Vec<String>>, usize)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant22(__v), __r)) => (__l, __v, __r),
@@ -1363,10 +1440,32 @@ mod __parse__Predicate {
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, Spec, usize)
+    ) -> (usize, Option<Vec<statement::SelectField>>, usize)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant19(__v), __r)) => (__l, __v, __r),
+            _ => __symbol_type_mismatch()
+        }
+    }
+    fn __pop_Variant23<
+      'input,
+    >(
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
+    ) -> (usize, Option<predicate::Predicate>, usize)
+     {
+        match __symbols.pop() {
+            Some((__l, __Symbol::Variant23(__v), __r)) => (__l, __v, __r),
+            _ => __symbol_type_mismatch()
+        }
+    }
+    fn __pop_Variant20<
+      'input,
+    >(
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
+    ) -> (usize, Spec, usize)
+     {
+        match __symbols.pop() {
+            Some((__l, __Symbol::Variant20(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -1396,43 +1495,10 @@ mod __parse__Predicate {
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, Vec<(expression::Expression, Option<String>)>, usize)
-     {
-        match __symbols.pop() {
-            Some((__l, __Symbol::Variant16(__v), __r)) => (__l, __v, __r),
-            _ => __symbol_type_mismatch()
-        }
-    }
-    fn __pop_Variant15<
-      'input,
-    >(
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
     ) -> (usize, Vec<String>, usize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant15(__v), __r)) => (__l, __v, __r),
-            _ => __symbol_type_mismatch()
-        }
-    }
-    fn __pop_Variant13<
-      'input,
-    >(
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, Vec<Value>, usize)
-     {
-        match __symbols.pop() {
-            Some((__l, __Symbol::Variant13(__v), __r)) => (__l, __v, __r),
-            _ => __symbol_type_mismatch()
-        }
-    }
-    fn __pop_Variant12<
-      'input,
-    >(
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, Vec<predicate::Term>, usize)
-     {
-        match __symbols.pop() {
-            Some((__l, __Symbol::Variant12(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant16(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -1440,21 +1506,43 @@ mod __parse__Predicate {
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, Vec<statement::FieldDefinition>, usize)
+    ) -> (usize, Vec<Value>, usize)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant14(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant8<
+    fn __pop_Variant13<
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, alloc::vec::Vec<(expression::Expression, Option<String>)>, usize)
+    ) -> (usize, Vec<predicate::Term>, usize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant8(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant13(__v), __r)) => (__l, __v, __r),
+            _ => __symbol_type_mismatch()
+        }
+    }
+    fn __pop_Variant15<
+      'input,
+    >(
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
+    ) -> (usize, Vec<statement::FieldDefinition>, usize)
+     {
+        match __symbols.pop() {
+            Some((__l, __Symbol::Variant15(__v), __r)) => (__l, __v, __r),
+            _ => __symbol_type_mismatch()
+        }
+    }
+    fn __pop_Variant17<
+      'input,
+    >(
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
+    ) -> (usize, Vec<statement::SelectField>, usize)
+     {
+        match __symbols.pop() {
+            Some((__l, __Symbol::Variant17(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -1502,6 +1590,17 @@ mod __parse__Predicate {
             _ => __symbol_type_mismatch()
         }
     }
+    fn __pop_Variant8<
+      'input,
+    >(
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
+    ) -> (usize, alloc::vec::Vec<statement::SelectField>, usize)
+     {
+        match __symbols.pop() {
+            Some((__l, __Symbol::Variant8(__v), __r)) => (__l, __v, __r),
+            _ => __symbol_type_mismatch()
+        }
+    }
     fn __pop_Variant11<
       'input,
     >(
@@ -1513,25 +1612,25 @@ mod __parse__Predicate {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant20<
+    fn __pop_Variant21<
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
     ) -> (usize, i32, usize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant20(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant21(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant23<
+    fn __pop_Variant24<
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
     ) -> (usize, predicate::Predicate, usize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant23(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant24(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -1546,14 +1645,14 @@ mod __parse__Predicate {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant17<
+    fn __pop_Variant18<
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
     ) -> (usize, statement::CreateCommand, usize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant17(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant18(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -1568,25 +1667,25 @@ mod __parse__Predicate {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant24<
+    fn __pop_Variant25<
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
     ) -> (usize, statement::QueryData, usize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant24(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant25(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant25<
+    fn __pop_Variant7<
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, statement::Statement, usize)
+    ) -> (usize, statement::SelectField, usize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant25(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant7(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -1594,10 +1693,21 @@ mod __parse__Predicate {
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, statement::UpdateCommand, usize)
+    ) -> (usize, statement::Statement, usize)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant26(__v), __r)) => (__l, __v, __r),
+            _ => __symbol_type_mismatch()
+        }
+    }
+    fn __pop_Variant27<
+      'input,
+    >(
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
+    ) -> (usize, statement::UpdateCommand, usize)
+     {
+        match __symbols.pop() {
+            Some((__l, __Symbol::Variant27(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -1621,13 +1731,13 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Constant> COMMA) = Constant, COMMA => ActionFn(62);
+        // (<Constant> COMMA) = Constant, COMMA => ActionFn(70);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant1(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action62::<>(input, __sym0, __sym1);
+        let __nt = super::__action70::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant1(__nt), __end));
         (2, 0)
     }
@@ -1640,10 +1750,10 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Constant> COMMA)* =  => ActionFn(60);
+        // (<Constant> COMMA)* =  => ActionFn(68);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action60::<>(input, &__start, &__end);
+        let __nt = super::__action68::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant2(__nt), __end));
         (0, 1)
     }
@@ -1656,11 +1766,11 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Constant> COMMA)* = (<Constant> COMMA)+ => ActionFn(61);
+        // (<Constant> COMMA)* = (<Constant> COMMA)+ => ActionFn(69);
         let __sym0 = __pop_Variant2(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action61::<>(input, __sym0);
+        let __nt = super::__action69::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant2(__nt), __end));
         (1, 1)
     }
@@ -1673,13 +1783,13 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Constant> COMMA)+ = Constant, COMMA => ActionFn(79);
+        // (<Constant> COMMA)+ = Constant, COMMA => ActionFn(87);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant1(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action79::<>(input, __sym0, __sym1);
+        let __nt = super::__action87::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant2(__nt), __end));
         (2, 2)
     }
@@ -1692,14 +1802,14 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Constant> COMMA)+ = (<Constant> COMMA)+, Constant, COMMA => ActionFn(80);
+        // (<Constant> COMMA)+ = (<Constant> COMMA)+, Constant, COMMA => ActionFn(88);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant1(__symbols);
         let __sym0 = __pop_Variant2(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action80::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action88::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant2(__nt), __end));
         (3, 2)
     }
@@ -1712,13 +1822,13 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<FieldDefinition> COMMA) = FieldDefinition, COMMA => ActionFn(65);
+        // (<FieldDefinition> COMMA) = FieldDefinition, COMMA => ActionFn(73);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant3(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action65::<>(input, __sym0, __sym1);
+        let __nt = super::__action73::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant3(__nt), __end));
         (2, 3)
     }
@@ -1731,10 +1841,10 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<FieldDefinition> COMMA)* =  => ActionFn(63);
+        // (<FieldDefinition> COMMA)* =  => ActionFn(71);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action63::<>(input, &__start, &__end);
+        let __nt = super::__action71::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant4(__nt), __end));
         (0, 4)
     }
@@ -1747,11 +1857,11 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<FieldDefinition> COMMA)* = (<FieldDefinition> COMMA)+ => ActionFn(64);
+        // (<FieldDefinition> COMMA)* = (<FieldDefinition> COMMA)+ => ActionFn(72);
         let __sym0 = __pop_Variant4(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action64::<>(input, __sym0);
+        let __nt = super::__action72::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant4(__nt), __end));
         (1, 4)
     }
@@ -1764,13 +1874,13 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<FieldDefinition> COMMA)+ = FieldDefinition, COMMA => ActionFn(83);
+        // (<FieldDefinition> COMMA)+ = FieldDefinition, COMMA => ActionFn(91);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant3(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action83::<>(input, __sym0, __sym1);
+        let __nt = super::__action91::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant4(__nt), __end));
         (2, 5)
     }
@@ -1783,14 +1893,14 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<FieldDefinition> COMMA)+ = (<FieldDefinition> COMMA)+, FieldDefinition, COMMA => ActionFn(84);
+        // (<FieldDefinition> COMMA)+ = (<FieldDefinition> COMMA)+, FieldDefinition, COMMA => ActionFn(92);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant3(__symbols);
         let __sym0 = __pop_Variant4(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action84::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action92::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant4(__nt), __end));
         (3, 5)
     }
@@ -1803,13 +1913,13 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<IdToken> COMMA) = IdToken, COMMA => ActionFn(56);
+        // (<IdToken> COMMA) = IdToken, COMMA => ActionFn(64);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action56::<>(input, __sym0, __sym1);
+        let __nt = super::__action64::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant5(__nt), __end));
         (2, 6)
     }
@@ -1822,10 +1932,10 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<IdToken> COMMA)* =  => ActionFn(54);
+        // (<IdToken> COMMA)* =  => ActionFn(62);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action54::<>(input, &__start, &__end);
+        let __nt = super::__action62::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant6(__nt), __end));
         (0, 7)
     }
@@ -1838,11 +1948,11 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<IdToken> COMMA)* = (<IdToken> COMMA)+ => ActionFn(55);
+        // (<IdToken> COMMA)* = (<IdToken> COMMA)+ => ActionFn(63);
         let __sym0 = __pop_Variant6(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action55::<>(input, __sym0);
+        let __nt = super::__action63::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant6(__nt), __end));
         (1, 7)
     }
@@ -1855,13 +1965,13 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<IdToken> COMMA)+ = IdToken, COMMA => ActionFn(87);
+        // (<IdToken> COMMA)+ = IdToken, COMMA => ActionFn(95);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action87::<>(input, __sym0, __sym1);
+        let __nt = super::__action95::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant6(__nt), __end));
         (2, 8)
     }
@@ -1874,14 +1984,14 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<IdToken> COMMA)+ = (<IdToken> COMMA)+, IdToken, COMMA => ActionFn(88);
+        // (<IdToken> COMMA)+ = (<IdToken> COMMA)+, IdToken, COMMA => ActionFn(96);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant5(__symbols);
         let __sym0 = __pop_Variant6(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action88::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action96::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant6(__nt), __end));
         (3, 8)
     }
@@ -1894,13 +2004,13 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<SelectField> COMMA) = SelectField, COMMA => ActionFn(59);
+        // (<SelectField> COMMA) = SelectField, COMMA => ActionFn(67);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant7(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action59::<>(input, __sym0, __sym1);
+        let __nt = super::__action67::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant7(__nt), __end));
         (2, 9)
     }
@@ -1913,10 +2023,10 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<SelectField> COMMA)* =  => ActionFn(57);
+        // (<SelectField> COMMA)* =  => ActionFn(65);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action57::<>(input, &__start, &__end);
+        let __nt = super::__action65::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant8(__nt), __end));
         (0, 10)
     }
@@ -1929,11 +2039,11 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<SelectField> COMMA)* = (<SelectField> COMMA)+ => ActionFn(58);
+        // (<SelectField> COMMA)* = (<SelectField> COMMA)+ => ActionFn(66);
         let __sym0 = __pop_Variant8(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action58::<>(input, __sym0);
+        let __nt = super::__action66::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant8(__nt), __end));
         (1, 10)
     }
@@ -1946,13 +2056,13 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<SelectField> COMMA)+ = SelectField, COMMA => ActionFn(91);
+        // (<SelectField> COMMA)+ = SelectField, COMMA => ActionFn(99);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant7(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action91::<>(input, __sym0, __sym1);
+        let __nt = super::__action99::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant8(__nt), __end));
         (2, 11)
     }
@@ -1965,14 +2075,14 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<SelectField> COMMA)+ = (<SelectField> COMMA)+, SelectField, COMMA => ActionFn(92);
+        // (<SelectField> COMMA)+ = (<SelectField> COMMA)+, SelectField, COMMA => ActionFn(100);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant7(__symbols);
         let __sym0 = __pop_Variant8(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action92::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action100::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant8(__nt), __end));
         (3, 11)
     }
@@ -1985,13 +2095,13 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Term> AND) = Term, AND => ActionFn(68);
+        // (<Term> AND) = Term, AND => ActionFn(76);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant9(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action68::<>(input, __sym0, __sym1);
+        let __nt = super::__action76::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant9(__nt), __end));
         (2, 12)
     }
@@ -2004,10 +2114,10 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Term> AND)* =  => ActionFn(66);
+        // (<Term> AND)* =  => ActionFn(74);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action66::<>(input, &__start, &__end);
+        let __nt = super::__action74::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant10(__nt), __end));
         (0, 13)
     }
@@ -2020,11 +2130,11 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Term> AND)* = (<Term> AND)+ => ActionFn(67);
+        // (<Term> AND)* = (<Term> AND)+ => ActionFn(75);
         let __sym0 = __pop_Variant10(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action67::<>(input, __sym0);
+        let __nt = super::__action75::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant10(__nt), __end));
         (1, 13)
     }
@@ -2037,13 +2147,13 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Term> AND)+ = Term, AND => ActionFn(95);
+        // (<Term> AND)+ = Term, AND => ActionFn(103);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant9(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action95::<>(input, __sym0, __sym1);
+        let __nt = super::__action103::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant10(__nt), __end));
         (2, 14)
     }
@@ -2056,14 +2166,14 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Term> AND)+ = (<Term> AND)+, Term, AND => ActionFn(96);
+        // (<Term> AND)+ = (<Term> AND)+, Term, AND => ActionFn(104);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant9(__symbols);
         let __sym0 = __pop_Variant10(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action96::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action104::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant10(__nt), __end));
         (3, 14)
     }
@@ -2076,14 +2186,14 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AddExpr = AddExpr, PLUS, MulExpr => ActionFn(32);
+        // AddExpr = AddExpr, PLUS, MulExpr => ActionFn(40);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant11(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action32::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action40::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (3, 15)
     }
@@ -2096,14 +2206,14 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AddExpr = AddExpr, MINUS, MulExpr => ActionFn(33);
+        // AddExpr = AddExpr, MINUS, MulExpr => ActionFn(41);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant11(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action33::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action41::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (3, 15)
     }
@@ -2116,11 +2226,11 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AddExpr = MulExpr => ActionFn(34);
+        // AddExpr = MulExpr => ActionFn(42);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action34::<>(input, __sym0);
+        let __nt = super::__action42::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (1, 15)
     }
@@ -2133,13 +2243,17 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // And<Term> = Term => ActionFn(97);
-        let __sym0 = __pop_Variant9(__symbols);
+        // AggregationFn = MAX, LPAREN, IdToken, RPAREN => ActionFn(13);
+        assert!(__symbols.len() >= 4);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action97::<>(input, __sym0);
+        let __end = __sym3.2;
+        let __nt = super::__action13::<>(input, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant12(__nt), __end));
-        (1, 16)
+        (4, 16)
     }
     fn __reduce29<
         'input,
@@ -2150,15 +2264,17 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // And<Term> = (<Term> AND)+, Term => ActionFn(98);
-        assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant9(__symbols);
-        let __sym0 = __pop_Variant10(__symbols);
+        // AggregationFn = MIN, LPAREN, IdToken, RPAREN => ActionFn(14);
+        assert!(__symbols.len() >= 4);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym1.2;
-        let __nt = super::__action98::<>(input, __sym0, __sym1);
+        let __end = __sym3.2;
+        let __nt = super::__action14::<>(input, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant12(__nt), __end));
-        (2, 16)
+        (4, 16)
     }
     fn __reduce30<
         'input,
@@ -2169,13 +2285,17 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<Constant> = Constant => ActionFn(81);
-        let __sym0 = __pop_Variant1(__symbols);
+        // AggregationFn = SUM, LPAREN, IdToken, RPAREN => ActionFn(15);
+        assert!(__symbols.len() >= 4);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action81::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant13(__nt), __end));
-        (1, 17)
+        let __end = __sym3.2;
+        let __nt = super::__action15::<>(input, __sym0, __sym1, __sym2, __sym3);
+        __symbols.push((__start, __Symbol::Variant12(__nt), __end));
+        (4, 16)
     }
     fn __reduce31<
         'input,
@@ -2186,15 +2306,17 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<Constant> = (<Constant> COMMA)+, Constant => ActionFn(82);
-        assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant1(__symbols);
-        let __sym0 = __pop_Variant2(__symbols);
+        // AggregationFn = COUNT, LPAREN, IdToken, RPAREN => ActionFn(16);
+        assert!(__symbols.len() >= 4);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym1.2;
-        let __nt = super::__action82::<>(input, __sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant13(__nt), __end));
-        (2, 17)
+        let __end = __sym3.2;
+        let __nt = super::__action16::<>(input, __sym0, __sym1, __sym2, __sym3);
+        __symbols.push((__start, __Symbol::Variant12(__nt), __end));
+        (4, 16)
     }
     fn __reduce32<
         'input,
@@ -2205,13 +2327,17 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<FieldDefinition> = FieldDefinition => ActionFn(85);
-        let __sym0 = __pop_Variant3(__symbols);
+        // AggregationFn = AVG, LPAREN, IdToken, RPAREN => ActionFn(17);
+        assert!(__symbols.len() >= 4);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action85::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant14(__nt), __end));
-        (1, 18)
+        let __end = __sym3.2;
+        let __nt = super::__action17::<>(input, __sym0, __sym1, __sym2, __sym3);
+        __symbols.push((__start, __Symbol::Variant12(__nt), __end));
+        (4, 16)
     }
     fn __reduce33<
         'input,
@@ -2222,15 +2348,13 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<FieldDefinition> = (<FieldDefinition> COMMA)+, FieldDefinition => ActionFn(86);
-        assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant3(__symbols);
-        let __sym0 = __pop_Variant4(__symbols);
+        // And<Term> = Term => ActionFn(105);
+        let __sym0 = __pop_Variant9(__symbols);
         let __start = __sym0.0;
-        let __end = __sym1.2;
-        let __nt = super::__action86::<>(input, __sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant14(__nt), __end));
-        (2, 18)
+        let __end = __sym0.2;
+        let __nt = super::__action105::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant13(__nt), __end));
+        (1, 17)
     }
     fn __reduce34<
         'input,
@@ -2241,13 +2365,15 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<IdToken> = IdToken => ActionFn(89);
-        let __sym0 = __pop_Variant5(__symbols);
+        // And<Term> = (<Term> AND)+, Term => ActionFn(106);
+        assert!(__symbols.len() >= 2);
+        let __sym1 = __pop_Variant9(__symbols);
+        let __sym0 = __pop_Variant10(__symbols);
         let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action89::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant15(__nt), __end));
-        (1, 19)
+        let __end = __sym1.2;
+        let __nt = super::__action106::<>(input, __sym0, __sym1);
+        __symbols.push((__start, __Symbol::Variant13(__nt), __end));
+        (2, 17)
     }
     fn __reduce35<
         'input,
@@ -2258,15 +2384,13 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<IdToken> = (<IdToken> COMMA)+, IdToken => ActionFn(90);
-        assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant5(__symbols);
-        let __sym0 = __pop_Variant6(__symbols);
+        // Comma<Constant> = Constant => ActionFn(89);
+        let __sym0 = __pop_Variant1(__symbols);
         let __start = __sym0.0;
-        let __end = __sym1.2;
-        let __nt = super::__action90::<>(input, __sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant15(__nt), __end));
-        (2, 19)
+        let __end = __sym0.2;
+        let __nt = super::__action89::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant14(__nt), __end));
+        (1, 18)
     }
     fn __reduce36<
         'input,
@@ -2277,13 +2401,15 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<SelectField> = SelectField => ActionFn(93);
-        let __sym0 = __pop_Variant7(__symbols);
+        // Comma<Constant> = (<Constant> COMMA)+, Constant => ActionFn(90);
+        assert!(__symbols.len() >= 2);
+        let __sym1 = __pop_Variant1(__symbols);
+        let __sym0 = __pop_Variant2(__symbols);
         let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action93::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant16(__nt), __end));
-        (1, 20)
+        let __end = __sym1.2;
+        let __nt = super::__action90::<>(input, __sym0, __sym1);
+        __symbols.push((__start, __Symbol::Variant14(__nt), __end));
+        (2, 18)
     }
     fn __reduce37<
         'input,
@@ -2294,15 +2420,13 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<SelectField> = (<SelectField> COMMA)+, SelectField => ActionFn(94);
-        assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant7(__symbols);
-        let __sym0 = __pop_Variant8(__symbols);
+        // Comma<FieldDefinition> = FieldDefinition => ActionFn(93);
+        let __sym0 = __pop_Variant3(__symbols);
         let __start = __sym0.0;
-        let __end = __sym1.2;
-        let __nt = super::__action94::<>(input, __sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant16(__nt), __end));
-        (2, 20)
+        let __end = __sym0.2;
+        let __nt = super::__action93::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant15(__nt), __end));
+        (1, 19)
     }
     fn __reduce38<
         'input,
@@ -2313,13 +2437,15 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Constant = NULL => ActionFn(43);
-        let __sym0 = __pop_Variant0(__symbols);
+        // Comma<FieldDefinition> = (<FieldDefinition> COMMA)+, FieldDefinition => ActionFn(94);
+        assert!(__symbols.len() >= 2);
+        let __sym1 = __pop_Variant3(__symbols);
+        let __sym0 = __pop_Variant4(__symbols);
         let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action43::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant1(__nt), __end));
-        (1, 21)
+        let __end = __sym1.2;
+        let __nt = super::__action94::<>(input, __sym0, __sym1);
+        __symbols.push((__start, __Symbol::Variant15(__nt), __end));
+        (2, 19)
     }
     fn __reduce39<
         'input,
@@ -2330,13 +2456,13 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Constant = I32Constant => ActionFn(44);
-        let __sym0 = __pop_Variant20(__symbols);
+        // Comma<IdToken> = IdToken => ActionFn(97);
+        let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action44::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant1(__nt), __end));
-        (1, 21)
+        let __nt = super::__action97::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant16(__nt), __end));
+        (1, 20)
     }
     fn __reduce40<
         'input,
@@ -2347,13 +2473,15 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Constant = StringConstant => ActionFn(45);
-        let __sym0 = __pop_Variant5(__symbols);
+        // Comma<IdToken> = (<IdToken> COMMA)+, IdToken => ActionFn(98);
+        assert!(__symbols.len() >= 2);
+        let __sym1 = __pop_Variant5(__symbols);
+        let __sym0 = __pop_Variant6(__symbols);
         let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action45::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant1(__nt), __end));
-        (1, 21)
+        let __end = __sym1.2;
+        let __nt = super::__action98::<>(input, __sym0, __sym1);
+        __symbols.push((__start, __Symbol::Variant16(__nt), __end));
+        (2, 20)
     }
     fn __reduce41<
         'input,
@@ -2364,19 +2492,13 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // CreateCommand = CREATE, TABLE, IdToken, LPAREN, Comma<FieldDefinition>, RPAREN => ActionFn(22);
-        assert!(__symbols.len() >= 6);
-        let __sym5 = __pop_Variant0(__symbols);
-        let __sym4 = __pop_Variant14(__symbols);
-        let __sym3 = __pop_Variant0(__symbols);
-        let __sym2 = __pop_Variant5(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
+        // Comma<SelectField> = SelectField => ActionFn(101);
+        let __sym0 = __pop_Variant7(__symbols);
         let __start = __sym0.0;
-        let __end = __sym5.2;
-        let __nt = super::__action22::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
+        let __end = __sym0.2;
+        let __nt = super::__action101::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant17(__nt), __end));
-        (6, 22)
+        (1, 21)
     }
     fn __reduce42<
         'input,
@@ -2387,18 +2509,15 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // CreateCommand = CREATE, VIEW, IdToken, AS, Query => ActionFn(23);
-        assert!(__symbols.len() >= 5);
-        let __sym4 = __pop_Variant24(__symbols);
-        let __sym3 = __pop_Variant0(__symbols);
-        let __sym2 = __pop_Variant5(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
+        // Comma<SelectField> = (<SelectField> COMMA)+, SelectField => ActionFn(102);
+        assert!(__symbols.len() >= 2);
+        let __sym1 = __pop_Variant7(__symbols);
+        let __sym0 = __pop_Variant8(__symbols);
         let __start = __sym0.0;
-        let __end = __sym4.2;
-        let __nt = super::__action23::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4);
+        let __end = __sym1.2;
+        let __nt = super::__action102::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant17(__nt), __end));
-        (5, 22)
+        (2, 21)
     }
     fn __reduce43<
         'input,
@@ -2409,7 +2528,103 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // CreateCommand = CREATE, INDEX, IdToken, ON, IdToken, LPAREN, IdToken, RPAREN => ActionFn(24);
+        // Constant = NULL => ActionFn(51);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action51::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant1(__nt), __end));
+        (1, 22)
+    }
+    fn __reduce44<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // Constant = I32Constant => ActionFn(52);
+        let __sym0 = __pop_Variant21(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action52::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant1(__nt), __end));
+        (1, 22)
+    }
+    fn __reduce45<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // Constant = StringConstant => ActionFn(53);
+        let __sym0 = __pop_Variant5(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action53::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant1(__nt), __end));
+        (1, 22)
+    }
+    fn __reduce46<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // CreateCommand = CREATE, TABLE, IdToken, LPAREN, Comma<FieldDefinition>, RPAREN => ActionFn(30);
+        assert!(__symbols.len() >= 6);
+        let __sym5 = __pop_Variant0(__symbols);
+        let __sym4 = __pop_Variant15(__symbols);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym5.2;
+        let __nt = super::__action30::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
+        __symbols.push((__start, __Symbol::Variant18(__nt), __end));
+        (6, 23)
+    }
+    fn __reduce47<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // CreateCommand = CREATE, VIEW, IdToken, AS, Query => ActionFn(31);
+        assert!(__symbols.len() >= 5);
+        let __sym4 = __pop_Variant25(__symbols);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym4.2;
+        let __nt = super::__action31::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4);
+        __symbols.push((__start, __Symbol::Variant18(__nt), __end));
+        (5, 23)
+    }
+    fn __reduce48<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // CreateCommand = CREATE, INDEX, IdToken, ON, IdToken, LPAREN, IdToken, RPAREN => ActionFn(32);
         assert!(__symbols.len() >= 8);
         let __sym7 = __pop_Variant0(__symbols);
         let __sym6 = __pop_Variant5(__symbols);
@@ -2421,97 +2636,9 @@ mod __parse__Predicate {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym7.2;
-        let __nt = super::__action24::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
-        __symbols.push((__start, __Symbol::Variant17(__nt), __end));
-        (8, 22)
-    }
-    fn __reduce44<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // Expression = AddExpr => ActionFn(31);
-        let __sym0 = __pop_Variant11(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action31::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
-        (1, 23)
-    }
-    fn __reduce45<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // Factor = LPAREN, Expression, RPAREN => ActionFn(38);
-        assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant11(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym2.2;
-        let __nt = super::__action38::<>(input, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
-        (3, 24)
-    }
-    fn __reduce46<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // Factor = NULL => ActionFn(39);
-        let __sym0 = __pop_Variant0(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action39::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
-        (1, 24)
-    }
-    fn __reduce47<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // Factor = I32Constant => ActionFn(40);
-        let __sym0 = __pop_Variant20(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action40::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
-        (1, 24)
-    }
-    fn __reduce48<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // Factor = StringConstant => ActionFn(41);
-        let __sym0 = __pop_Variant5(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action41::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
-        (1, 24)
+        let __nt = super::__action32::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
+        __symbols.push((__start, __Symbol::Variant18(__nt), __end));
+        (8, 23)
     }
     fn __reduce49<
         'input,
@@ -2522,11 +2649,11 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Factor = IdToken => ActionFn(42);
-        let __sym0 = __pop_Variant5(__symbols);
+        // Expression = AddExpr => ActionFn(39);
+        let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action42::<>(input, __sym0);
+        let __nt = super::__action39::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (1, 24)
     }
@@ -2539,17 +2666,105 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // FieldDefinition = IdToken, FieldType => ActionFn(25);
+        // Factor = LPAREN, Expression, RPAREN => ActionFn(46);
+        assert!(__symbols.len() >= 3);
+        let __sym2 = __pop_Variant0(__symbols);
+        let __sym1 = __pop_Variant11(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym2.2;
+        let __nt = super::__action46::<>(input, __sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
+        (3, 25)
+    }
+    fn __reduce51<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // Factor = NULL => ActionFn(47);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action47::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
+        (1, 25)
+    }
+    fn __reduce52<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // Factor = I32Constant => ActionFn(48);
+        let __sym0 = __pop_Variant21(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action48::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
+        (1, 25)
+    }
+    fn __reduce53<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // Factor = StringConstant => ActionFn(49);
+        let __sym0 = __pop_Variant5(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action49::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
+        (1, 25)
+    }
+    fn __reduce54<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // Factor = IdToken => ActionFn(50);
+        let __sym0 = __pop_Variant5(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action50::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
+        (1, 25)
+    }
+    fn __reduce55<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // FieldDefinition = IdToken, FieldType => ActionFn(33);
         assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant19(__symbols);
+        let __sym1 = __pop_Variant20(__symbols);
         let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action25::<>(input, __sym0, __sym1);
+        let __nt = super::__action33::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant3(__nt), __end));
-        (2, 25)
+        (2, 26)
     }
-    fn __reduce51<
+    fn __reduce56<
         'input,
     >(
         input: &'input str,
@@ -2563,97 +2778,8 @@ mod __parse__Predicate {
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action8::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant18(__nt), __end));
-        (1, 26)
-    }
-    fn __reduce52<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // FieldList = Comma<SelectField> => ActionFn(9);
-        let __sym0 = __pop_Variant16(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action9::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant18(__nt), __end));
-        (1, 26)
-    }
-    fn __reduce53<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // FieldType = I32 => ActionFn(26);
-        let __sym0 = __pop_Variant0(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action26::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant19(__nt), __end));
         (1, 27)
-    }
-    fn __reduce54<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // FieldType = VARCHAR, LPAREN, I32Constant, RPAREN => ActionFn(27);
-        assert!(__symbols.len() >= 4);
-        let __sym3 = __pop_Variant0(__symbols);
-        let __sym2 = __pop_Variant20(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym3.2;
-        let __nt = super::__action27::<>(input, __sym0, __sym1, __sym2, __sym3);
-        __symbols.push((__start, __Symbol::Variant19(__nt), __end));
-        (4, 27)
-    }
-    fn __reduce55<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // I32Constant = I32_LITERAL => ActionFn(46);
-        let __sym0 = __pop_Variant0(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action46::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant20(__nt), __end));
-        (1, 28)
-    }
-    fn __reduce56<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // IdToken = ID => ActionFn(48);
-        let __sym0 = __pop_Variant0(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action48::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant5(__nt), __end));
-        (1, 29)
     }
     fn __reduce57<
         'input,
@@ -2664,16 +2790,13 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // MulExpr = MulExpr, STAR, Factor => ActionFn(35);
-        assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant11(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant11(__symbols);
+        // FieldList = Comma<SelectField> => ActionFn(9);
+        let __sym0 = __pop_Variant17(__symbols);
         let __start = __sym0.0;
-        let __end = __sym2.2;
-        let __nt = super::__action35::<>(input, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
-        (3, 30)
+        let __end = __sym0.2;
+        let __nt = super::__action9::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant19(__nt), __end));
+        (1, 27)
     }
     fn __reduce58<
         'input,
@@ -2684,16 +2807,13 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // MulExpr = MulExpr, SLASH, Factor => ActionFn(36);
-        assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant11(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant11(__symbols);
+        // FieldType = I32 => ActionFn(34);
+        let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym2.2;
-        let __nt = super::__action36::<>(input, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
-        (3, 30)
+        let __end = __sym0.2;
+        let __nt = super::__action34::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant20(__nt), __end));
+        (1, 28)
     }
     fn __reduce59<
         'input,
@@ -2704,13 +2824,17 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // MulExpr = Factor => ActionFn(37);
-        let __sym0 = __pop_Variant11(__symbols);
+        // FieldType = VARCHAR, LPAREN, I32Constant, RPAREN => ActionFn(35);
+        assert!(__symbols.len() >= 4);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant21(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action37::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
-        (1, 30)
+        let __end = __sym3.2;
+        let __nt = super::__action35::<>(input, __sym0, __sym1, __sym2, __sym3);
+        __symbols.push((__start, __Symbol::Variant20(__nt), __end));
+        (4, 28)
     }
     fn __reduce60<
         'input,
@@ -2721,16 +2845,13 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // OptOrderBy = ORDER, BY, Comma<IdToken> => ActionFn(14);
-        assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant15(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
+        // I32Constant = I32_LITERAL => ActionFn(54);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym2.2;
-        let __nt = super::__action14::<>(input, __sym0, __sym1, __sym2);
+        let __end = __sym0.2;
+        let __nt = super::__action54::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant21(__nt), __end));
-        (3, 31)
+        (1, 29)
     }
     fn __reduce61<
         'input,
@@ -2741,12 +2862,13 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // OptOrderBy =  => ActionFn(15);
-        let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
-        let __end = __start;
-        let __nt = super::__action15::<>(input, &__start, &__end);
-        __symbols.push((__start, __Symbol::Variant21(__nt), __end));
-        (0, 31)
+        // IdToken = ID => ActionFn(56);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action56::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant5(__nt), __end));
+        (1, 30)
     }
     fn __reduce62<
         'input,
@@ -2757,15 +2879,16 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // OptPredicate = WHERE, Predicate => ActionFn(12);
-        assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant23(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
+        // MulExpr = MulExpr, STAR, Factor => ActionFn(43);
+        assert!(__symbols.len() >= 3);
+        let __sym2 = __pop_Variant11(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
-        let __end = __sym1.2;
-        let __nt = super::__action12::<>(input, __sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant22(__nt), __end));
-        (2, 32)
+        let __end = __sym2.2;
+        let __nt = super::__action43::<>(input, __sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
+        (3, 31)
     }
     fn __reduce63<
         'input,
@@ -2776,12 +2899,16 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // OptPredicate =  => ActionFn(13);
-        let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
-        let __end = __start;
-        let __nt = super::__action13::<>(input, &__start, &__end);
-        __symbols.push((__start, __Symbol::Variant22(__nt), __end));
-        (0, 32)
+        // MulExpr = MulExpr, SLASH, Factor => ActionFn(44);
+        assert!(__symbols.len() >= 3);
+        let __sym2 = __pop_Variant11(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant11(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym2.2;
+        let __nt = super::__action44::<>(input, __sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
+        (3, 31)
     }
     fn __reduce64<
         'input,
@@ -2792,13 +2919,13 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Predicate = And<Term> => ActionFn(28);
-        let __sym0 = __pop_Variant12(__symbols);
+        // MulExpr = Factor => ActionFn(45);
+        let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action28::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant23(__nt), __end));
-        (1, 33)
+        let __nt = super::__action45::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
+        (1, 31)
     }
     fn __reduce65<
         'input,
@@ -2809,21 +2936,146 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Query = SELECT, FieldList, FROM, Comma<IdToken>, OptPredicate, OptOrderBy => ActionFn(7);
-        assert!(__symbols.len() >= 6);
-        let __sym5 = __pop_Variant21(__symbols);
-        let __sym4 = __pop_Variant22(__symbols);
-        let __sym3 = __pop_Variant15(__symbols);
-        let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant18(__symbols);
+        // OptGroupBy = GROUP, BY, Comma<IdToken> => ActionFn(20);
+        assert!(__symbols.len() >= 3);
+        let __sym2 = __pop_Variant16(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym5.2;
-        let __nt = super::__action7::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
-        __symbols.push((__start, __Symbol::Variant24(__nt), __end));
-        (6, 34)
+        let __end = __sym2.2;
+        let __nt = super::__action20::<>(input, __sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant22(__nt), __end));
+        (3, 32)
     }
     fn __reduce66<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // OptGroupBy =  => ActionFn(21);
+        let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
+        let __end = __start;
+        let __nt = super::__action21::<>(input, &__start, &__end);
+        __symbols.push((__start, __Symbol::Variant22(__nt), __end));
+        (0, 32)
+    }
+    fn __reduce67<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // OptOrderBy = ORDER, BY, Comma<IdToken> => ActionFn(22);
+        assert!(__symbols.len() >= 3);
+        let __sym2 = __pop_Variant16(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym2.2;
+        let __nt = super::__action22::<>(input, __sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant22(__nt), __end));
+        (3, 33)
+    }
+    fn __reduce68<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // OptOrderBy =  => ActionFn(23);
+        let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
+        let __end = __start;
+        let __nt = super::__action23::<>(input, &__start, &__end);
+        __symbols.push((__start, __Symbol::Variant22(__nt), __end));
+        (0, 33)
+    }
+    fn __reduce69<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // OptPredicate = WHERE, Predicate => ActionFn(18);
+        assert!(__symbols.len() >= 2);
+        let __sym1 = __pop_Variant24(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym1.2;
+        let __nt = super::__action18::<>(input, __sym0, __sym1);
+        __symbols.push((__start, __Symbol::Variant23(__nt), __end));
+        (2, 34)
+    }
+    fn __reduce70<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // OptPredicate =  => ActionFn(19);
+        let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
+        let __end = __start;
+        let __nt = super::__action19::<>(input, &__start, &__end);
+        __symbols.push((__start, __Symbol::Variant23(__nt), __end));
+        (0, 34)
+    }
+    fn __reduce71<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // Predicate = And<Term> => ActionFn(36);
+        let __sym0 = __pop_Variant13(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action36::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant24(__nt), __end));
+        (1, 35)
+    }
+    fn __reduce72<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // Query = SELECT, FieldList, FROM, Comma<IdToken>, OptPredicate, OptGroupBy, OptOrderBy => ActionFn(7);
+        assert!(__symbols.len() >= 7);
+        let __sym6 = __pop_Variant22(__symbols);
+        let __sym5 = __pop_Variant22(__symbols);
+        let __sym4 = __pop_Variant23(__symbols);
+        let __sym3 = __pop_Variant16(__symbols);
+        let __sym2 = __pop_Variant0(__symbols);
+        let __sym1 = __pop_Variant19(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym6.2;
+        let __nt = super::__action7::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6);
+        __symbols.push((__start, __Symbol::Variant25(__nt), __end));
+        (7, 36)
+    }
+    fn __reduce73<
         'input,
     >(
         input: &'input str,
@@ -2841,142 +3093,7 @@ mod __parse__Predicate {
         let __end = __sym2.2;
         let __nt = super::__action10::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant7(__nt), __end));
-        (3, 35)
-    }
-    fn __reduce67<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // SelectField = IdToken => ActionFn(11);
-        let __sym0 = __pop_Variant5(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action11::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant7(__nt), __end));
-        (1, 35)
-    }
-    fn __reduce68<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // Statement = Query => ActionFn(5);
-        let __sym0 = __pop_Variant24(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action5::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant25(__nt), __end));
-        (1, 36)
-    }
-    fn __reduce69<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // Statement = UpdateCommand => ActionFn(6);
-        let __sym0 = __pop_Variant26(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action6::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant25(__nt), __end));
-        (1, 36)
-    }
-    fn __reduce70<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // StringConstant = STRING_LITERAL => ActionFn(47);
-        let __sym0 = __pop_Variant0(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action47::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant5(__nt), __end));
-        (1, 37)
-    }
-    fn __reduce71<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // Term = Expression, IS, NULL => ActionFn(29);
-        assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant11(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym2.2;
-        let __nt = super::__action29::<>(input, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant9(__nt), __end));
-        (3, 38)
-    }
-    fn __reduce72<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // Term = Expression, EQ, Expression => ActionFn(30);
-        assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant11(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant11(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym2.2;
-        let __nt = super::__action30::<>(input, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant9(__nt), __end));
-        (3, 38)
-    }
-    fn __reduce73<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // UpdateCommand = INSERT, INTO, IdToken, LPAREN, Comma<IdToken>, RPAREN, VALUES, LPAREN, Comma<Constant>, RPAREN => ActionFn(16);
-        assert!(__symbols.len() >= 10);
-        let __sym9 = __pop_Variant0(__symbols);
-        let __sym8 = __pop_Variant13(__symbols);
-        let __sym7 = __pop_Variant0(__symbols);
-        let __sym6 = __pop_Variant0(__symbols);
-        let __sym5 = __pop_Variant0(__symbols);
-        let __sym4 = __pop_Variant15(__symbols);
-        let __sym3 = __pop_Variant0(__symbols);
-        let __sym2 = __pop_Variant5(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym9.2;
-        let __nt = super::__action16::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9);
-        __symbols.push((__start, __Symbol::Variant26(__nt), __end));
-        (10, 39)
+        (3, 37)
     }
     fn __reduce74<
         'input,
@@ -2987,16 +3104,13 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // UpdateCommand = DELETE, FROM, IdToken => ActionFn(17);
-        assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant5(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
+        // SelectField = Expression => ActionFn(11);
+        let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
-        let __end = __sym2.2;
-        let __nt = super::__action17::<>(input, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant26(__nt), __end));
-        (3, 39)
+        let __end = __sym0.2;
+        let __nt = super::__action11::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant7(__nt), __end));
+        (1, 37)
     }
     fn __reduce75<
         'input,
@@ -3007,18 +3121,13 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // UpdateCommand = DELETE, FROM, IdToken, WHERE, Predicate => ActionFn(18);
-        assert!(__symbols.len() >= 5);
-        let __sym4 = __pop_Variant23(__symbols);
-        let __sym3 = __pop_Variant0(__symbols);
-        let __sym2 = __pop_Variant5(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
+        // SelectField = AggregationFn => ActionFn(12);
+        let __sym0 = __pop_Variant12(__symbols);
         let __start = __sym0.0;
-        let __end = __sym4.2;
-        let __nt = super::__action18::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4);
-        __symbols.push((__start, __Symbol::Variant26(__nt), __end));
-        (5, 39)
+        let __end = __sym0.2;
+        let __nt = super::__action12::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant7(__nt), __end));
+        (1, 37)
     }
     fn __reduce76<
         'input,
@@ -3029,19 +3138,13 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // UpdateCommand = MODIFY, IdToken, SET, IdToken, EQ, Expression => ActionFn(19);
-        assert!(__symbols.len() >= 6);
-        let __sym5 = __pop_Variant11(__symbols);
-        let __sym4 = __pop_Variant0(__symbols);
-        let __sym3 = __pop_Variant5(__symbols);
-        let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant5(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
+        // Statement = Query => ActionFn(5);
+        let __sym0 = __pop_Variant25(__symbols);
         let __start = __sym0.0;
-        let __end = __sym5.2;
-        let __nt = super::__action19::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
+        let __end = __sym0.2;
+        let __nt = super::__action5::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant26(__nt), __end));
-        (6, 39)
+        (1, 38)
     }
     fn __reduce77<
         'input,
@@ -3052,21 +3155,13 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // UpdateCommand = MODIFY, IdToken, SET, IdToken, EQ, Expression, WHERE, Predicate => ActionFn(20);
-        assert!(__symbols.len() >= 8);
-        let __sym7 = __pop_Variant23(__symbols);
-        let __sym6 = __pop_Variant0(__symbols);
-        let __sym5 = __pop_Variant11(__symbols);
-        let __sym4 = __pop_Variant0(__symbols);
-        let __sym3 = __pop_Variant5(__symbols);
-        let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant5(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
+        // Statement = UpdateCommand => ActionFn(6);
+        let __sym0 = __pop_Variant27(__symbols);
         let __start = __sym0.0;
-        let __end = __sym7.2;
-        let __nt = super::__action20::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
+        let __end = __sym0.2;
+        let __nt = super::__action6::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant26(__nt), __end));
-        (8, 39)
+        (1, 38)
     }
     fn __reduce78<
         'input,
@@ -3077,13 +3172,33 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // UpdateCommand = CreateCommand => ActionFn(21);
-        let __sym0 = __pop_Variant17(__symbols);
+        // StringConstant = STRING_LITERAL => ActionFn(55);
+        let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action21::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant26(__nt), __end));
+        let __nt = super::__action55::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant5(__nt), __end));
         (1, 39)
+    }
+    fn __reduce79<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // Term = Expression, IS, NULL => ActionFn(37);
+        assert!(__symbols.len() >= 3);
+        let __sym2 = __pop_Variant0(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant11(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym2.2;
+        let __nt = super::__action37::<>(input, __sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant9(__nt), __end));
+        (3, 40)
     }
     fn __reduce80<
         'input,
@@ -3094,13 +3209,16 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // __Query = Query => ActionFn(1);
-        let __sym0 = __pop_Variant24(__symbols);
+        // Term = Expression, EQ, Expression => ActionFn(38);
+        assert!(__symbols.len() >= 3);
+        let __sym2 = __pop_Variant11(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action1::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant24(__nt), __end));
-        (1, 41)
+        let __end = __sym2.2;
+        let __nt = super::__action38::<>(input, __sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant9(__nt), __end));
+        (3, 40)
     }
     fn __reduce81<
         'input,
@@ -3111,15 +3229,166 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // __Statement = Statement => ActionFn(0);
+        // UpdateCommand = INSERT, INTO, IdToken, LPAREN, Comma<IdToken>, RPAREN, VALUES, LPAREN, Comma<Constant>, RPAREN => ActionFn(24);
+        assert!(__symbols.len() >= 10);
+        let __sym9 = __pop_Variant0(__symbols);
+        let __sym8 = __pop_Variant14(__symbols);
+        let __sym7 = __pop_Variant0(__symbols);
+        let __sym6 = __pop_Variant0(__symbols);
+        let __sym5 = __pop_Variant0(__symbols);
+        let __sym4 = __pop_Variant16(__symbols);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym9.2;
+        let __nt = super::__action24::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9);
+        __symbols.push((__start, __Symbol::Variant27(__nt), __end));
+        (10, 41)
+    }
+    fn __reduce82<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // UpdateCommand = DELETE, FROM, IdToken => ActionFn(25);
+        assert!(__symbols.len() >= 3);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym2.2;
+        let __nt = super::__action25::<>(input, __sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant27(__nt), __end));
+        (3, 41)
+    }
+    fn __reduce83<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // UpdateCommand = DELETE, FROM, IdToken, WHERE, Predicate => ActionFn(26);
+        assert!(__symbols.len() >= 5);
+        let __sym4 = __pop_Variant24(__symbols);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym4.2;
+        let __nt = super::__action26::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4);
+        __symbols.push((__start, __Symbol::Variant27(__nt), __end));
+        (5, 41)
+    }
+    fn __reduce84<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // UpdateCommand = MODIFY, IdToken, SET, IdToken, EQ, Expression => ActionFn(27);
+        assert!(__symbols.len() >= 6);
+        let __sym5 = __pop_Variant11(__symbols);
+        let __sym4 = __pop_Variant0(__symbols);
+        let __sym3 = __pop_Variant5(__symbols);
+        let __sym2 = __pop_Variant0(__symbols);
+        let __sym1 = __pop_Variant5(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym5.2;
+        let __nt = super::__action27::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
+        __symbols.push((__start, __Symbol::Variant27(__nt), __end));
+        (6, 41)
+    }
+    fn __reduce85<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // UpdateCommand = MODIFY, IdToken, SET, IdToken, EQ, Expression, WHERE, Predicate => ActionFn(28);
+        assert!(__symbols.len() >= 8);
+        let __sym7 = __pop_Variant24(__symbols);
+        let __sym6 = __pop_Variant0(__symbols);
+        let __sym5 = __pop_Variant11(__symbols);
+        let __sym4 = __pop_Variant0(__symbols);
+        let __sym3 = __pop_Variant5(__symbols);
+        let __sym2 = __pop_Variant0(__symbols);
+        let __sym1 = __pop_Variant5(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym7.2;
+        let __nt = super::__action28::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
+        __symbols.push((__start, __Symbol::Variant27(__nt), __end));
+        (8, 41)
+    }
+    fn __reduce86<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // UpdateCommand = CreateCommand => ActionFn(29);
+        let __sym0 = __pop_Variant18(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action29::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant27(__nt), __end));
+        (1, 41)
+    }
+    fn __reduce88<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // __Query = Query => ActionFn(1);
         let __sym0 = __pop_Variant25(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action0::<>(input, __sym0);
+        let __nt = super::__action1::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant25(__nt), __end));
-        (1, 42)
+        (1, 43)
     }
-    fn __reduce82<
+    fn __reduce89<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // __Statement = Statement => ActionFn(0);
+        let __sym0 = __pop_Variant26(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action0::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant26(__nt), __end));
+        (1, 44)
+    }
+    fn __reduce90<
         'input,
     >(
         input: &'input str,
@@ -3134,9 +3403,9 @@ mod __parse__Predicate {
         let __end = __sym0.2;
         let __nt = super::__action4::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant9(__nt), __end));
-        (1, 43)
+        (1, 45)
     }
-    fn __reduce83<
+    fn __reduce91<
         'input,
     >(
         input: &'input str,
@@ -3146,12 +3415,12 @@ mod __parse__Predicate {
     ) -> (usize, usize)
     {
         // __UpdateCommand = UpdateCommand => ActionFn(2);
-        let __sym0 = __pop_Variant26(__symbols);
+        let __sym0 = __pop_Variant27(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action2::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant26(__nt), __end));
-        (1, 44)
+        __symbols.push((__start, __Symbol::Variant27(__nt), __end));
+        (1, 46)
     }
 }
 #[allow(unused_imports)]
@@ -3166,6 +3435,15 @@ mod __parse__Query {
     use super::super::predicate;
     use super::super::expression;
     use crate::record::field::{Spec, Value};
+    use crate::materialization::{
+    aggregation_function::AggregationFn,
+    aggregation_function::AggregationFnControl,
+    avg_function::AvgFn,
+    count_function::CountFn,
+    max_function::MaxFn,
+    min_function::MinFn,
+    sum_function::SumFn,
+};
     #[allow(unused_extern_crates)]
     extern crate lalrpop_util as __lalrpop_util;
     #[allow(unused_imports)]
@@ -3183,153 +3461,202 @@ mod __parse__Query {
         Variant4(alloc::vec::Vec<statement::FieldDefinition>),
         Variant5(String),
         Variant6(alloc::vec::Vec<String>),
-        Variant7((expression::Expression, Option<String>)),
-        Variant8(alloc::vec::Vec<(expression::Expression, Option<String>)>),
+        Variant7(statement::SelectField),
+        Variant8(alloc::vec::Vec<statement::SelectField>),
         Variant9(predicate::Term),
         Variant10(alloc::vec::Vec<predicate::Term>),
         Variant11(expression::Expression),
-        Variant12(Vec<predicate::Term>),
-        Variant13(Vec<Value>),
-        Variant14(Vec<statement::FieldDefinition>),
-        Variant15(Vec<String>),
-        Variant16(Vec<(expression::Expression, Option<String>)>),
-        Variant17(statement::CreateCommand),
-        Variant18(Option<Vec<(expression::Expression, Option<String>)>>),
-        Variant19(Spec),
-        Variant20(i32),
-        Variant21(Option<Vec<String>>),
-        Variant22(Option<predicate::Predicate>),
-        Variant23(predicate::Predicate),
-        Variant24(statement::QueryData),
-        Variant25(statement::Statement),
-        Variant26(statement::UpdateCommand),
+        Variant12(AggregationFn),
+        Variant13(Vec<predicate::Term>),
+        Variant14(Vec<Value>),
+        Variant15(Vec<statement::FieldDefinition>),
+        Variant16(Vec<String>),
+        Variant17(Vec<statement::SelectField>),
+        Variant18(statement::CreateCommand),
+        Variant19(Option<Vec<statement::SelectField>>),
+        Variant20(Spec),
+        Variant21(i32),
+        Variant22(Option<Vec<String>>),
+        Variant23(Option<predicate::Predicate>),
+        Variant24(predicate::Predicate),
+        Variant25(statement::QueryData),
+        Variant26(statement::Statement),
+        Variant27(statement::UpdateCommand),
     }
     const __ACTION: &[i8] = &[
         // State 0
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0,
         // State 1
-        0, 30, 33, 29, 0, 4, 0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 31, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 40, 45, 39, 0, 4, 0, 44, 0, 0, 0, 0, 0, 0, 37, 0, 38, 0, 0, 0, 0, 0, 0, 0, 0, 0, 41, 42, 0, 43, 0, 0, 0, 0, 46, 0, 0, 0, 0, 0,
         // State 2
-        0, 30, 33, 29, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 31, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 40, 45, 39, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 37, 0, 38, 0, 0, 0, 0, 0, 0, 0, 0, 0, 41, 42, 0, 43, 0, 0, 0, 0, 46, 0, 0, 0, 0, 0,
         // State 3
-        0, 30, 33, 29, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 31, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 40, 45, 39, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 43, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 4
-        0, 30, 33, 29, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 31, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 40, 45, 39, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 43, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 5
-        0, 30, 33, 29, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 31, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 40, 45, 39, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 43, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 6
-        0, 30, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 40, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 7
-        0, 30, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 40, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 8
-        0, 30, 33, 29, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 31, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 40, 45, 39, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 43, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 9
-        0, 30, 33, 29, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 31, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 40, 45, 39, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 43, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 10
-        0, 30, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 40, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 11
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -64, 0, 0, 0, 0, 0, 0, 14,
+        0, 40, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 12
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 50, 0, 0, 0, 0, 0, 0, 0,
+        0, 40, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 13
-        0, 30, 33, 29, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 31, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 40, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 14
-        0, 30, 33, 29, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 31, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 40, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 15
-        0, 30, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 40, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 16
-        0, 30, 33, 29, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 31, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -71, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -71, 0, 0, 0, 0, 0, 0, 0, 19,
         // State 17
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 71, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -67, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 18
-        0, 0, 0, 0, 5, 0, -45, 0, 6, 0, 0, -45, -45, -45, 0, 0, 0, 0, 0, 0, 0, 0, -45, 0, 0, 0, -45, 0, 0, 0, 0, 0, 0, 0,
+        0, 40, 45, 39, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 43, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 19
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 77, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 20
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 40, 45, 39, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 43, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 21
-        0, 0, 0, 0, -60, 0, -60, -60, -60, 0, -60, -60, -60, -60, 0, 0, 0, 0, 0, 0, 0, 0, -60, 0, 0, 0, -60, 0, 0, 0, 0, 0, 0, 0,
+        0, 40, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 22
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 40, 45, 39, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 43, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 23
-        0, 0, 0, 0, -48, 0, -48, -48, -48, 0, -48, -48, -48, -48, 0, 0, 0, 0, 0, 0, 0, 0, -48, 0, 0, 0, -48, 0, 0, 0, 0, 0, 0, 0,
+        0, 40, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 24
-        0, 0, 0, 0, -50, 0, 0, -50, -50, -68, -50, 0, 0, -50, 0, 0, 0, -68, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 25
-        0, 0, 0, 0, -28, 0, -28, 10, -28, 0, 9, -28, -28, -28, 0, 0, 0, 0, 0, 0, 0, 0, -28, 0, 0, 0, -28, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 5, 0, -50, 0, 6, -50, 0, -50, -50, -50, 0, 0, 0, 0, 0, -50, -50, 0, 0, 0, 0, -50, 0, 0, 0, 0, 0, -50, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 26
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 35, 0, 0, 0, 0, 0, 0, 0, -37, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, -76, 0, 0, 0, 0, 0, 0, 0, 0, 0, -76, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 27
-        0, 0, 0, 0, -49, 0, -49, -49, -49, 0, -49, -49, -49, -49, 0, 0, 0, 0, 0, 0, 0, 0, -49, 0, 0, 0, -49, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -58, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 28
-        0, 0, 0, 0, -56, 0, -56, -56, -56, 0, -56, -56, -56, -56, 0, 0, 0, 0, 0, 0, 0, 0, -56, 0, 0, 0, -56, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, -75, 0, 0, 0, 7, 0, 0, 0, 0, 0, -75, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 29
-        0, 0, 0, 0, -57, 0, -57, -57, -57, -57, -57, -57, -57, -57, 0, 0, 0, -57, 0, 0, 0, 0, -57, 0, 0, 0, -57, 0, 0, 0, 0, 0, 0, -57,
+        0, 0, 0, 0, -65, 0, -65, -65, -65, -65, -65, -65, -65, -65, 0, 0, 0, 0, 0, -65, -65, 0, 0, 0, 0, -65, 0, 0, 0, 0, 0, -65, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 30
-        0, 0, 0, 0, -47, 0, -47, -47, -47, 0, -47, -47, -47, -47, 0, 0, 0, 0, 0, 0, 0, 0, -47, 0, 0, 0, -47, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 31
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -52, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -53, 0, -53, -53, -53, -53, -53, -53, -53, -53, 0, 0, 0, 0, 0, -53, -53, 0, 0, 0, 0, -53, 0, 0, 0, 0, 0, -53, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 32
-        0, 0, 0, 0, -71, 0, -71, -71, -71, 0, -71, -71, -71, -71, 0, 0, 0, 0, 0, 0, 0, 0, -71, 0, 0, 0, -71, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -55, 0, -55, -55, -55, -55, -55, -55, -55, -55, 0, 0, 0, 0, 0, -55, -55, 0, 0, 0, 0, -55, 0, 0, 0, 0, 0, -55, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 33
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 38, 0, 0, 0, 0, 0, 0, 0, -38, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -28, 0, -28, 10, -28, -28, 9, -28, -28, -28, 0, 0, 0, 0, 0, -28, -28, 0, 0, 0, 0, -28, 0, 0, 0, 0, 0, -28, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 34
-        0, -19, -19, -19, 0, -19, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -19, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 48, 0, 0, 0, 0, 0, 0, 0, 0, 0, -42, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 35
-        0, 0, 0, 0, 0, 0, 45, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -54, 0, -54, -54, -54, -54, -54, -54, -54, -54, 0, 0, 0, 0, 0, -54, -54, 0, 0, 0, 0, -54, 0, 0, 0, 0, 0, -54, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 36
-        0, 0, 0, 0, -50, 0, -50, -50, -50, 0, -50, -50, -50, -50, 0, 0, 0, 0, 0, 0, 0, 0, -50, 0, 0, 0, -50, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 11, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 37
-        0, -20, -20, -20, 0, -20, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -20, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 38
-        0, 0, 0, 0, -27, 0, -27, 10, -27, 0, 9, -27, -27, -27, 0, 0, 0, 0, 0, 0, 0, 0, -27, 0, 0, 0, -27, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -61, 0, -61, -61, -61, -61, -61, -61, -61, -61, 0, 0, 0, 0, 0, -61, -61, 0, 0, 0, 0, -61, 0, 0, 0, 0, 0, -61, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 39
-        0, 0, 0, 0, -26, 0, -26, 10, -26, 0, 9, -26, -26, -26, 0, 0, 0, 0, 0, 0, 0, 0, -26, 0, 0, 0, -26, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -62, 0, -62, -62, -62, -62, -62, -62, -62, -62, 0, 0, 0, 0, 0, -62, -62, 0, 0, 0, 0, -62, 0, 0, 0, 0, 0, -62, 0, 0, 0, 0, 0, 0, 0, -62,
         // State 40
-        0, 0, 0, 0, 0, 0, 0, 0, 0, -67, 0, 0, 0, 0, 0, 0, 0, -67, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 13, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 41
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 47, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -35, 0, 0, 0, 0, 0, 0, -35,
+        0, 0, 0, 0, 0, 14, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 42
-        0, 0, 0, 0, -59, 0, -59, -59, -59, 0, -59, -59, -59, -59, 0, 0, 0, 0, 0, 0, 0, 0, -59, 0, 0, 0, -59, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -52, 0, -52, -52, -52, -52, -52, -52, -52, -52, 0, 0, 0, 0, 0, -52, -52, 0, 0, 0, 0, -52, 0, 0, 0, 0, 0, -52, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 43
-        0, 0, 0, 0, -58, 0, -58, -58, -58, 0, -58, -58, -58, -58, 0, 0, 0, 0, 0, 0, 0, 0, -58, 0, 0, 0, -58, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -57, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 44
-        0, 0, 0, 0, -46, 0, -46, -46, -46, 0, -46, -46, -46, -46, 0, 0, 0, 0, 0, 0, 0, 0, -46, 0, 0, 0, -46, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -79, 0, -79, -79, -79, -79, -79, -79, -79, -79, 0, 0, 0, 0, 0, -79, -79, 0, 0, 0, 0, -79, 0, 0, 0, 0, 0, -79, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 45
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 48, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -36, 0, 0, 0, 0, 0, 0, -36,
+        0, 0, 0, 0, 0, 15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 46
-        0, -14, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 50, 0, 0, 0, 0, 0, 0, 0, 0, 0, -43, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 47
-        0, -15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, -19, -19, -19, 0, -19, 0, 0, 0, 0, 0, 0, 0, 0, -19, 0, -19, 0, 0, 0, 0, 0, 0, 0, 0, 0, -19, -19, 0, -19, 0, 0, 0, 0, -19, 0, 0, 0, 0, 0,
         // State 48
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 59, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 49
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, -20, -20, -20, 0, -20, 0, 0, 0, 0, 0, 0, 0, 0, -20, 0, -20, 0, 0, 0, 0, 0, 0, 0, 0, 0, -20, -20, 0, -20, 0, 0, 0, 0, -20, 0, 0, 0, 0, 0,
         // State 50
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -65, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -27, 0, -27, 10, -27, -27, 9, -27, -27, -27, 0, 0, 0, 0, 0, -27, -27, 0, 0, 0, 0, -27, 0, 0, 0, 0, 0, -27, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 51
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 17, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 56, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -26, 0, -26, 10, -26, -26, 9, -26, -26, -26, 0, 0, 0, 0, 0, -26, -26, 0, 0, 0, 0, -26, 0, 0, 0, 0, 0, -26, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 52
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -63, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, -74, 0, 0, 0, 0, 0, 0, 0, 0, 0, -74, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 53
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 57, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -29, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -40, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -40, 0, 0, 0, 0, 0, 0, 0, -40,
         // State 54
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 59, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -30, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -64, 0, -64, -64, -64, -64, -64, -64, -64, -64, 0, 0, 0, 0, 0, -64, -64, 0, 0, 0, 0, -64, 0, 0, 0, 0, 0, -64, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 55
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 61, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -63, 0, -63, -63, -63, -63, -63, -63, -63, -63, 0, 0, 0, 0, 0, -63, -63, 0, 0, 0, 0, -63, 0, 0, 0, 0, 0, -63, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 56
-        0, -24, -24, -24, 0, -24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -24, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 65, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 57
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 66, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 58
-        0, -25, -25, -25, 0, -25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -25, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -51, 0, -51, -51, -51, -51, -51, -51, -51, -51, 0, 0, 0, 0, 0, -51, -51, 0, 0, 0, 0, -51, 0, 0, 0, 0, 0, -51, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 59
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -73, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -73, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 67, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 60
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -72, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -72, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 68, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 61
+        0, 0, 0, 0, 0, 0, 69, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 62
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 70, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -41, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -41, 0, 0, 0, 0, 0, 0, 0, -41,
+        // State 63
+        0, -14, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 64
+        0, 0, 0, 0, 0, 0, 0, 0, 0, -33, 0, 0, 0, 0, 0, 0, 0, 0, 0, -33, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 65
+        0, 0, 0, 0, 0, 0, 0, 0, 0, -32, 0, 0, 0, 0, 0, 0, 0, 0, 0, -32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 66
+        0, 0, 0, 0, 0, 0, 0, 0, 0, -29, 0, 0, 0, 0, 0, 0, 0, 0, 0, -29, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 67
+        0, 0, 0, 0, 0, 0, 0, 0, 0, -30, 0, 0, 0, 0, 0, 0, 0, 0, 0, -30, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 68
+        0, 0, 0, 0, 0, 0, 0, 0, 0, -31, 0, 0, 0, 0, 0, 0, 0, 0, 0, -31, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 69
+        0, -15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 70
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 22, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 71
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -72, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -72, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 72
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 23, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 79, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 73
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -70, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -70, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 74
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 80, 0, 0, 0, 0, 0, 0, 0, -34, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -34, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 75
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 76
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 77
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 82, 0, 0, 0, 0, 0, 0, 0, -35, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -35, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 78
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 84, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 79
+        0, -24, -24, -24, 0, -24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 80
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -66, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 81
+        0, -25, -25, -25, 0, -25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 82
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -81, 0, 0, 0, 0, 0, 0, 0, -81, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -81, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 83
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -80, 0, 0, 0, 0, 0, 0, 0, -80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -80, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 84
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     ];
     fn __action(state: i8, integer: usize) -> i8 {
-        __ACTION[(state as usize) * 34 + integer]
+        __ACTION[(state as usize) * 40 + integer]
     }
     const __EOF_ACTION: &[i8] = &[
         // State 0
@@ -3355,9 +3682,9 @@ mod __parse__Query {
         // State 10
         0,
         // State 11
-        -64,
+        0,
         // State 12
-        -62,
+        0,
         // State 13
         0,
         // State 14
@@ -3365,145 +3692,200 @@ mod __parse__Query {
         // State 15
         0,
         // State 16
-        0,
+        -71,
         // State 17
-        -81,
+        -67,
         // State 18
-        -45,
-        // State 19
         0,
+        // State 19
+        -69,
         // State 20
         0,
         // State 21
-        -60,
+        0,
         // State 22
         0,
         // State 23
-        -48,
-        // State 24
         0,
+        // State 24
+        -89,
         // State 25
-        -28,
+        -50,
         // State 26
         0,
         // State 27
-        -49,
+        0,
         // State 28
-        -56,
+        0,
         // State 29
-        -57,
+        -65,
         // State 30
-        -47,
+        0,
         // State 31
-        0,
+        -53,
         // State 32
-        -71,
+        -55,
         // State 33
-        0,
+        -28,
         // State 34
         0,
         // State 35
-        0,
+        -54,
         // State 36
-        -50,
+        0,
         // State 37
         0,
         // State 38
-        -27,
+        -61,
         // State 39
-        -26,
+        -62,
         // State 40
         0,
         // State 41
-        -35,
+        0,
         // State 42
-        -59,
+        -52,
         // State 43
-        -58,
+        0,
         // State 44
-        -46,
+        -79,
         // State 45
-        -36,
+        0,
         // State 46
         0,
         // State 47
         0,
         // State 48
-        -66,
+        0,
         // State 49
         0,
         // State 50
-        -65,
+        -27,
         // State 51
-        0,
+        -26,
         // State 52
-        -63,
-        // State 53
-        -29,
-        // State 54
-        -30,
-        // State 55
         0,
+        // State 53
+        -40,
+        // State 54
+        -64,
+        // State 55
+        -63,
         // State 56
         0,
         // State 57
-        -61,
-        // State 58
         0,
+        // State 58
+        -51,
         // State 59
-        -73,
+        0,
         // State 60
+        0,
+        // State 61
+        0,
+        // State 62
+        -41,
+        // State 63
+        0,
+        // State 64
+        0,
+        // State 65
+        0,
+        // State 66
+        0,
+        // State 67
+        0,
+        // State 68
+        0,
+        // State 69
+        0,
+        // State 70
+        0,
+        // State 71
         -72,
+        // State 72
+        0,
+        // State 73
+        -70,
+        // State 74
+        -34,
+        // State 75
+        -73,
+        // State 76
+        0,
+        // State 77
+        -35,
+        // State 78
+        0,
+        // State 79
+        0,
+        // State 80
+        -66,
+        // State 81
+        0,
+        // State 82
+        -81,
+        // State 83
+        -80,
+        // State 84
+        -68,
     ];
     fn __goto(state: i8, nt: usize) -> i8 {
         match nt {
-            8 => 10,
+            8 => 15,
             11 => 2,
-            14 => 14,
-            15 => 18,
-            16 => 50,
-            19 => match state {
-                15 => 57,
-                _ => 11,
+            14 => 20,
+            15 => 25,
+            16 => 26,
+            17 => 71,
+            20 => match state {
+                21 => 80,
+                23 => 84,
+                _ => 16,
             },
-            20 => 19,
-            23 => match state {
-                3 => 35,
-                13..=14 => 51,
-                16 => 59,
-                _ => 20,
-            },
+            21 => 27,
             24 => match state {
-                8 => 42,
-                9 => 43,
-                _ => 21,
+                1..=2 => 28,
+                3 => 48,
+                22 => 82,
+                _ => 72,
             },
-            26 => 22,
-            28 => 23,
-            29 => match state {
-                1..=2 => 24,
-                6 => 40,
-                7 | 15 => 41,
-                10 => 45,
-                _ => 36,
+            25 => match state {
+                8 => 54,
+                9 => 55,
+                _ => 29,
             },
+            27 => 30,
+            29 => 31,
             30 => match state {
-                4 => 38,
-                5 => 39,
-                _ => 25,
+                6 => 52,
+                7 | 21 | 23 => 53,
+                10 => 56,
+                11 => 57,
+                12 => 59,
+                13 => 60,
+                14 => 61,
+                15 => 62,
+                _ => 32,
             },
-            31 => 48,
-            32 => 12,
-            33 => 52,
+            31 => match state {
+                4 => 50,
+                5 => 51,
+                _ => 33,
+            },
+            32 => 19,
+            33 => 75,
             34 => 17,
-            35 => match state {
-                2 => 33,
-                _ => 26,
+            35 => 73,
+            36 => 24,
+            37 => match state {
+                2 => 46,
+                _ => 34,
             },
-            37 => 27,
-            38 => match state {
-                14 => 54,
-                _ => 53,
+            39 => 35,
+            40 => match state {
+                20 => 77,
+                _ => 74,
             },
             _ => 0,
         }
@@ -3523,21 +3905,27 @@ mod __parse__Query {
         r###"EQ"###,
         r###"AND"###,
         r###"AS"###,
+        r###"AVG"###,
         r###"BY"###,
+        r###"COUNT"###,
         r###"CREATE"###,
         r###"DELETE"###,
         r###"FROM"###,
+        r###"GROUP"###,
         r###"I32"###,
         r###"INDEX"###,
         r###"INSERT"###,
         r###"INTO"###,
         r###"IS"###,
+        r###"MAX"###,
+        r###"MIN"###,
         r###"MODIFY"###,
         r###"NULL"###,
         r###"ON"###,
         r###"ORDER"###,
         r###"SELECT"###,
         r###"SET"###,
+        r###"SUM"###,
         r###"TABLE"###,
         r###"VALUES"###,
         r###"VARCHAR"###,
@@ -3611,7 +3999,7 @@ mod __parse__Query {
 
         #[inline]
         fn error_action(&self, state: i8) -> i8 {
-            __action(state, 34 - 1)
+            __action(state, 40 - 1)
         }
 
         #[inline]
@@ -3713,6 +4101,12 @@ mod __parse__Query {
             Token(31, _) if true => Some(31),
             Token(32, _) if true => Some(32),
             Token(33, _) if true => Some(33),
+            Token(34, _) if true => Some(34),
+            Token(35, _) if true => Some(35),
+            Token(36, _) if true => Some(36),
+            Token(37, _) if true => Some(37),
+            Token(38, _) if true => Some(38),
+            Token(39, _) if true => Some(39),
             _ => None,
         }
     }
@@ -3725,8 +4119,8 @@ mod __parse__Query {
     ) -> __Symbol<'input>
     {
         #[allow(clippy::manual_range_patterns)]match __token_index {
-            0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20 | 21 | 22 | 23 | 24 | 25 | 26 | 27 | 28 | 29 | 30 | 31 | 32 | 33 => match __token {
-                Token(0, __tok0) | Token(1, __tok0) | Token(2, __tok0) | Token(3, __tok0) | Token(4, __tok0) | Token(5, __tok0) | Token(6, __tok0) | Token(7, __tok0) | Token(8, __tok0) | Token(9, __tok0) | Token(10, __tok0) | Token(11, __tok0) | Token(12, __tok0) | Token(13, __tok0) | Token(14, __tok0) | Token(15, __tok0) | Token(16, __tok0) | Token(17, __tok0) | Token(18, __tok0) | Token(19, __tok0) | Token(20, __tok0) | Token(21, __tok0) | Token(22, __tok0) | Token(23, __tok0) | Token(24, __tok0) | Token(25, __tok0) | Token(26, __tok0) | Token(27, __tok0) | Token(28, __tok0) | Token(29, __tok0) | Token(30, __tok0) | Token(31, __tok0) | Token(32, __tok0) | Token(33, __tok0) if true => __Symbol::Variant0(__tok0),
+            0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20 | 21 | 22 | 23 | 24 | 25 | 26 | 27 | 28 | 29 | 30 | 31 | 32 | 33 | 34 | 35 | 36 | 37 | 38 | 39 => match __token {
+                Token(0, __tok0) | Token(1, __tok0) | Token(2, __tok0) | Token(3, __tok0) | Token(4, __tok0) | Token(5, __tok0) | Token(6, __tok0) | Token(7, __tok0) | Token(8, __tok0) | Token(9, __tok0) | Token(10, __tok0) | Token(11, __tok0) | Token(12, __tok0) | Token(13, __tok0) | Token(14, __tok0) | Token(15, __tok0) | Token(16, __tok0) | Token(17, __tok0) | Token(18, __tok0) | Token(19, __tok0) | Token(20, __tok0) | Token(21, __tok0) | Token(22, __tok0) | Token(23, __tok0) | Token(24, __tok0) | Token(25, __tok0) | Token(26, __tok0) | Token(27, __tok0) | Token(28, __tok0) | Token(29, __tok0) | Token(30, __tok0) | Token(31, __tok0) | Token(32, __tok0) | Token(33, __tok0) | Token(34, __tok0) | Token(35, __tok0) | Token(36, __tok0) | Token(37, __tok0) | Token(38, __tok0) | Token(39, __tok0) if true => __Symbol::Variant0(__tok0),
                 _ => unreachable!(),
             },
             _ => unreachable!(),
@@ -3910,128 +4304,128 @@ mod __parse__Query {
             }
             28 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
+                    states_to_pop: 4,
                     nonterminal_produced: 16,
                 }
             }
             29 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 2,
+                    states_to_pop: 4,
                     nonterminal_produced: 16,
                 }
             }
             30 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 17,
+                    states_to_pop: 4,
+                    nonterminal_produced: 16,
                 }
             }
             31 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 2,
-                    nonterminal_produced: 17,
+                    states_to_pop: 4,
+                    nonterminal_produced: 16,
                 }
             }
             32 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 18,
+                    states_to_pop: 4,
+                    nonterminal_produced: 16,
                 }
             }
             33 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 2,
-                    nonterminal_produced: 18,
+                    states_to_pop: 1,
+                    nonterminal_produced: 17,
                 }
             }
             34 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 19,
+                    states_to_pop: 2,
+                    nonterminal_produced: 17,
                 }
             }
             35 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 2,
-                    nonterminal_produced: 19,
+                    states_to_pop: 1,
+                    nonterminal_produced: 18,
                 }
             }
             36 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 20,
+                    states_to_pop: 2,
+                    nonterminal_produced: 18,
                 }
             }
             37 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 2,
-                    nonterminal_produced: 20,
+                    states_to_pop: 1,
+                    nonterminal_produced: 19,
                 }
             }
             38 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 21,
+                    states_to_pop: 2,
+                    nonterminal_produced: 19,
                 }
             }
             39 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
-                    nonterminal_produced: 21,
+                    nonterminal_produced: 20,
                 }
             }
             40 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 2,
+                    nonterminal_produced: 20,
+                }
+            }
+            41 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
                     nonterminal_produced: 21,
                 }
             }
-            41 => {
-                __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 6,
-                    nonterminal_produced: 22,
-                }
-            }
             42 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 5,
-                    nonterminal_produced: 22,
+                    states_to_pop: 2,
+                    nonterminal_produced: 21,
                 }
             }
             43 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 8,
+                    states_to_pop: 1,
                     nonterminal_produced: 22,
                 }
             }
             44 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
-                    nonterminal_produced: 23,
+                    nonterminal_produced: 22,
                 }
             }
             45 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 3,
-                    nonterminal_produced: 24,
+                    states_to_pop: 1,
+                    nonterminal_produced: 22,
                 }
             }
             46 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 24,
+                    states_to_pop: 6,
+                    nonterminal_produced: 23,
                 }
             }
             47 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 24,
+                    states_to_pop: 5,
+                    nonterminal_produced: 23,
                 }
             }
             48 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 24,
+                    states_to_pop: 8,
+                    nonterminal_produced: 23,
                 }
             }
             49 => {
@@ -4042,170 +4436,170 @@ mod __parse__Query {
             }
             50 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 2,
+                    states_to_pop: 3,
                     nonterminal_produced: 25,
                 }
             }
             51 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
-                    nonterminal_produced: 26,
+                    nonterminal_produced: 25,
                 }
             }
             52 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
-                    nonterminal_produced: 26,
+                    nonterminal_produced: 25,
                 }
             }
             53 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
-                    nonterminal_produced: 27,
+                    nonterminal_produced: 25,
                 }
             }
             54 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 4,
-                    nonterminal_produced: 27,
+                    states_to_pop: 1,
+                    nonterminal_produced: 25,
                 }
             }
             55 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 28,
+                    states_to_pop: 2,
+                    nonterminal_produced: 26,
                 }
             }
             56 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
-                    nonterminal_produced: 29,
+                    nonterminal_produced: 27,
                 }
             }
             57 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 3,
-                    nonterminal_produced: 30,
+                    states_to_pop: 1,
+                    nonterminal_produced: 27,
                 }
             }
             58 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 3,
-                    nonterminal_produced: 30,
+                    states_to_pop: 1,
+                    nonterminal_produced: 28,
                 }
             }
             59 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 4,
+                    nonterminal_produced: 28,
+                }
+            }
+            60 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 1,
+                    nonterminal_produced: 29,
+                }
+            }
+            61 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
                     nonterminal_produced: 30,
                 }
             }
-            60 => {
+            62 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 3,
                     nonterminal_produced: 31,
                 }
             }
-            61 => {
-                __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 0,
-                    nonterminal_produced: 31,
-                }
-            }
-            62 => {
-                __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 2,
-                    nonterminal_produced: 32,
-                }
-            }
             63 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 0,
-                    nonterminal_produced: 32,
+                    states_to_pop: 3,
+                    nonterminal_produced: 31,
                 }
             }
             64 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
-                    nonterminal_produced: 33,
+                    nonterminal_produced: 31,
                 }
             }
             65 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 6,
-                    nonterminal_produced: 34,
+                    states_to_pop: 3,
+                    nonterminal_produced: 32,
                 }
             }
             66 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 3,
-                    nonterminal_produced: 35,
+                    states_to_pop: 0,
+                    nonterminal_produced: 32,
                 }
             }
             67 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 35,
+                    states_to_pop: 3,
+                    nonterminal_produced: 33,
                 }
             }
             68 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 36,
+                    states_to_pop: 0,
+                    nonterminal_produced: 33,
                 }
             }
             69 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 36,
+                    states_to_pop: 2,
+                    nonterminal_produced: 34,
                 }
             }
             70 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 0,
+                    nonterminal_produced: 34,
+                }
+            }
+            71 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 1,
+                    nonterminal_produced: 35,
+                }
+            }
+            72 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 7,
+                    nonterminal_produced: 36,
+                }
+            }
+            73 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 3,
+                    nonterminal_produced: 37,
+                }
+            }
+            74 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
                     nonterminal_produced: 37,
                 }
             }
-            71 => {
-                __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 3,
-                    nonterminal_produced: 38,
-                }
-            }
-            72 => {
-                __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 3,
-                    nonterminal_produced: 38,
-                }
-            }
-            73 => {
-                __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 10,
-                    nonterminal_produced: 39,
-                }
-            }
-            74 => {
-                __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 3,
-                    nonterminal_produced: 39,
-                }
-            }
             75 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 5,
-                    nonterminal_produced: 39,
+                    states_to_pop: 1,
+                    nonterminal_produced: 37,
                 }
             }
             76 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 6,
-                    nonterminal_produced: 39,
+                    states_to_pop: 1,
+                    nonterminal_produced: 38,
                 }
             }
             77 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 8,
-                    nonterminal_produced: 39,
+                    states_to_pop: 1,
+                    nonterminal_produced: 38,
                 }
             }
             78 => {
@@ -4216,27 +4610,75 @@ mod __parse__Query {
             }
             79 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
+                    states_to_pop: 3,
                     nonterminal_produced: 40,
                 }
             }
-            80 => __state_machine::SimulatedReduce::Accept,
+            80 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 3,
+                    nonterminal_produced: 40,
+                }
+            }
             81 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 10,
+                    nonterminal_produced: 41,
+                }
+            }
+            82 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 3,
+                    nonterminal_produced: 41,
+                }
+            }
+            83 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 5,
+                    nonterminal_produced: 41,
+                }
+            }
+            84 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 6,
+                    nonterminal_produced: 41,
+                }
+            }
+            85 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 8,
+                    nonterminal_produced: 41,
+                }
+            }
+            86 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 1,
+                    nonterminal_produced: 41,
+                }
+            }
+            87 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
                     nonterminal_produced: 42,
                 }
             }
-            82 => {
-                __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 43,
-                }
-            }
-            83 => {
+            88 => __state_machine::SimulatedReduce::Accept,
+            89 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
                     nonterminal_produced: 44,
+                }
+            }
+            90 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 1,
+                    nonterminal_produced: 45,
+                }
+            }
+            91 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 1,
+                    nonterminal_produced: 46,
                 }
             }
             _ => panic!("invalid reduction index {}", __reduce_index)
@@ -4561,12 +5003,7 @@ mod __parse__Query {
                 __reduce79(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
             }
             80 => {
-                // __Query = Query => ActionFn(1);
-                let __sym0 = __pop_Variant24(__symbols);
-                let __start = __sym0.0;
-                let __end = __sym0.2;
-                let __nt = super::__action1::<>(input, __sym0);
-                return Some(Ok(__nt));
+                __reduce80(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
             }
             81 => {
                 __reduce81(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
@@ -4576,6 +5013,35 @@ mod __parse__Query {
             }
             83 => {
                 __reduce83(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
+            }
+            84 => {
+                __reduce84(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
+            }
+            85 => {
+                __reduce85(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
+            }
+            86 => {
+                __reduce86(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
+            }
+            87 => {
+                __reduce87(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
+            }
+            88 => {
+                // __Query = Query => ActionFn(1);
+                let __sym0 = __pop_Variant25(__symbols);
+                let __start = __sym0.0;
+                let __end = __sym0.2;
+                let __nt = super::__action1::<>(input, __sym0);
+                return Some(Ok(__nt));
+            }
+            89 => {
+                __reduce89(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
+            }
+            90 => {
+                __reduce90(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
+            }
+            91 => {
+                __reduce91(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
             }
             _ => panic!("invalid action code {}", __action)
         };
@@ -4590,36 +5056,14 @@ mod __parse__Query {
     fn __symbol_type_mismatch() -> ! {
         panic!("symbol type mismatch")
     }
-    fn __pop_Variant7<
+    fn __pop_Variant12<
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, (expression::Expression, Option<String>), usize)
+    ) -> (usize, AggregationFn, usize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant7(__v), __r)) => (__l, __v, __r),
-            _ => __symbol_type_mismatch()
-        }
-    }
-    fn __pop_Variant18<
-      'input,
-    >(
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, Option<Vec<(expression::Expression, Option<String>)>>, usize)
-     {
-        match __symbols.pop() {
-            Some((__l, __Symbol::Variant18(__v), __r)) => (__l, __v, __r),
-            _ => __symbol_type_mismatch()
-        }
-    }
-    fn __pop_Variant21<
-      'input,
-    >(
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, Option<Vec<String>>, usize)
-     {
-        match __symbols.pop() {
-            Some((__l, __Symbol::Variant21(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant12(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -4627,7 +5071,7 @@ mod __parse__Query {
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, Option<predicate::Predicate>, usize)
+    ) -> (usize, Option<Vec<String>>, usize)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant22(__v), __r)) => (__l, __v, __r),
@@ -4638,10 +5082,32 @@ mod __parse__Query {
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, Spec, usize)
+    ) -> (usize, Option<Vec<statement::SelectField>>, usize)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant19(__v), __r)) => (__l, __v, __r),
+            _ => __symbol_type_mismatch()
+        }
+    }
+    fn __pop_Variant23<
+      'input,
+    >(
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
+    ) -> (usize, Option<predicate::Predicate>, usize)
+     {
+        match __symbols.pop() {
+            Some((__l, __Symbol::Variant23(__v), __r)) => (__l, __v, __r),
+            _ => __symbol_type_mismatch()
+        }
+    }
+    fn __pop_Variant20<
+      'input,
+    >(
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
+    ) -> (usize, Spec, usize)
+     {
+        match __symbols.pop() {
+            Some((__l, __Symbol::Variant20(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -4671,43 +5137,10 @@ mod __parse__Query {
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, Vec<(expression::Expression, Option<String>)>, usize)
-     {
-        match __symbols.pop() {
-            Some((__l, __Symbol::Variant16(__v), __r)) => (__l, __v, __r),
-            _ => __symbol_type_mismatch()
-        }
-    }
-    fn __pop_Variant15<
-      'input,
-    >(
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
     ) -> (usize, Vec<String>, usize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant15(__v), __r)) => (__l, __v, __r),
-            _ => __symbol_type_mismatch()
-        }
-    }
-    fn __pop_Variant13<
-      'input,
-    >(
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, Vec<Value>, usize)
-     {
-        match __symbols.pop() {
-            Some((__l, __Symbol::Variant13(__v), __r)) => (__l, __v, __r),
-            _ => __symbol_type_mismatch()
-        }
-    }
-    fn __pop_Variant12<
-      'input,
-    >(
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, Vec<predicate::Term>, usize)
-     {
-        match __symbols.pop() {
-            Some((__l, __Symbol::Variant12(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant16(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -4715,21 +5148,43 @@ mod __parse__Query {
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, Vec<statement::FieldDefinition>, usize)
+    ) -> (usize, Vec<Value>, usize)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant14(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant8<
+    fn __pop_Variant13<
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, alloc::vec::Vec<(expression::Expression, Option<String>)>, usize)
+    ) -> (usize, Vec<predicate::Term>, usize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant8(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant13(__v), __r)) => (__l, __v, __r),
+            _ => __symbol_type_mismatch()
+        }
+    }
+    fn __pop_Variant15<
+      'input,
+    >(
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
+    ) -> (usize, Vec<statement::FieldDefinition>, usize)
+     {
+        match __symbols.pop() {
+            Some((__l, __Symbol::Variant15(__v), __r)) => (__l, __v, __r),
+            _ => __symbol_type_mismatch()
+        }
+    }
+    fn __pop_Variant17<
+      'input,
+    >(
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
+    ) -> (usize, Vec<statement::SelectField>, usize)
+     {
+        match __symbols.pop() {
+            Some((__l, __Symbol::Variant17(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -4777,6 +5232,17 @@ mod __parse__Query {
             _ => __symbol_type_mismatch()
         }
     }
+    fn __pop_Variant8<
+      'input,
+    >(
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
+    ) -> (usize, alloc::vec::Vec<statement::SelectField>, usize)
+     {
+        match __symbols.pop() {
+            Some((__l, __Symbol::Variant8(__v), __r)) => (__l, __v, __r),
+            _ => __symbol_type_mismatch()
+        }
+    }
     fn __pop_Variant11<
       'input,
     >(
@@ -4788,25 +5254,25 @@ mod __parse__Query {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant20<
+    fn __pop_Variant21<
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
     ) -> (usize, i32, usize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant20(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant21(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant23<
+    fn __pop_Variant24<
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
     ) -> (usize, predicate::Predicate, usize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant23(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant24(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -4821,14 +5287,14 @@ mod __parse__Query {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant17<
+    fn __pop_Variant18<
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
     ) -> (usize, statement::CreateCommand, usize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant17(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant18(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -4843,25 +5309,25 @@ mod __parse__Query {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant24<
+    fn __pop_Variant25<
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
     ) -> (usize, statement::QueryData, usize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant24(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant25(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant25<
+    fn __pop_Variant7<
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, statement::Statement, usize)
+    ) -> (usize, statement::SelectField, usize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant25(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant7(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -4869,10 +5335,21 @@ mod __parse__Query {
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, statement::UpdateCommand, usize)
+    ) -> (usize, statement::Statement, usize)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant26(__v), __r)) => (__l, __v, __r),
+            _ => __symbol_type_mismatch()
+        }
+    }
+    fn __pop_Variant27<
+      'input,
+    >(
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
+    ) -> (usize, statement::UpdateCommand, usize)
+     {
+        match __symbols.pop() {
+            Some((__l, __Symbol::Variant27(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -4896,13 +5373,13 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Constant> COMMA) = Constant, COMMA => ActionFn(62);
+        // (<Constant> COMMA) = Constant, COMMA => ActionFn(70);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant1(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action62::<>(input, __sym0, __sym1);
+        let __nt = super::__action70::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant1(__nt), __end));
         (2, 0)
     }
@@ -4915,10 +5392,10 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Constant> COMMA)* =  => ActionFn(60);
+        // (<Constant> COMMA)* =  => ActionFn(68);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action60::<>(input, &__start, &__end);
+        let __nt = super::__action68::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant2(__nt), __end));
         (0, 1)
     }
@@ -4931,11 +5408,11 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Constant> COMMA)* = (<Constant> COMMA)+ => ActionFn(61);
+        // (<Constant> COMMA)* = (<Constant> COMMA)+ => ActionFn(69);
         let __sym0 = __pop_Variant2(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action61::<>(input, __sym0);
+        let __nt = super::__action69::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant2(__nt), __end));
         (1, 1)
     }
@@ -4948,13 +5425,13 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Constant> COMMA)+ = Constant, COMMA => ActionFn(79);
+        // (<Constant> COMMA)+ = Constant, COMMA => ActionFn(87);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant1(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action79::<>(input, __sym0, __sym1);
+        let __nt = super::__action87::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant2(__nt), __end));
         (2, 2)
     }
@@ -4967,14 +5444,14 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Constant> COMMA)+ = (<Constant> COMMA)+, Constant, COMMA => ActionFn(80);
+        // (<Constant> COMMA)+ = (<Constant> COMMA)+, Constant, COMMA => ActionFn(88);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant1(__symbols);
         let __sym0 = __pop_Variant2(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action80::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action88::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant2(__nt), __end));
         (3, 2)
     }
@@ -4987,13 +5464,13 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<FieldDefinition> COMMA) = FieldDefinition, COMMA => ActionFn(65);
+        // (<FieldDefinition> COMMA) = FieldDefinition, COMMA => ActionFn(73);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant3(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action65::<>(input, __sym0, __sym1);
+        let __nt = super::__action73::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant3(__nt), __end));
         (2, 3)
     }
@@ -5006,10 +5483,10 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<FieldDefinition> COMMA)* =  => ActionFn(63);
+        // (<FieldDefinition> COMMA)* =  => ActionFn(71);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action63::<>(input, &__start, &__end);
+        let __nt = super::__action71::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant4(__nt), __end));
         (0, 4)
     }
@@ -5022,11 +5499,11 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<FieldDefinition> COMMA)* = (<FieldDefinition> COMMA)+ => ActionFn(64);
+        // (<FieldDefinition> COMMA)* = (<FieldDefinition> COMMA)+ => ActionFn(72);
         let __sym0 = __pop_Variant4(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action64::<>(input, __sym0);
+        let __nt = super::__action72::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant4(__nt), __end));
         (1, 4)
     }
@@ -5039,13 +5516,13 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<FieldDefinition> COMMA)+ = FieldDefinition, COMMA => ActionFn(83);
+        // (<FieldDefinition> COMMA)+ = FieldDefinition, COMMA => ActionFn(91);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant3(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action83::<>(input, __sym0, __sym1);
+        let __nt = super::__action91::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant4(__nt), __end));
         (2, 5)
     }
@@ -5058,14 +5535,14 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<FieldDefinition> COMMA)+ = (<FieldDefinition> COMMA)+, FieldDefinition, COMMA => ActionFn(84);
+        // (<FieldDefinition> COMMA)+ = (<FieldDefinition> COMMA)+, FieldDefinition, COMMA => ActionFn(92);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant3(__symbols);
         let __sym0 = __pop_Variant4(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action84::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action92::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant4(__nt), __end));
         (3, 5)
     }
@@ -5078,13 +5555,13 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<IdToken> COMMA) = IdToken, COMMA => ActionFn(56);
+        // (<IdToken> COMMA) = IdToken, COMMA => ActionFn(64);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action56::<>(input, __sym0, __sym1);
+        let __nt = super::__action64::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant5(__nt), __end));
         (2, 6)
     }
@@ -5097,10 +5574,10 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<IdToken> COMMA)* =  => ActionFn(54);
+        // (<IdToken> COMMA)* =  => ActionFn(62);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action54::<>(input, &__start, &__end);
+        let __nt = super::__action62::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant6(__nt), __end));
         (0, 7)
     }
@@ -5113,11 +5590,11 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<IdToken> COMMA)* = (<IdToken> COMMA)+ => ActionFn(55);
+        // (<IdToken> COMMA)* = (<IdToken> COMMA)+ => ActionFn(63);
         let __sym0 = __pop_Variant6(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action55::<>(input, __sym0);
+        let __nt = super::__action63::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant6(__nt), __end));
         (1, 7)
     }
@@ -5130,13 +5607,13 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<IdToken> COMMA)+ = IdToken, COMMA => ActionFn(87);
+        // (<IdToken> COMMA)+ = IdToken, COMMA => ActionFn(95);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action87::<>(input, __sym0, __sym1);
+        let __nt = super::__action95::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant6(__nt), __end));
         (2, 8)
     }
@@ -5149,14 +5626,14 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<IdToken> COMMA)+ = (<IdToken> COMMA)+, IdToken, COMMA => ActionFn(88);
+        // (<IdToken> COMMA)+ = (<IdToken> COMMA)+, IdToken, COMMA => ActionFn(96);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant5(__symbols);
         let __sym0 = __pop_Variant6(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action88::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action96::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant6(__nt), __end));
         (3, 8)
     }
@@ -5169,13 +5646,13 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<SelectField> COMMA) = SelectField, COMMA => ActionFn(59);
+        // (<SelectField> COMMA) = SelectField, COMMA => ActionFn(67);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant7(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action59::<>(input, __sym0, __sym1);
+        let __nt = super::__action67::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant7(__nt), __end));
         (2, 9)
     }
@@ -5188,10 +5665,10 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<SelectField> COMMA)* =  => ActionFn(57);
+        // (<SelectField> COMMA)* =  => ActionFn(65);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action57::<>(input, &__start, &__end);
+        let __nt = super::__action65::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant8(__nt), __end));
         (0, 10)
     }
@@ -5204,11 +5681,11 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<SelectField> COMMA)* = (<SelectField> COMMA)+ => ActionFn(58);
+        // (<SelectField> COMMA)* = (<SelectField> COMMA)+ => ActionFn(66);
         let __sym0 = __pop_Variant8(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action58::<>(input, __sym0);
+        let __nt = super::__action66::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant8(__nt), __end));
         (1, 10)
     }
@@ -5221,13 +5698,13 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<SelectField> COMMA)+ = SelectField, COMMA => ActionFn(91);
+        // (<SelectField> COMMA)+ = SelectField, COMMA => ActionFn(99);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant7(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action91::<>(input, __sym0, __sym1);
+        let __nt = super::__action99::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant8(__nt), __end));
         (2, 11)
     }
@@ -5240,14 +5717,14 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<SelectField> COMMA)+ = (<SelectField> COMMA)+, SelectField, COMMA => ActionFn(92);
+        // (<SelectField> COMMA)+ = (<SelectField> COMMA)+, SelectField, COMMA => ActionFn(100);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant7(__symbols);
         let __sym0 = __pop_Variant8(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action92::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action100::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant8(__nt), __end));
         (3, 11)
     }
@@ -5260,13 +5737,13 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Term> AND) = Term, AND => ActionFn(68);
+        // (<Term> AND) = Term, AND => ActionFn(76);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant9(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action68::<>(input, __sym0, __sym1);
+        let __nt = super::__action76::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant9(__nt), __end));
         (2, 12)
     }
@@ -5279,10 +5756,10 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Term> AND)* =  => ActionFn(66);
+        // (<Term> AND)* =  => ActionFn(74);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action66::<>(input, &__start, &__end);
+        let __nt = super::__action74::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant10(__nt), __end));
         (0, 13)
     }
@@ -5295,11 +5772,11 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Term> AND)* = (<Term> AND)+ => ActionFn(67);
+        // (<Term> AND)* = (<Term> AND)+ => ActionFn(75);
         let __sym0 = __pop_Variant10(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action67::<>(input, __sym0);
+        let __nt = super::__action75::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant10(__nt), __end));
         (1, 13)
     }
@@ -5312,13 +5789,13 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Term> AND)+ = Term, AND => ActionFn(95);
+        // (<Term> AND)+ = Term, AND => ActionFn(103);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant9(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action95::<>(input, __sym0, __sym1);
+        let __nt = super::__action103::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant10(__nt), __end));
         (2, 14)
     }
@@ -5331,14 +5808,14 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Term> AND)+ = (<Term> AND)+, Term, AND => ActionFn(96);
+        // (<Term> AND)+ = (<Term> AND)+, Term, AND => ActionFn(104);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant9(__symbols);
         let __sym0 = __pop_Variant10(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action96::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action104::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant10(__nt), __end));
         (3, 14)
     }
@@ -5351,14 +5828,14 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AddExpr = AddExpr, PLUS, MulExpr => ActionFn(32);
+        // AddExpr = AddExpr, PLUS, MulExpr => ActionFn(40);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant11(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action32::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action40::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (3, 15)
     }
@@ -5371,14 +5848,14 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AddExpr = AddExpr, MINUS, MulExpr => ActionFn(33);
+        // AddExpr = AddExpr, MINUS, MulExpr => ActionFn(41);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant11(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action33::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action41::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (3, 15)
     }
@@ -5391,11 +5868,11 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AddExpr = MulExpr => ActionFn(34);
+        // AddExpr = MulExpr => ActionFn(42);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action34::<>(input, __sym0);
+        let __nt = super::__action42::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (1, 15)
     }
@@ -5408,13 +5885,17 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // And<Term> = Term => ActionFn(97);
-        let __sym0 = __pop_Variant9(__symbols);
+        // AggregationFn = MAX, LPAREN, IdToken, RPAREN => ActionFn(13);
+        assert!(__symbols.len() >= 4);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action97::<>(input, __sym0);
+        let __end = __sym3.2;
+        let __nt = super::__action13::<>(input, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant12(__nt), __end));
-        (1, 16)
+        (4, 16)
     }
     fn __reduce29<
         'input,
@@ -5425,15 +5906,17 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // And<Term> = (<Term> AND)+, Term => ActionFn(98);
-        assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant9(__symbols);
-        let __sym0 = __pop_Variant10(__symbols);
+        // AggregationFn = MIN, LPAREN, IdToken, RPAREN => ActionFn(14);
+        assert!(__symbols.len() >= 4);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym1.2;
-        let __nt = super::__action98::<>(input, __sym0, __sym1);
+        let __end = __sym3.2;
+        let __nt = super::__action14::<>(input, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant12(__nt), __end));
-        (2, 16)
+        (4, 16)
     }
     fn __reduce30<
         'input,
@@ -5444,13 +5927,17 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<Constant> = Constant => ActionFn(81);
-        let __sym0 = __pop_Variant1(__symbols);
+        // AggregationFn = SUM, LPAREN, IdToken, RPAREN => ActionFn(15);
+        assert!(__symbols.len() >= 4);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action81::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant13(__nt), __end));
-        (1, 17)
+        let __end = __sym3.2;
+        let __nt = super::__action15::<>(input, __sym0, __sym1, __sym2, __sym3);
+        __symbols.push((__start, __Symbol::Variant12(__nt), __end));
+        (4, 16)
     }
     fn __reduce31<
         'input,
@@ -5461,15 +5948,17 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<Constant> = (<Constant> COMMA)+, Constant => ActionFn(82);
-        assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant1(__symbols);
-        let __sym0 = __pop_Variant2(__symbols);
+        // AggregationFn = COUNT, LPAREN, IdToken, RPAREN => ActionFn(16);
+        assert!(__symbols.len() >= 4);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym1.2;
-        let __nt = super::__action82::<>(input, __sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant13(__nt), __end));
-        (2, 17)
+        let __end = __sym3.2;
+        let __nt = super::__action16::<>(input, __sym0, __sym1, __sym2, __sym3);
+        __symbols.push((__start, __Symbol::Variant12(__nt), __end));
+        (4, 16)
     }
     fn __reduce32<
         'input,
@@ -5480,13 +5969,17 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<FieldDefinition> = FieldDefinition => ActionFn(85);
-        let __sym0 = __pop_Variant3(__symbols);
+        // AggregationFn = AVG, LPAREN, IdToken, RPAREN => ActionFn(17);
+        assert!(__symbols.len() >= 4);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action85::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant14(__nt), __end));
-        (1, 18)
+        let __end = __sym3.2;
+        let __nt = super::__action17::<>(input, __sym0, __sym1, __sym2, __sym3);
+        __symbols.push((__start, __Symbol::Variant12(__nt), __end));
+        (4, 16)
     }
     fn __reduce33<
         'input,
@@ -5497,15 +5990,13 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<FieldDefinition> = (<FieldDefinition> COMMA)+, FieldDefinition => ActionFn(86);
-        assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant3(__symbols);
-        let __sym0 = __pop_Variant4(__symbols);
+        // And<Term> = Term => ActionFn(105);
+        let __sym0 = __pop_Variant9(__symbols);
         let __start = __sym0.0;
-        let __end = __sym1.2;
-        let __nt = super::__action86::<>(input, __sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant14(__nt), __end));
-        (2, 18)
+        let __end = __sym0.2;
+        let __nt = super::__action105::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant13(__nt), __end));
+        (1, 17)
     }
     fn __reduce34<
         'input,
@@ -5516,13 +6007,15 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<IdToken> = IdToken => ActionFn(89);
-        let __sym0 = __pop_Variant5(__symbols);
+        // And<Term> = (<Term> AND)+, Term => ActionFn(106);
+        assert!(__symbols.len() >= 2);
+        let __sym1 = __pop_Variant9(__symbols);
+        let __sym0 = __pop_Variant10(__symbols);
         let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action89::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant15(__nt), __end));
-        (1, 19)
+        let __end = __sym1.2;
+        let __nt = super::__action106::<>(input, __sym0, __sym1);
+        __symbols.push((__start, __Symbol::Variant13(__nt), __end));
+        (2, 17)
     }
     fn __reduce35<
         'input,
@@ -5533,15 +6026,13 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<IdToken> = (<IdToken> COMMA)+, IdToken => ActionFn(90);
-        assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant5(__symbols);
-        let __sym0 = __pop_Variant6(__symbols);
+        // Comma<Constant> = Constant => ActionFn(89);
+        let __sym0 = __pop_Variant1(__symbols);
         let __start = __sym0.0;
-        let __end = __sym1.2;
-        let __nt = super::__action90::<>(input, __sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant15(__nt), __end));
-        (2, 19)
+        let __end = __sym0.2;
+        let __nt = super::__action89::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant14(__nt), __end));
+        (1, 18)
     }
     fn __reduce36<
         'input,
@@ -5552,13 +6043,15 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<SelectField> = SelectField => ActionFn(93);
-        let __sym0 = __pop_Variant7(__symbols);
+        // Comma<Constant> = (<Constant> COMMA)+, Constant => ActionFn(90);
+        assert!(__symbols.len() >= 2);
+        let __sym1 = __pop_Variant1(__symbols);
+        let __sym0 = __pop_Variant2(__symbols);
         let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action93::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant16(__nt), __end));
-        (1, 20)
+        let __end = __sym1.2;
+        let __nt = super::__action90::<>(input, __sym0, __sym1);
+        __symbols.push((__start, __Symbol::Variant14(__nt), __end));
+        (2, 18)
     }
     fn __reduce37<
         'input,
@@ -5569,15 +6062,13 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<SelectField> = (<SelectField> COMMA)+, SelectField => ActionFn(94);
-        assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant7(__symbols);
-        let __sym0 = __pop_Variant8(__symbols);
+        // Comma<FieldDefinition> = FieldDefinition => ActionFn(93);
+        let __sym0 = __pop_Variant3(__symbols);
         let __start = __sym0.0;
-        let __end = __sym1.2;
-        let __nt = super::__action94::<>(input, __sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant16(__nt), __end));
-        (2, 20)
+        let __end = __sym0.2;
+        let __nt = super::__action93::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant15(__nt), __end));
+        (1, 19)
     }
     fn __reduce38<
         'input,
@@ -5588,13 +6079,15 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Constant = NULL => ActionFn(43);
-        let __sym0 = __pop_Variant0(__symbols);
+        // Comma<FieldDefinition> = (<FieldDefinition> COMMA)+, FieldDefinition => ActionFn(94);
+        assert!(__symbols.len() >= 2);
+        let __sym1 = __pop_Variant3(__symbols);
+        let __sym0 = __pop_Variant4(__symbols);
         let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action43::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant1(__nt), __end));
-        (1, 21)
+        let __end = __sym1.2;
+        let __nt = super::__action94::<>(input, __sym0, __sym1);
+        __symbols.push((__start, __Symbol::Variant15(__nt), __end));
+        (2, 19)
     }
     fn __reduce39<
         'input,
@@ -5605,13 +6098,13 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Constant = I32Constant => ActionFn(44);
-        let __sym0 = __pop_Variant20(__symbols);
+        // Comma<IdToken> = IdToken => ActionFn(97);
+        let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action44::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant1(__nt), __end));
-        (1, 21)
+        let __nt = super::__action97::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant16(__nt), __end));
+        (1, 20)
     }
     fn __reduce40<
         'input,
@@ -5622,13 +6115,15 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Constant = StringConstant => ActionFn(45);
-        let __sym0 = __pop_Variant5(__symbols);
+        // Comma<IdToken> = (<IdToken> COMMA)+, IdToken => ActionFn(98);
+        assert!(__symbols.len() >= 2);
+        let __sym1 = __pop_Variant5(__symbols);
+        let __sym0 = __pop_Variant6(__symbols);
         let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action45::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant1(__nt), __end));
-        (1, 21)
+        let __end = __sym1.2;
+        let __nt = super::__action98::<>(input, __sym0, __sym1);
+        __symbols.push((__start, __Symbol::Variant16(__nt), __end));
+        (2, 20)
     }
     fn __reduce41<
         'input,
@@ -5639,19 +6134,13 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // CreateCommand = CREATE, TABLE, IdToken, LPAREN, Comma<FieldDefinition>, RPAREN => ActionFn(22);
-        assert!(__symbols.len() >= 6);
-        let __sym5 = __pop_Variant0(__symbols);
-        let __sym4 = __pop_Variant14(__symbols);
-        let __sym3 = __pop_Variant0(__symbols);
-        let __sym2 = __pop_Variant5(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
+        // Comma<SelectField> = SelectField => ActionFn(101);
+        let __sym0 = __pop_Variant7(__symbols);
         let __start = __sym0.0;
-        let __end = __sym5.2;
-        let __nt = super::__action22::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
+        let __end = __sym0.2;
+        let __nt = super::__action101::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant17(__nt), __end));
-        (6, 22)
+        (1, 21)
     }
     fn __reduce42<
         'input,
@@ -5662,18 +6151,15 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // CreateCommand = CREATE, VIEW, IdToken, AS, Query => ActionFn(23);
-        assert!(__symbols.len() >= 5);
-        let __sym4 = __pop_Variant24(__symbols);
-        let __sym3 = __pop_Variant0(__symbols);
-        let __sym2 = __pop_Variant5(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
+        // Comma<SelectField> = (<SelectField> COMMA)+, SelectField => ActionFn(102);
+        assert!(__symbols.len() >= 2);
+        let __sym1 = __pop_Variant7(__symbols);
+        let __sym0 = __pop_Variant8(__symbols);
         let __start = __sym0.0;
-        let __end = __sym4.2;
-        let __nt = super::__action23::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4);
+        let __end = __sym1.2;
+        let __nt = super::__action102::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant17(__nt), __end));
-        (5, 22)
+        (2, 21)
     }
     fn __reduce43<
         'input,
@@ -5684,7 +6170,103 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // CreateCommand = CREATE, INDEX, IdToken, ON, IdToken, LPAREN, IdToken, RPAREN => ActionFn(24);
+        // Constant = NULL => ActionFn(51);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action51::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant1(__nt), __end));
+        (1, 22)
+    }
+    fn __reduce44<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // Constant = I32Constant => ActionFn(52);
+        let __sym0 = __pop_Variant21(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action52::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant1(__nt), __end));
+        (1, 22)
+    }
+    fn __reduce45<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // Constant = StringConstant => ActionFn(53);
+        let __sym0 = __pop_Variant5(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action53::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant1(__nt), __end));
+        (1, 22)
+    }
+    fn __reduce46<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // CreateCommand = CREATE, TABLE, IdToken, LPAREN, Comma<FieldDefinition>, RPAREN => ActionFn(30);
+        assert!(__symbols.len() >= 6);
+        let __sym5 = __pop_Variant0(__symbols);
+        let __sym4 = __pop_Variant15(__symbols);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym5.2;
+        let __nt = super::__action30::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
+        __symbols.push((__start, __Symbol::Variant18(__nt), __end));
+        (6, 23)
+    }
+    fn __reduce47<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // CreateCommand = CREATE, VIEW, IdToken, AS, Query => ActionFn(31);
+        assert!(__symbols.len() >= 5);
+        let __sym4 = __pop_Variant25(__symbols);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym4.2;
+        let __nt = super::__action31::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4);
+        __symbols.push((__start, __Symbol::Variant18(__nt), __end));
+        (5, 23)
+    }
+    fn __reduce48<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // CreateCommand = CREATE, INDEX, IdToken, ON, IdToken, LPAREN, IdToken, RPAREN => ActionFn(32);
         assert!(__symbols.len() >= 8);
         let __sym7 = __pop_Variant0(__symbols);
         let __sym6 = __pop_Variant5(__symbols);
@@ -5696,97 +6278,9 @@ mod __parse__Query {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym7.2;
-        let __nt = super::__action24::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
-        __symbols.push((__start, __Symbol::Variant17(__nt), __end));
-        (8, 22)
-    }
-    fn __reduce44<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // Expression = AddExpr => ActionFn(31);
-        let __sym0 = __pop_Variant11(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action31::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
-        (1, 23)
-    }
-    fn __reduce45<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // Factor = LPAREN, Expression, RPAREN => ActionFn(38);
-        assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant11(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym2.2;
-        let __nt = super::__action38::<>(input, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
-        (3, 24)
-    }
-    fn __reduce46<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // Factor = NULL => ActionFn(39);
-        let __sym0 = __pop_Variant0(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action39::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
-        (1, 24)
-    }
-    fn __reduce47<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // Factor = I32Constant => ActionFn(40);
-        let __sym0 = __pop_Variant20(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action40::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
-        (1, 24)
-    }
-    fn __reduce48<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // Factor = StringConstant => ActionFn(41);
-        let __sym0 = __pop_Variant5(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action41::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
-        (1, 24)
+        let __nt = super::__action32::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
+        __symbols.push((__start, __Symbol::Variant18(__nt), __end));
+        (8, 23)
     }
     fn __reduce49<
         'input,
@@ -5797,11 +6291,11 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Factor = IdToken => ActionFn(42);
-        let __sym0 = __pop_Variant5(__symbols);
+        // Expression = AddExpr => ActionFn(39);
+        let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action42::<>(input, __sym0);
+        let __nt = super::__action39::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (1, 24)
     }
@@ -5814,17 +6308,105 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // FieldDefinition = IdToken, FieldType => ActionFn(25);
+        // Factor = LPAREN, Expression, RPAREN => ActionFn(46);
+        assert!(__symbols.len() >= 3);
+        let __sym2 = __pop_Variant0(__symbols);
+        let __sym1 = __pop_Variant11(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym2.2;
+        let __nt = super::__action46::<>(input, __sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
+        (3, 25)
+    }
+    fn __reduce51<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // Factor = NULL => ActionFn(47);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action47::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
+        (1, 25)
+    }
+    fn __reduce52<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // Factor = I32Constant => ActionFn(48);
+        let __sym0 = __pop_Variant21(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action48::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
+        (1, 25)
+    }
+    fn __reduce53<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // Factor = StringConstant => ActionFn(49);
+        let __sym0 = __pop_Variant5(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action49::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
+        (1, 25)
+    }
+    fn __reduce54<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // Factor = IdToken => ActionFn(50);
+        let __sym0 = __pop_Variant5(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action50::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
+        (1, 25)
+    }
+    fn __reduce55<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // FieldDefinition = IdToken, FieldType => ActionFn(33);
         assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant19(__symbols);
+        let __sym1 = __pop_Variant20(__symbols);
         let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action25::<>(input, __sym0, __sym1);
+        let __nt = super::__action33::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant3(__nt), __end));
-        (2, 25)
+        (2, 26)
     }
-    fn __reduce51<
+    fn __reduce56<
         'input,
     >(
         input: &'input str,
@@ -5838,97 +6420,8 @@ mod __parse__Query {
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action8::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant18(__nt), __end));
-        (1, 26)
-    }
-    fn __reduce52<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // FieldList = Comma<SelectField> => ActionFn(9);
-        let __sym0 = __pop_Variant16(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action9::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant18(__nt), __end));
-        (1, 26)
-    }
-    fn __reduce53<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // FieldType = I32 => ActionFn(26);
-        let __sym0 = __pop_Variant0(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action26::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant19(__nt), __end));
         (1, 27)
-    }
-    fn __reduce54<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // FieldType = VARCHAR, LPAREN, I32Constant, RPAREN => ActionFn(27);
-        assert!(__symbols.len() >= 4);
-        let __sym3 = __pop_Variant0(__symbols);
-        let __sym2 = __pop_Variant20(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym3.2;
-        let __nt = super::__action27::<>(input, __sym0, __sym1, __sym2, __sym3);
-        __symbols.push((__start, __Symbol::Variant19(__nt), __end));
-        (4, 27)
-    }
-    fn __reduce55<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // I32Constant = I32_LITERAL => ActionFn(46);
-        let __sym0 = __pop_Variant0(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action46::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant20(__nt), __end));
-        (1, 28)
-    }
-    fn __reduce56<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // IdToken = ID => ActionFn(48);
-        let __sym0 = __pop_Variant0(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action48::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant5(__nt), __end));
-        (1, 29)
     }
     fn __reduce57<
         'input,
@@ -5939,16 +6432,13 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // MulExpr = MulExpr, STAR, Factor => ActionFn(35);
-        assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant11(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant11(__symbols);
+        // FieldList = Comma<SelectField> => ActionFn(9);
+        let __sym0 = __pop_Variant17(__symbols);
         let __start = __sym0.0;
-        let __end = __sym2.2;
-        let __nt = super::__action35::<>(input, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
-        (3, 30)
+        let __end = __sym0.2;
+        let __nt = super::__action9::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant19(__nt), __end));
+        (1, 27)
     }
     fn __reduce58<
         'input,
@@ -5959,16 +6449,13 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // MulExpr = MulExpr, SLASH, Factor => ActionFn(36);
-        assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant11(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant11(__symbols);
+        // FieldType = I32 => ActionFn(34);
+        let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym2.2;
-        let __nt = super::__action36::<>(input, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
-        (3, 30)
+        let __end = __sym0.2;
+        let __nt = super::__action34::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant20(__nt), __end));
+        (1, 28)
     }
     fn __reduce59<
         'input,
@@ -5979,13 +6466,17 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // MulExpr = Factor => ActionFn(37);
-        let __sym0 = __pop_Variant11(__symbols);
+        // FieldType = VARCHAR, LPAREN, I32Constant, RPAREN => ActionFn(35);
+        assert!(__symbols.len() >= 4);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant21(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action37::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
-        (1, 30)
+        let __end = __sym3.2;
+        let __nt = super::__action35::<>(input, __sym0, __sym1, __sym2, __sym3);
+        __symbols.push((__start, __Symbol::Variant20(__nt), __end));
+        (4, 28)
     }
     fn __reduce60<
         'input,
@@ -5996,16 +6487,13 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // OptOrderBy = ORDER, BY, Comma<IdToken> => ActionFn(14);
-        assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant15(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
+        // I32Constant = I32_LITERAL => ActionFn(54);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym2.2;
-        let __nt = super::__action14::<>(input, __sym0, __sym1, __sym2);
+        let __end = __sym0.2;
+        let __nt = super::__action54::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant21(__nt), __end));
-        (3, 31)
+        (1, 29)
     }
     fn __reduce61<
         'input,
@@ -6016,12 +6504,13 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // OptOrderBy =  => ActionFn(15);
-        let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
-        let __end = __start;
-        let __nt = super::__action15::<>(input, &__start, &__end);
-        __symbols.push((__start, __Symbol::Variant21(__nt), __end));
-        (0, 31)
+        // IdToken = ID => ActionFn(56);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action56::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant5(__nt), __end));
+        (1, 30)
     }
     fn __reduce62<
         'input,
@@ -6032,15 +6521,16 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // OptPredicate = WHERE, Predicate => ActionFn(12);
-        assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant23(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
+        // MulExpr = MulExpr, STAR, Factor => ActionFn(43);
+        assert!(__symbols.len() >= 3);
+        let __sym2 = __pop_Variant11(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
-        let __end = __sym1.2;
-        let __nt = super::__action12::<>(input, __sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant22(__nt), __end));
-        (2, 32)
+        let __end = __sym2.2;
+        let __nt = super::__action43::<>(input, __sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
+        (3, 31)
     }
     fn __reduce63<
         'input,
@@ -6051,12 +6541,16 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // OptPredicate =  => ActionFn(13);
-        let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
-        let __end = __start;
-        let __nt = super::__action13::<>(input, &__start, &__end);
-        __symbols.push((__start, __Symbol::Variant22(__nt), __end));
-        (0, 32)
+        // MulExpr = MulExpr, SLASH, Factor => ActionFn(44);
+        assert!(__symbols.len() >= 3);
+        let __sym2 = __pop_Variant11(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant11(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym2.2;
+        let __nt = super::__action44::<>(input, __sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
+        (3, 31)
     }
     fn __reduce64<
         'input,
@@ -6067,13 +6561,13 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Predicate = And<Term> => ActionFn(28);
-        let __sym0 = __pop_Variant12(__symbols);
+        // MulExpr = Factor => ActionFn(45);
+        let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action28::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant23(__nt), __end));
-        (1, 33)
+        let __nt = super::__action45::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
+        (1, 31)
     }
     fn __reduce65<
         'input,
@@ -6084,21 +6578,146 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Query = SELECT, FieldList, FROM, Comma<IdToken>, OptPredicate, OptOrderBy => ActionFn(7);
-        assert!(__symbols.len() >= 6);
-        let __sym5 = __pop_Variant21(__symbols);
-        let __sym4 = __pop_Variant22(__symbols);
-        let __sym3 = __pop_Variant15(__symbols);
-        let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant18(__symbols);
+        // OptGroupBy = GROUP, BY, Comma<IdToken> => ActionFn(20);
+        assert!(__symbols.len() >= 3);
+        let __sym2 = __pop_Variant16(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym5.2;
-        let __nt = super::__action7::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
-        __symbols.push((__start, __Symbol::Variant24(__nt), __end));
-        (6, 34)
+        let __end = __sym2.2;
+        let __nt = super::__action20::<>(input, __sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant22(__nt), __end));
+        (3, 32)
     }
     fn __reduce66<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // OptGroupBy =  => ActionFn(21);
+        let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
+        let __end = __start;
+        let __nt = super::__action21::<>(input, &__start, &__end);
+        __symbols.push((__start, __Symbol::Variant22(__nt), __end));
+        (0, 32)
+    }
+    fn __reduce67<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // OptOrderBy = ORDER, BY, Comma<IdToken> => ActionFn(22);
+        assert!(__symbols.len() >= 3);
+        let __sym2 = __pop_Variant16(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym2.2;
+        let __nt = super::__action22::<>(input, __sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant22(__nt), __end));
+        (3, 33)
+    }
+    fn __reduce68<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // OptOrderBy =  => ActionFn(23);
+        let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
+        let __end = __start;
+        let __nt = super::__action23::<>(input, &__start, &__end);
+        __symbols.push((__start, __Symbol::Variant22(__nt), __end));
+        (0, 33)
+    }
+    fn __reduce69<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // OptPredicate = WHERE, Predicate => ActionFn(18);
+        assert!(__symbols.len() >= 2);
+        let __sym1 = __pop_Variant24(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym1.2;
+        let __nt = super::__action18::<>(input, __sym0, __sym1);
+        __symbols.push((__start, __Symbol::Variant23(__nt), __end));
+        (2, 34)
+    }
+    fn __reduce70<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // OptPredicate =  => ActionFn(19);
+        let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
+        let __end = __start;
+        let __nt = super::__action19::<>(input, &__start, &__end);
+        __symbols.push((__start, __Symbol::Variant23(__nt), __end));
+        (0, 34)
+    }
+    fn __reduce71<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // Predicate = And<Term> => ActionFn(36);
+        let __sym0 = __pop_Variant13(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action36::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant24(__nt), __end));
+        (1, 35)
+    }
+    fn __reduce72<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // Query = SELECT, FieldList, FROM, Comma<IdToken>, OptPredicate, OptGroupBy, OptOrderBy => ActionFn(7);
+        assert!(__symbols.len() >= 7);
+        let __sym6 = __pop_Variant22(__symbols);
+        let __sym5 = __pop_Variant22(__symbols);
+        let __sym4 = __pop_Variant23(__symbols);
+        let __sym3 = __pop_Variant16(__symbols);
+        let __sym2 = __pop_Variant0(__symbols);
+        let __sym1 = __pop_Variant19(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym6.2;
+        let __nt = super::__action7::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6);
+        __symbols.push((__start, __Symbol::Variant25(__nt), __end));
+        (7, 36)
+    }
+    fn __reduce73<
         'input,
     >(
         input: &'input str,
@@ -6116,142 +6735,7 @@ mod __parse__Query {
         let __end = __sym2.2;
         let __nt = super::__action10::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant7(__nt), __end));
-        (3, 35)
-    }
-    fn __reduce67<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // SelectField = IdToken => ActionFn(11);
-        let __sym0 = __pop_Variant5(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action11::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant7(__nt), __end));
-        (1, 35)
-    }
-    fn __reduce68<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // Statement = Query => ActionFn(5);
-        let __sym0 = __pop_Variant24(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action5::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant25(__nt), __end));
-        (1, 36)
-    }
-    fn __reduce69<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // Statement = UpdateCommand => ActionFn(6);
-        let __sym0 = __pop_Variant26(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action6::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant25(__nt), __end));
-        (1, 36)
-    }
-    fn __reduce70<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // StringConstant = STRING_LITERAL => ActionFn(47);
-        let __sym0 = __pop_Variant0(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action47::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant5(__nt), __end));
-        (1, 37)
-    }
-    fn __reduce71<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // Term = Expression, IS, NULL => ActionFn(29);
-        assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant11(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym2.2;
-        let __nt = super::__action29::<>(input, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant9(__nt), __end));
-        (3, 38)
-    }
-    fn __reduce72<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // Term = Expression, EQ, Expression => ActionFn(30);
-        assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant11(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant11(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym2.2;
-        let __nt = super::__action30::<>(input, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant9(__nt), __end));
-        (3, 38)
-    }
-    fn __reduce73<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // UpdateCommand = INSERT, INTO, IdToken, LPAREN, Comma<IdToken>, RPAREN, VALUES, LPAREN, Comma<Constant>, RPAREN => ActionFn(16);
-        assert!(__symbols.len() >= 10);
-        let __sym9 = __pop_Variant0(__symbols);
-        let __sym8 = __pop_Variant13(__symbols);
-        let __sym7 = __pop_Variant0(__symbols);
-        let __sym6 = __pop_Variant0(__symbols);
-        let __sym5 = __pop_Variant0(__symbols);
-        let __sym4 = __pop_Variant15(__symbols);
-        let __sym3 = __pop_Variant0(__symbols);
-        let __sym2 = __pop_Variant5(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym9.2;
-        let __nt = super::__action16::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9);
-        __symbols.push((__start, __Symbol::Variant26(__nt), __end));
-        (10, 39)
+        (3, 37)
     }
     fn __reduce74<
         'input,
@@ -6262,16 +6746,13 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // UpdateCommand = DELETE, FROM, IdToken => ActionFn(17);
-        assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant5(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
+        // SelectField = Expression => ActionFn(11);
+        let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
-        let __end = __sym2.2;
-        let __nt = super::__action17::<>(input, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant26(__nt), __end));
-        (3, 39)
+        let __end = __sym0.2;
+        let __nt = super::__action11::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant7(__nt), __end));
+        (1, 37)
     }
     fn __reduce75<
         'input,
@@ -6282,18 +6763,13 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // UpdateCommand = DELETE, FROM, IdToken, WHERE, Predicate => ActionFn(18);
-        assert!(__symbols.len() >= 5);
-        let __sym4 = __pop_Variant23(__symbols);
-        let __sym3 = __pop_Variant0(__symbols);
-        let __sym2 = __pop_Variant5(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
+        // SelectField = AggregationFn => ActionFn(12);
+        let __sym0 = __pop_Variant12(__symbols);
         let __start = __sym0.0;
-        let __end = __sym4.2;
-        let __nt = super::__action18::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4);
-        __symbols.push((__start, __Symbol::Variant26(__nt), __end));
-        (5, 39)
+        let __end = __sym0.2;
+        let __nt = super::__action12::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant7(__nt), __end));
+        (1, 37)
     }
     fn __reduce76<
         'input,
@@ -6304,19 +6780,13 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // UpdateCommand = MODIFY, IdToken, SET, IdToken, EQ, Expression => ActionFn(19);
-        assert!(__symbols.len() >= 6);
-        let __sym5 = __pop_Variant11(__symbols);
-        let __sym4 = __pop_Variant0(__symbols);
-        let __sym3 = __pop_Variant5(__symbols);
-        let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant5(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
+        // Statement = Query => ActionFn(5);
+        let __sym0 = __pop_Variant25(__symbols);
         let __start = __sym0.0;
-        let __end = __sym5.2;
-        let __nt = super::__action19::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
+        let __end = __sym0.2;
+        let __nt = super::__action5::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant26(__nt), __end));
-        (6, 39)
+        (1, 38)
     }
     fn __reduce77<
         'input,
@@ -6327,21 +6797,13 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // UpdateCommand = MODIFY, IdToken, SET, IdToken, EQ, Expression, WHERE, Predicate => ActionFn(20);
-        assert!(__symbols.len() >= 8);
-        let __sym7 = __pop_Variant23(__symbols);
-        let __sym6 = __pop_Variant0(__symbols);
-        let __sym5 = __pop_Variant11(__symbols);
-        let __sym4 = __pop_Variant0(__symbols);
-        let __sym3 = __pop_Variant5(__symbols);
-        let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant5(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
+        // Statement = UpdateCommand => ActionFn(6);
+        let __sym0 = __pop_Variant27(__symbols);
         let __start = __sym0.0;
-        let __end = __sym7.2;
-        let __nt = super::__action20::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
+        let __end = __sym0.2;
+        let __nt = super::__action6::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant26(__nt), __end));
-        (8, 39)
+        (1, 38)
     }
     fn __reduce78<
         'input,
@@ -6352,12 +6814,12 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // UpdateCommand = CreateCommand => ActionFn(21);
-        let __sym0 = __pop_Variant17(__symbols);
+        // StringConstant = STRING_LITERAL => ActionFn(55);
+        let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action21::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant26(__nt), __end));
+        let __nt = super::__action55::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant5(__nt), __end));
         (1, 39)
     }
     fn __reduce79<
@@ -6369,13 +6831,36 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // __Predicate = Predicate => ActionFn(3);
-        let __sym0 = __pop_Variant23(__symbols);
+        // Term = Expression, IS, NULL => ActionFn(37);
+        assert!(__symbols.len() >= 3);
+        let __sym2 = __pop_Variant0(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action3::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant23(__nt), __end));
-        (1, 40)
+        let __end = __sym2.2;
+        let __nt = super::__action37::<>(input, __sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant9(__nt), __end));
+        (3, 40)
+    }
+    fn __reduce80<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // Term = Expression, EQ, Expression => ActionFn(38);
+        assert!(__symbols.len() >= 3);
+        let __sym2 = __pop_Variant11(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant11(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym2.2;
+        let __nt = super::__action38::<>(input, __sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant9(__nt), __end));
+        (3, 40)
     }
     fn __reduce81<
         'input,
@@ -6386,15 +6871,166 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
+        // UpdateCommand = INSERT, INTO, IdToken, LPAREN, Comma<IdToken>, RPAREN, VALUES, LPAREN, Comma<Constant>, RPAREN => ActionFn(24);
+        assert!(__symbols.len() >= 10);
+        let __sym9 = __pop_Variant0(__symbols);
+        let __sym8 = __pop_Variant14(__symbols);
+        let __sym7 = __pop_Variant0(__symbols);
+        let __sym6 = __pop_Variant0(__symbols);
+        let __sym5 = __pop_Variant0(__symbols);
+        let __sym4 = __pop_Variant16(__symbols);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym9.2;
+        let __nt = super::__action24::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9);
+        __symbols.push((__start, __Symbol::Variant27(__nt), __end));
+        (10, 41)
+    }
+    fn __reduce82<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // UpdateCommand = DELETE, FROM, IdToken => ActionFn(25);
+        assert!(__symbols.len() >= 3);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym2.2;
+        let __nt = super::__action25::<>(input, __sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant27(__nt), __end));
+        (3, 41)
+    }
+    fn __reduce83<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // UpdateCommand = DELETE, FROM, IdToken, WHERE, Predicate => ActionFn(26);
+        assert!(__symbols.len() >= 5);
+        let __sym4 = __pop_Variant24(__symbols);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym4.2;
+        let __nt = super::__action26::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4);
+        __symbols.push((__start, __Symbol::Variant27(__nt), __end));
+        (5, 41)
+    }
+    fn __reduce84<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // UpdateCommand = MODIFY, IdToken, SET, IdToken, EQ, Expression => ActionFn(27);
+        assert!(__symbols.len() >= 6);
+        let __sym5 = __pop_Variant11(__symbols);
+        let __sym4 = __pop_Variant0(__symbols);
+        let __sym3 = __pop_Variant5(__symbols);
+        let __sym2 = __pop_Variant0(__symbols);
+        let __sym1 = __pop_Variant5(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym5.2;
+        let __nt = super::__action27::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
+        __symbols.push((__start, __Symbol::Variant27(__nt), __end));
+        (6, 41)
+    }
+    fn __reduce85<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // UpdateCommand = MODIFY, IdToken, SET, IdToken, EQ, Expression, WHERE, Predicate => ActionFn(28);
+        assert!(__symbols.len() >= 8);
+        let __sym7 = __pop_Variant24(__symbols);
+        let __sym6 = __pop_Variant0(__symbols);
+        let __sym5 = __pop_Variant11(__symbols);
+        let __sym4 = __pop_Variant0(__symbols);
+        let __sym3 = __pop_Variant5(__symbols);
+        let __sym2 = __pop_Variant0(__symbols);
+        let __sym1 = __pop_Variant5(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym7.2;
+        let __nt = super::__action28::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
+        __symbols.push((__start, __Symbol::Variant27(__nt), __end));
+        (8, 41)
+    }
+    fn __reduce86<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // UpdateCommand = CreateCommand => ActionFn(29);
+        let __sym0 = __pop_Variant18(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action29::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant27(__nt), __end));
+        (1, 41)
+    }
+    fn __reduce87<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // __Predicate = Predicate => ActionFn(3);
+        let __sym0 = __pop_Variant24(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action3::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant24(__nt), __end));
+        (1, 42)
+    }
+    fn __reduce89<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
         // __Statement = Statement => ActionFn(0);
-        let __sym0 = __pop_Variant25(__symbols);
+        let __sym0 = __pop_Variant26(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action0::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant25(__nt), __end));
-        (1, 42)
+        __symbols.push((__start, __Symbol::Variant26(__nt), __end));
+        (1, 44)
     }
-    fn __reduce82<
+    fn __reduce90<
         'input,
     >(
         input: &'input str,
@@ -6409,9 +7045,9 @@ mod __parse__Query {
         let __end = __sym0.2;
         let __nt = super::__action4::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant9(__nt), __end));
-        (1, 43)
+        (1, 45)
     }
-    fn __reduce83<
+    fn __reduce91<
         'input,
     >(
         input: &'input str,
@@ -6421,12 +7057,12 @@ mod __parse__Query {
     ) -> (usize, usize)
     {
         // __UpdateCommand = UpdateCommand => ActionFn(2);
-        let __sym0 = __pop_Variant26(__symbols);
+        let __sym0 = __pop_Variant27(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action2::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant26(__nt), __end));
-        (1, 44)
+        __symbols.push((__start, __Symbol::Variant27(__nt), __end));
+        (1, 46)
     }
 }
 #[allow(unused_imports)]
@@ -6441,6 +7077,15 @@ mod __parse__Statement {
     use super::super::predicate;
     use super::super::expression;
     use crate::record::field::{Spec, Value};
+    use crate::materialization::{
+    aggregation_function::AggregationFn,
+    aggregation_function::AggregationFnControl,
+    avg_function::AvgFn,
+    count_function::CountFn,
+    max_function::MaxFn,
+    min_function::MinFn,
+    sum_function::SumFn,
+};
     #[allow(unused_extern_crates)]
     extern crate lalrpop_util as __lalrpop_util;
     #[allow(unused_imports)]
@@ -6458,281 +7103,330 @@ mod __parse__Statement {
         Variant4(alloc::vec::Vec<statement::FieldDefinition>),
         Variant5(String),
         Variant6(alloc::vec::Vec<String>),
-        Variant7((expression::Expression, Option<String>)),
-        Variant8(alloc::vec::Vec<(expression::Expression, Option<String>)>),
+        Variant7(statement::SelectField),
+        Variant8(alloc::vec::Vec<statement::SelectField>),
         Variant9(predicate::Term),
         Variant10(alloc::vec::Vec<predicate::Term>),
         Variant11(expression::Expression),
-        Variant12(Vec<predicate::Term>),
-        Variant13(Vec<Value>),
-        Variant14(Vec<statement::FieldDefinition>),
-        Variant15(Vec<String>),
-        Variant16(Vec<(expression::Expression, Option<String>)>),
-        Variant17(statement::CreateCommand),
-        Variant18(Option<Vec<(expression::Expression, Option<String>)>>),
-        Variant19(Spec),
-        Variant20(i32),
-        Variant21(Option<Vec<String>>),
-        Variant22(Option<predicate::Predicate>),
-        Variant23(predicate::Predicate),
-        Variant24(statement::QueryData),
-        Variant25(statement::Statement),
-        Variant26(statement::UpdateCommand),
+        Variant12(AggregationFn),
+        Variant13(Vec<predicate::Term>),
+        Variant14(Vec<Value>),
+        Variant15(Vec<statement::FieldDefinition>),
+        Variant16(Vec<String>),
+        Variant17(Vec<statement::SelectField>),
+        Variant18(statement::CreateCommand),
+        Variant19(Option<Vec<statement::SelectField>>),
+        Variant20(Spec),
+        Variant21(i32),
+        Variant22(Option<Vec<String>>),
+        Variant23(Option<predicate::Predicate>),
+        Variant24(predicate::Predicate),
+        Variant25(statement::QueryData),
+        Variant26(statement::Statement),
+        Variant27(statement::UpdateCommand),
     }
-    const __ACTION: &[i8] = &[
+    const __ACTION: &[i16] = &[
         // State 0
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 42, 43, 0, 0, 0, 44, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 49, 50, 0, 0, 0, 0, 51, 0, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0,
         // State 1
-        0, 46, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 2
-        0, 46, 60, 57, 0, 10, 0, 59, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 58, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 53, 72, 67, 0, 10, 0, 71, 0, 0, 0, 0, 0, 0, 65, 0, 66, 0, 0, 0, 0, 0, 0, 0, 0, 0, 68, 69, 0, 70, 0, 0, 0, 0, 73, 0, 0, 0, 0, 0,
         // State 3
-        0, 46, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 4
-        0, 46, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 5
-        0, 46, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 6
-        0, 46, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 7
-        0, 46, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 8
-        0, 46, 60, 57, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 58, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 53, 72, 67, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 65, 0, 66, 0, 0, 0, 0, 0, 0, 0, 0, 0, 68, 69, 0, 70, 0, 0, 0, 0, 73, 0, 0, 0, 0, 0,
         // State 9
-        0, 46, 60, 57, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 58, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 53, 72, 67, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 70, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 10
-        0, 46, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 11
-        0, 46, 60, 57, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 58, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 53, 72, 67, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 70, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 12
-        0, 46, 60, 57, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 58, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 53, 72, 67, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 70, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 13
-        0, 46, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 14
-        0, 46, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 15
-        0, 46, 60, 57, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 58, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 53, 72, 67, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 70, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 16
-        0, 46, 60, 57, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 58, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 53, 72, 67, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 70, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 17
-        0, 46, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 18
-        0, 46, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 19
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0,
+        0, 53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 20
-        0, 46, 60, 57, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 58, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 21
-        0, 46, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 22
-        0, 46, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 23
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -64, 0, 0, 0, 0, 0, 0, 30,
+        0, 53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 24
-        0, 46, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0,
         // State 25
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 94, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 95, 0, 0,
+        0, 53, 72, 67, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 70, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 26
-        0, 46, 60, 57, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 58, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 27
-        0, 46, 60, 57, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 58, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 28
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 103, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -71, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -71, 0, 0, 0, 0, 0, 0, 0, 35,
         // State 29
-        0, 46, 60, 57, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 58, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 30
-        0, 46, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 116, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 117, 0, 0,
         // State 31
-        0, 46, 60, 57, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 58, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 53, 72, 67, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 70, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 32
-        0, 0, 0, 57, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 53, 72, 67, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 70, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 33
-        0, 46, 60, 57, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 58, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 124, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -67, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 34
-        0, 46, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 53, 72, 67, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 70, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 35
-        0, 0, 60, 57, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 120, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 36
-        0, 0, 60, 57, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 120, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 53, 72, 67, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 70, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 37
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 133, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 38
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 67, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 39
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 53, 72, 67, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 70, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 40
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 41
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 6, 0,
+        0, 0, 72, 67, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 143, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 42
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 43
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 72, 67, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 143, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 44
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 45
-        0, 0, 0, 0, -57, -57, -57, -57, -57, -57, -57, -57, -57, -57, 0, 0, 0, -57, -57, 0, 0, 0, -57, 0, 0, -57, -57, 0, -57, 0, 0, -57, 0, -57,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 46
-        0, 0, 0, 0, 12, 0, -45, 0, 13, 0, 0, -45, -45, -45, 0, 0, 0, 0, 0, 0, 0, 0, -45, 0, 0, 0, -45, 0, 0, 0, 0, 0, 0, -45,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 47
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 48
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 14, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 6, 0,
         // State 49
-        0, 0, 0, 0, -60, 0, -60, -60, -60, 0, -60, -60, -60, -60, 0, 0, 0, 0, 0, 0, 0, 0, -60, 0, 0, 0, -60, 0, 0, 0, 0, 0, 0, -60,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 50
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 51
-        0, 0, 0, 0, -48, 0, -48, -48, -48, 0, -48, -48, -48, -48, 0, 0, 0, 0, 0, 0, 0, 0, -48, 0, 0, 0, -48, 0, 0, 0, 0, 0, 0, -48,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 0, 0, 0, 0, 0, 0,
         // State 52
-        0, 0, 0, 0, -50, 0, 0, -50, -50, -68, -50, 0, 0, -50, 0, 0, 0, -68, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -62, -62, -62, -62, -62, -62, -62, -62, -62, -62, 0, 0, 0, 0, 0, -62, -62, -62, 0, 0, 0, -62, 0, 0, 0, 0, -62, -62, 0, -62, 0, 0, 0, -62, 0, -62,
         // State 53
-        0, 0, 0, 0, -28, 0, -28, 17, -28, 0, 16, -28, -28, -28, 0, 0, 0, 0, 0, 0, 0, 0, -28, 0, 0, 0, -28, 0, 0, 0, 0, 0, 0, -28,
+        0, 0, 0, 0, 12, 0, -50, 0, 13, -50, 0, -50, -50, -50, 0, 0, 0, 0, 0, -50, -50, 0, 0, 0, 0, -50, 0, 0, 0, 0, 0, -50, 0, 0, 0, 0, 0, 0, 0, -50,
         // State 54
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 67, 0, 0, 0, 0, 0, 0, 0, -37, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, -76, 0, 0, 0, 0, 0, 0, 0, 0, 0, -76, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 55
-        0, 0, 0, 0, -49, 0, -49, -49, -49, 0, -49, -49, -49, -49, 0, 0, 0, 0, 0, 0, 0, 0, -49, 0, 0, 0, -49, 0, 0, 0, 0, 0, 0, -49,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -58, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 56
-        0, 0, 0, 0, -56, 0, -56, -56, -56, -56, -56, -56, -56, -56, 0, 0, 0, 0, 0, 0, 0, 0, -56, 0, 0, 0, -56, 0, 0, 0, 0, 0, 0, -56,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, -75, 0, 0, 0, 14, 0, 0, 0, 0, 0, -75, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 57
-        0, 0, 0, 0, -47, 0, -47, -47, -47, 0, -47, -47, -47, -47, 0, 0, 0, 0, 0, 0, 0, 0, -47, 0, 0, 0, -47, 0, 0, 0, 0, 0, 0, -47,
+        0, 0, 0, 0, -65, 0, -65, -65, -65, -65, -65, -65, -65, -65, 0, 0, 0, 0, 0, -65, -65, 0, 0, 0, 0, -65, 0, 0, 0, 0, 0, -65, 0, 0, 0, 0, 0, 0, 0, -65,
         // State 58
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -52, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 59
-        0, 0, 0, 0, -71, 0, -71, -71, -71, -71, -71, -71, -71, -71, 0, 0, 0, 0, 0, 0, 0, 0, -71, 0, 0, 0, -71, 0, 0, 0, 0, 0, 0, -71,
+        0, 0, 0, 0, -53, 0, -53, -53, -53, -53, -53, -53, -53, -53, 0, 0, 0, 0, 0, -53, -53, 0, 0, 0, 0, -53, 0, 0, 0, 0, 0, -53, 0, 0, 0, 0, 0, 0, 0, -53,
         // State 60
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -55, 0, -55, -55, -55, -55, -55, -55, -55, -55, 0, 0, 0, 0, 0, -55, -55, 0, 0, 0, 0, -55, 0, 0, 0, 0, 0, -55, 0, 0, 0, 0, 0, 0, 0, -55,
         // State 61
-        0, 0, 0, 0, 0, 19, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -28, 0, -28, 17, -28, -28, 16, -28, -28, -28, 0, 0, 0, 0, 0, -28, -28, 0, 0, 0, 0, -28, 0, 0, 0, 0, 0, -28, 0, 0, 0, 0, 0, 0, 0, -28,
         // State 62
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 20, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 80, 0, 0, 0, 0, 0, 0, 0, 0, 0, -42, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 63
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 21,
+        0, 0, 0, 0, -54, 0, -54, -54, -54, -54, -54, -54, -54, -54, 0, 0, 0, 0, 0, -54, -54, 0, 0, 0, 0, -54, 0, 0, 0, 0, 0, -54, 0, 0, 0, 0, 0, 0, 0, -54,
         // State 64
-        0, 0, 0, 0, 0, 22, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 65
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 71, 0, 0, 0, 0, 0, 0, 0, -38, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 19, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 66
-        0, -19, -19, -19, 0, -19, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -19, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -61, 0, -61, -61, -61, -61, -61, -61, -61, -61, 0, 0, 0, 0, 0, -61, -61, 0, 0, 0, 0, -61, 0, 0, 0, 0, 0, -61, 0, 0, 0, 0, 0, 0, 0, -61,
         // State 67
-        0, 0, 0, 0, 0, 0, 78, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 20, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 68
-        0, 0, 0, 0, -50, 0, -50, -50, -50, 0, -50, -50, -50, -50, 0, 0, 0, 0, 0, 0, 0, 0, -50, 0, 0, 0, -50, 0, 0, 0, 0, 0, 0, -50,
+        0, 0, 0, 0, 0, 21, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 69
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 28, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -52, 0, -52, -52, -52, -52, -52, -52, -52, -52, 0, 0, 0, 0, 0, -52, -52, 0, 0, 0, 0, -52, 0, 0, 0, 0, 0, -52, 0, 0, 0, 0, 0, 0, 0, -52,
         // State 70
-        0, -20, -20, -20, 0, -20, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -20, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -57, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 71
-        0, 0, 0, 0, -27, 0, -27, 17, -27, 0, 16, -27, -27, -27, 0, 0, 0, 0, 0, 0, 0, 0, -27, 0, 0, 0, -27, 0, 0, 0, 0, 0, 0, -27,
+        0, 0, 0, 0, -79, 0, -79, -79, -79, -79, -79, -79, -79, -79, 0, 0, 0, 0, 0, -79, -79, 0, 0, 0, 0, -79, 0, 0, 0, 0, 0, -79, 0, 0, 0, 0, 0, 0, 0, -79,
         // State 72
-        0, 0, 0, 0, -26, 0, -26, 17, -26, 0, 16, -26, -26, -26, 0, 0, 0, 0, 0, 0, 0, 0, -26, 0, 0, 0, -26, 0, 0, 0, 0, 0, 0, -26,
+        0, 0, 0, 0, 0, 22, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 73
-        0, 0, 0, 0, 0, 0, 0, 0, 0, -67, 0, 0, 0, 0, 0, 0, 0, -67, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 23, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 74
-        0, 0, 0, 0, 0, 0, -35, 0, 0, 89, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -35, 0, 0, 0, 0, 0, 0, -35,
+        0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 75
-        0, 0, 0, 0, -59, 0, -59, -59, -59, 0, -59, -59, -59, -59, 0, 0, 0, 0, 0, 0, 0, 0, -59, 0, 0, 0, -59, 0, 0, 0, 0, 0, 0, -59,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 76
-        0, 0, 0, 0, -58, 0, -58, -58, -58, 0, -58, -58, -58, -58, 0, 0, 0, 0, 0, 0, 0, 0, -58, 0, 0, 0, -58, 0, 0, 0, 0, 0, 0, -58,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 26,
         // State 77
-        0, 0, 0, 0, -46, 0, -46, -46, -46, 0, -46, -46, -46, -46, 0, 0, 0, 0, 0, 0, 0, 0, -46, 0, 0, 0, -46, 0, 0, 0, 0, 0, 0, -46,
+        0, 0, 0, 0, 0, 27, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 78
-        0, 0, 0, 0, 0, 31, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 83, 0, 0, 0, 0, 0, 0, 0, 0, 0, -43, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 79
-        0, 0, 0, 0, 0, 0, 91, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, -19, -19, -19, 0, -19, 0, 0, 0, 0, 0, 0, 0, 0, -19, 0, -19, 0, 0, 0, 0, 0, 0, 0, 0, 0, -19, -19, 0, -19, 0, 0, 0, 0, -19, 0, 0, 0, 0, 0,
         // State 80
-        0, 0, 0, 0, 0, 0, -33, 0, 0, 92, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 92, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 81
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 33, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 82
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -65, 0, 0, 0, 0, 0, 0, 0,
+        0, -20, -20, -20, 0, -20, 0, 0, 0, 0, 0, 0, 0, 0, -20, 0, -20, 0, 0, 0, 0, 0, 0, 0, 0, 0, -20, -20, 0, -20, 0, 0, 0, 0, -20, 0, 0, 0, 0, 0,
         // State 83
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 97, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -27, 0, -27, 17, -27, -27, 16, -27, -27, -27, 0, 0, 0, 0, 0, -27, -27, 0, 0, 0, 0, -27, 0, 0, 0, 0, 0, -27, 0, 0, 0, 0, 0, 0, 0, -27,
         // State 84
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -26, 0, -26, 17, -26, -26, 16, -26, -26, -26, 0, 0, 0, 0, 0, -26, -26, 0, 0, 0, 0, -26, 0, 0, 0, 0, 0, -26, 0, 0, 0, 0, 0, 0, 0, -26,
         // State 85
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 98, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -29, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, -74, 0, 0, 0, 0, 0, 0, 0, 0, 0, -74, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 86
-        0, 0, 0, 0, 0, 0, 99, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, -40, 0, 0, 106, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -40, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -40, 0, 0, 0, 0, 0, 0, 0, -40,
         // State 87
-        0, 0, 0, 0, 0, 0, -36, 0, 0, 101, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -36, 0, 0, 0, 0, 0, 0, -36,
+        0, 0, 0, 0, -64, 0, -64, -64, -64, -64, -64, -64, -64, -64, 0, 0, 0, 0, 0, -64, -64, 0, 0, 0, 0, -64, 0, 0, 0, 0, 0, -64, 0, 0, 0, 0, 0, 0, 0, -64,
         // State 88
-        0, -14, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -63, 0, -63, -63, -63, -63, -63, -63, -63, -63, 0, 0, 0, 0, 0, -63, -63, 0, 0, 0, 0, -63, 0, 0, 0, 0, 0, -63, 0, 0, 0, 0, 0, 0, 0, -63,
         // State 89
-        0, 0, 0, 0, 0, 0, -34, 0, 0, 106, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 107, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 90
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 108, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 91
-        0, -9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -51, 0, -51, -51, -51, -51, -51, -51, -51, -51, 0, 0, 0, 0, 0, -51, -51, 0, 0, 0, 0, -51, 0, 0, 0, 0, 0, -51, 0, 0, 0, 0, 0, 0, 0, -51,
         // State 92
-        0, 0, 0, 0, 0, 0, -51, 0, 0, -51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 109, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 93
-        0, 0, 0, 0, 0, 0, -54, 0, 0, -54, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 110, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 94
-        0, 0, 0, 0, 0, 33, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 111, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 95
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 107, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -30, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 36, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 96
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 109, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 113, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 97
-        0, -24, -24, -24, 0, -24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -24, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, -38, 0, 0, 114, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 98
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 110, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 99
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 34,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -72, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -72, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 100
-        0, -15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 37, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 119, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 101
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 102
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 35, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 120, 0, 0, 0, 0, 0, 0, 0, -34, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -34, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 103
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -63, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 121, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 104
-        0, 0, 0, 0, 0, 0, 111, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, -41, 0, 0, 123, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -41, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -41, 0, 0, 0, 0, 0, 0, 0, -41,
         // State 105
-        0, -10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, -14, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 106
-        0, -25, -25, -25, 0, -25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -25, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, -33, 0, 0, 0, 0, 0, 0, 0, 0, 0, -33, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 107
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -73, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -73, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, -32, 0, 0, 0, 0, 0, 0, 0, 0, 0, -32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 108
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -72, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -72, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, -29, 0, 0, 0, 0, 0, 0, 0, 0, 0, -29, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 109
-        0, 0, 0, 0, 0, 36, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, -30, 0, 0, 0, 0, 0, 0, 0, 0, 0, -30, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 110
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, -31, 0, 0, 0, 0, 0, 0, 0, 0, 0, -31, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 111
-        0, 0, 0, 0, 0, 0, 115, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, -39, 0, 0, 127, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 112
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 113
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, -9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 114
-        0, 0, 0, 0, 0, 0, -55, 0, 0, -55, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, -56, 0, 0, -56, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 115
-        0, 0, 0, 0, 0, 0, 122, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, -59, 0, 0, -59, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 116
-        0, 0, 0, 0, 0, 0, -31, 0, 0, 123, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 39, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 117
-        0, 0, 0, 0, 0, 0, -40, 0, 0, -40, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128, 0, 0, 0, 0, 0, 0, 0, -35, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -35, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 118
-        0, 0, 0, 0, 0, 0, -41, 0, 0, -41, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 130, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 119
-        0, 0, 0, 0, 0, 0, -39, 0, 0, -39, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, -24, -24, -24, 0, -24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 120
-        0, 0, 0, 0, 0, 0, -32, 0, 0, 124, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 131, 0, 0, 0,
         // State 121
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 40,
         // State 122
-        0, 0, -4, -4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -4, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, -15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 123
-        0, 0, -5, -5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -5, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 124
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -70, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -70, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 125
+        0, 0, 0, 0, 0, 0, 134, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 126
+        0, -10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 127
+        0, -25, -25, -25, 0, -25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 128
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -81, 0, 0, 0, 0, 0, 0, 0, -81, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -81, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 129
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -80, 0, 0, 0, 0, 0, 0, 0, -80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -80, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 130
+        0, 0, 0, 0, 0, 42, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 131
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 132
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 43, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 133
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 134
+        0, 0, 0, 0, 0, 0, 138, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 135
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 136
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -66, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 137
+        0, 0, 0, 0, 0, 0, -60, 0, 0, -60, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 138
+        0, 0, 0, 0, 0, 0, 146, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 139
+        0, 0, 0, 0, 0, 0, -36, 0, 0, 147, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 140
+        0, 0, 0, 0, 0, 0, -45, 0, 0, -45, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 141
+        0, 0, 0, 0, 0, 0, -46, 0, 0, -46, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 142
+        0, 0, 0, 0, 0, 0, -44, 0, 0, -44, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 143
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 144
+        0, 0, 0, 0, 0, 0, -37, 0, 0, 148, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 145
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 146
+        0, 0, -4, -4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 147
+        0, 0, -5, -5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     ];
-    fn __action(state: i8, integer: usize) -> i8 {
-        __ACTION[(state as usize) * 34 + integer]
+    fn __action(state: i16, integer: usize) -> i16 {
+        __ACTION[(state as usize) * 40 + integer]
     }
-    const __EOF_ACTION: &[i8] = &[
+    const __EOF_ACTION: &[i16] = &[
         // State 0
         0,
         // State 1
@@ -6780,7 +7474,7 @@ mod __parse__Statement {
         // State 22
         0,
         // State 23
-        -64,
+        0,
         // State 24
         0,
         // State 25
@@ -6790,105 +7484,105 @@ mod __parse__Statement {
         // State 27
         0,
         // State 28
-        -62,
-        // State 29
-        0,
-        // State 30
-        0,
-        // State 31
-        0,
-        // State 32
-        0,
-        // State 33
-        0,
-        // State 34
-        0,
-        // State 35
-        0,
-        // State 36
-        0,
-        // State 37
-        -79,
-        // State 38
-        -69,
-        // State 39
-        -82,
-        // State 40
-        -70,
-        // State 41
-        0,
-        // State 42
-        0,
-        // State 43
-        0,
-        // State 44
-        0,
-        // State 45
-        -57,
-        // State 46
-        -45,
-        // State 47
-        0,
-        // State 48
-        0,
-        // State 49
-        -60,
-        // State 50
-        0,
-        // State 51
-        -48,
-        // State 52
-        0,
-        // State 53
-        -28,
-        // State 54
-        0,
-        // State 55
-        -49,
-        // State 56
-        -56,
-        // State 57
-        -47,
-        // State 58
-        0,
-        // State 59
         -71,
+        // State 29
+        0,
+        // State 30
+        0,
+        // State 31
+        0,
+        // State 32
+        0,
+        // State 33
+        -67,
+        // State 34
+        0,
+        // State 35
+        0,
+        // State 36
+        0,
+        // State 37
+        -69,
+        // State 38
+        0,
+        // State 39
+        0,
+        // State 40
+        0,
+        // State 41
+        0,
+        // State 42
+        0,
+        // State 43
+        0,
+        // State 44
+        -87,
+        // State 45
+        -77,
+        // State 46
+        -90,
+        // State 47
+        -78,
+        // State 48
+        0,
+        // State 49
+        0,
+        // State 50
+        0,
+        // State 51
+        0,
+        // State 52
+        -62,
+        // State 53
+        -50,
+        // State 54
+        0,
+        // State 55
+        0,
+        // State 56
+        0,
+        // State 57
+        -65,
+        // State 58
+        0,
+        // State 59
+        -53,
         // State 60
-        0,
+        -55,
         // State 61
-        0,
+        -28,
         // State 62
         0,
         // State 63
-        -75,
+        -54,
         // State 64
         0,
         // State 65
         0,
         // State 66
-        0,
+        -61,
         // State 67
         0,
         // State 68
-        -50,
-        // State 69
         0,
+        // State 69
+        -52,
         // State 70
         0,
         // State 71
-        -27,
+        -79,
         // State 72
-        -26,
+        0,
         // State 73
         0,
         // State 74
-        -35,
+        0,
         // State 75
-        -59,
+        0,
         // State 76
-        -58,
+        -83,
         // State 77
-        -46,
+        0,
         // State 78
         0,
         // State 79
@@ -6896,27 +7590,27 @@ mod __parse__Statement {
         // State 80
         0,
         // State 81
-        -43,
+        0,
         // State 82
-        -65,
+        0,
         // State 83
-        0,
+        -27,
         // State 84
-        -76,
+        -26,
         // State 85
-        -29,
+        0,
         // State 86
-        0,
+        -40,
         // State 87
-        -36,
+        -64,
         // State 88
-        0,
+        -63,
         // State 89
         0,
         // State 90
-        -42,
-        // State 91
         0,
+        // State 91
+        -51,
         // State 92
         0,
         // State 93
@@ -6924,43 +7618,43 @@ mod __parse__Statement {
         // State 94
         0,
         // State 95
-        -30,
+        0,
         // State 96
         0,
         // State 97
         0,
         // State 98
-        0,
+        -48,
         // State 99
-        -77,
+        -72,
         // State 100
         0,
         // State 101
-        -66,
+        -84,
         // State 102
-        0,
+        -34,
         // State 103
-        -63,
-        // State 104
         0,
+        // State 104
+        -41,
         // State 105
         0,
         // State 106
         0,
         // State 107
-        -73,
+        0,
         // State 108
-        -72,
+        0,
         // State 109
         0,
         // State 110
-        -44,
+        0,
         // State 111
         0,
         // State 112
-        -78,
+        -47,
         // State 113
-        -61,
+        0,
         // State 114
         0,
         // State 115
@@ -6968,7 +7662,7 @@ mod __parse__Statement {
         // State 116
         0,
         // State 117
-        0,
+        -35,
         // State 118
         0,
         // State 119
@@ -6976,104 +7670,159 @@ mod __parse__Statement {
         // State 120
         0,
         // State 121
-        -74,
+        -85,
         // State 122
         0,
         // State 123
         0,
+        // State 124
+        -70,
+        // State 125
+        0,
+        // State 126
+        0,
+        // State 127
+        0,
+        // State 128
+        -81,
+        // State 129
+        -80,
+        // State 130
+        0,
+        // State 131
+        -73,
+        // State 132
+        0,
+        // State 133
+        -49,
+        // State 134
+        0,
+        // State 135
+        -86,
+        // State 136
+        -66,
+        // State 137
+        0,
+        // State 138
+        0,
+        // State 139
+        0,
+        // State 140
+        0,
+        // State 141
+        0,
+        // State 142
+        0,
+        // State 143
+        -68,
+        // State 144
+        0,
+        // State 145
+        -82,
+        // State 146
+        0,
+        // State 147
+        0,
     ];
-    fn __goto(state: i8, nt: usize) -> i8 {
+    fn __goto(state: i16, nt: usize) -> i16 {
         match nt {
-            2 => 36,
-            5 => 24,
-            8 => 22,
+            2 => 43,
+            5 => 29,
+            8 => 27,
             11 => 8,
-            14 => 26,
-            15 => 46,
-            16 => 82,
-            17 => 115,
-            18 => 79,
-            19 => match state {
-                21 => 86,
-                34 => 113,
-                _ => 23,
+            14 => 31,
+            15 => 53,
+            16 => 54,
+            17 => 99,
+            18 => 138,
+            19 => 96,
+            20 => match state {
+                26 => 103,
+                40 => 136,
+                42 => 143,
+                _ => 28,
             },
-            20 => 47,
-            21 => match state {
-                36 => 120,
-                _ => 116,
+            21 => 55,
+            22 => match state {
+                43 => 144,
+                _ => 139,
             },
-            22 => 37,
-            23 => match state {
-                2 | 8 => 48,
-                9 => 67,
-                27 => 99,
-                31 => 107,
-                _ => 83,
-            },
+            23 => 44,
             24 => match state {
-                15 => 75,
-                16 => 76,
-                _ => 49,
+                2 | 8 => 56,
+                9 => 80,
+                32 => 121,
+                36 => 128,
+                _ => 100,
             },
             25 => match state {
-                24 => 89,
-                _ => 80,
+                15 => 87,
+                16 => 88,
+                _ => 57,
             },
-            26 => 50,
-            27 => 92,
-            28 => match state {
-                32 => 111,
-                35..=36 => 117,
-                _ => 51,
+            26 => match state {
+                29 => 111,
+                _ => 97,
             },
+            27 => 58,
+            28 => 114,
             29 => match state {
-                18 | 24 => 25,
-                1 => 44,
-                2 | 8 => 52,
-                3 => 60,
-                4 => 61,
-                5 => 62,
-                6 => 63,
-                7 => 64,
-                10 => 69,
-                13 => 73,
-                14 | 21 | 34 => 74,
-                17 => 78,
-                22 => 87,
-                30 => 104,
-                _ => 68,
+                38 => 134,
+                41 | 43 => 140,
+                _ => 59,
             },
             30 => match state {
-                11 => 71,
-                12 => 72,
-                _ => 53,
+                23 | 29 => 30,
+                1 => 51,
+                3 => 73,
+                4 => 74,
+                5 => 75,
+                6 => 76,
+                7 => 77,
+                10 => 81,
+                13 => 85,
+                14 | 26 | 40 | 42 => 86,
+                17 => 89,
+                18 => 90,
+                19 => 92,
+                20 => 93,
+                21 => 94,
+                22 => 95,
+                27 => 104,
+                35 => 125,
+                _ => 60,
             },
-            31 => 101,
-            32 => 28,
-            33 => match state {
-                29 => 103,
-                33 => 112,
-                _ => 84,
+            31 => match state {
+                11 => 83,
+                12 => 84,
+                _ => 61,
             },
-            34 => match state {
-                19 => 81,
-                _ => 38,
-            },
+            32 => 37,
+            33 => 131,
+            34 => 33,
             35 => match state {
-                8 => 65,
-                _ => 54,
+                34 => 124,
+                39 => 135,
+                _ => 101,
             },
-            36 => 39,
+            36 => match state {
+                24 => 98,
+                _ => 45,
+            },
             37 => match state {
-                35..=36 => 118,
-                _ => 55,
+                8 => 78,
+                _ => 62,
             },
-            38 => match state {
-                26 => 95,
-                _ => 85,
+            38 => 46,
+            39 => match state {
+                41 | 43 => 141,
+                _ => 63,
             },
-            39 => 40,
+            40 => match state {
+                31 => 117,
+                _ => 102,
+            },
+            41 => 47,
             _ => 0,
         }
     }
@@ -7092,28 +7841,34 @@ mod __parse__Statement {
         r###"EQ"###,
         r###"AND"###,
         r###"AS"###,
+        r###"AVG"###,
         r###"BY"###,
+        r###"COUNT"###,
         r###"CREATE"###,
         r###"DELETE"###,
         r###"FROM"###,
+        r###"GROUP"###,
         r###"I32"###,
         r###"INDEX"###,
         r###"INSERT"###,
         r###"INTO"###,
         r###"IS"###,
+        r###"MAX"###,
+        r###"MIN"###,
         r###"MODIFY"###,
         r###"NULL"###,
         r###"ON"###,
         r###"ORDER"###,
         r###"SELECT"###,
         r###"SET"###,
+        r###"SUM"###,
         r###"TABLE"###,
         r###"VALUES"###,
         r###"VARCHAR"###,
         r###"VIEW"###,
         r###"WHERE"###,
     ];
-    fn __expected_tokens(__state: i8) -> alloc::vec::Vec<alloc::string::String> {
+    fn __expected_tokens(__state: i16) -> alloc::vec::Vec<alloc::string::String> {
         __TERMINAL.iter().enumerate().filter_map(|(index, terminal)| {
             let next_state = __action(__state, index);
             if next_state == 0 {
@@ -7126,7 +7881,7 @@ mod __parse__Statement {
     fn __expected_tokens_from_states<
         'input,
     >(
-        __states: &[i8],
+        __states: &[i16],
         _: core::marker::PhantomData<(&'input ())>,
     ) -> alloc::vec::Vec<alloc::string::String>
     {
@@ -7153,9 +7908,9 @@ mod __parse__Statement {
         type TokenIndex = usize;
         type Symbol = __Symbol<'input>;
         type Success = statement::Statement;
-        type StateIndex = i8;
-        type Action = i8;
-        type ReduceIndex = i8;
+        type StateIndex = i16;
+        type Action = i16;
+        type ReduceIndex = i16;
         type NonterminalIndex = usize;
 
         #[inline]
@@ -7174,22 +7929,22 @@ mod __parse__Statement {
         }
 
         #[inline]
-        fn action(&self, state: i8, integer: usize) -> i8 {
+        fn action(&self, state: i16, integer: usize) -> i16 {
             __action(state, integer)
         }
 
         #[inline]
-        fn error_action(&self, state: i8) -> i8 {
-            __action(state, 34 - 1)
+        fn error_action(&self, state: i16) -> i16 {
+            __action(state, 40 - 1)
         }
 
         #[inline]
-        fn eof_action(&self, state: i8) -> i8 {
+        fn eof_action(&self, state: i16) -> i16 {
             __EOF_ACTION[state as usize]
         }
 
         #[inline]
-        fn goto(&self, state: i8, nt: usize) -> i8 {
+        fn goto(&self, state: i16, nt: usize) -> i16 {
             __goto(state, nt)
         }
 
@@ -7197,11 +7952,11 @@ mod __parse__Statement {
             __token_to_symbol(token_index, token, core::marker::PhantomData::<(&())>)
         }
 
-        fn expected_tokens(&self, state: i8) -> alloc::vec::Vec<alloc::string::String> {
+        fn expected_tokens(&self, state: i16) -> alloc::vec::Vec<alloc::string::String> {
             __expected_tokens(state)
         }
 
-        fn expected_tokens_from_states(&self, states: &[i8]) -> alloc::vec::Vec<alloc::string::String> {
+        fn expected_tokens_from_states(&self, states: &[i16]) -> alloc::vec::Vec<alloc::string::String> {
             __expected_tokens_from_states(states, core::marker::PhantomData::<(&())>)
         }
 
@@ -7220,9 +7975,9 @@ mod __parse__Statement {
 
         fn reduce(
             &mut self,
-            action: i8,
+            action: i16,
             start_location: Option<&Self::Location>,
-            states: &mut alloc::vec::Vec<i8>,
+            states: &mut alloc::vec::Vec<i16>,
             symbols: &mut alloc::vec::Vec<__state_machine::SymbolTriple<Self>>,
         ) -> Option<__state_machine::ParseResult<Self>> {
             __reduce(
@@ -7235,7 +7990,7 @@ mod __parse__Statement {
             )
         }
 
-        fn simulate_reduce(&self, action: i8) -> __state_machine::SimulatedReduce<Self> {
+        fn simulate_reduce(&self, action: i16) -> __state_machine::SimulatedReduce<Self> {
             __simulate_reduce(action, core::marker::PhantomData::<(&())>)
         }
     }
@@ -7282,6 +8037,12 @@ mod __parse__Statement {
             Token(31, _) if true => Some(31),
             Token(32, _) if true => Some(32),
             Token(33, _) if true => Some(33),
+            Token(34, _) if true => Some(34),
+            Token(35, _) if true => Some(35),
+            Token(36, _) if true => Some(36),
+            Token(37, _) if true => Some(37),
+            Token(38, _) if true => Some(38),
+            Token(39, _) if true => Some(39),
             _ => None,
         }
     }
@@ -7294,8 +8055,8 @@ mod __parse__Statement {
     ) -> __Symbol<'input>
     {
         #[allow(clippy::manual_range_patterns)]match __token_index {
-            0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20 | 21 | 22 | 23 | 24 | 25 | 26 | 27 | 28 | 29 | 30 | 31 | 32 | 33 => match __token {
-                Token(0, __tok0) | Token(1, __tok0) | Token(2, __tok0) | Token(3, __tok0) | Token(4, __tok0) | Token(5, __tok0) | Token(6, __tok0) | Token(7, __tok0) | Token(8, __tok0) | Token(9, __tok0) | Token(10, __tok0) | Token(11, __tok0) | Token(12, __tok0) | Token(13, __tok0) | Token(14, __tok0) | Token(15, __tok0) | Token(16, __tok0) | Token(17, __tok0) | Token(18, __tok0) | Token(19, __tok0) | Token(20, __tok0) | Token(21, __tok0) | Token(22, __tok0) | Token(23, __tok0) | Token(24, __tok0) | Token(25, __tok0) | Token(26, __tok0) | Token(27, __tok0) | Token(28, __tok0) | Token(29, __tok0) | Token(30, __tok0) | Token(31, __tok0) | Token(32, __tok0) | Token(33, __tok0) if true => __Symbol::Variant0(__tok0),
+            0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20 | 21 | 22 | 23 | 24 | 25 | 26 | 27 | 28 | 29 | 30 | 31 | 32 | 33 | 34 | 35 | 36 | 37 | 38 | 39 => match __token {
+                Token(0, __tok0) | Token(1, __tok0) | Token(2, __tok0) | Token(3, __tok0) | Token(4, __tok0) | Token(5, __tok0) | Token(6, __tok0) | Token(7, __tok0) | Token(8, __tok0) | Token(9, __tok0) | Token(10, __tok0) | Token(11, __tok0) | Token(12, __tok0) | Token(13, __tok0) | Token(14, __tok0) | Token(15, __tok0) | Token(16, __tok0) | Token(17, __tok0) | Token(18, __tok0) | Token(19, __tok0) | Token(20, __tok0) | Token(21, __tok0) | Token(22, __tok0) | Token(23, __tok0) | Token(24, __tok0) | Token(25, __tok0) | Token(26, __tok0) | Token(27, __tok0) | Token(28, __tok0) | Token(29, __tok0) | Token(30, __tok0) | Token(31, __tok0) | Token(32, __tok0) | Token(33, __tok0) | Token(34, __tok0) | Token(35, __tok0) | Token(36, __tok0) | Token(37, __tok0) | Token(38, __tok0) | Token(39, __tok0) if true => __Symbol::Variant0(__tok0),
                 _ => unreachable!(),
             },
             _ => unreachable!(),
@@ -7304,7 +8065,7 @@ mod __parse__Statement {
     fn __simulate_reduce<
         'input,
     >(
-        __reduce_index: i8,
+        __reduce_index: i16,
         _: core::marker::PhantomData<(&'input ())>,
     ) -> __state_machine::SimulatedReduce<__StateMachine<'input>>
     {
@@ -7479,128 +8240,128 @@ mod __parse__Statement {
             }
             28 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
+                    states_to_pop: 4,
                     nonterminal_produced: 16,
                 }
             }
             29 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 2,
+                    states_to_pop: 4,
                     nonterminal_produced: 16,
                 }
             }
             30 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 17,
+                    states_to_pop: 4,
+                    nonterminal_produced: 16,
                 }
             }
             31 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 2,
-                    nonterminal_produced: 17,
+                    states_to_pop: 4,
+                    nonterminal_produced: 16,
                 }
             }
             32 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 18,
+                    states_to_pop: 4,
+                    nonterminal_produced: 16,
                 }
             }
             33 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 2,
-                    nonterminal_produced: 18,
+                    states_to_pop: 1,
+                    nonterminal_produced: 17,
                 }
             }
             34 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 19,
+                    states_to_pop: 2,
+                    nonterminal_produced: 17,
                 }
             }
             35 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 2,
-                    nonterminal_produced: 19,
+                    states_to_pop: 1,
+                    nonterminal_produced: 18,
                 }
             }
             36 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 20,
+                    states_to_pop: 2,
+                    nonterminal_produced: 18,
                 }
             }
             37 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 2,
-                    nonterminal_produced: 20,
+                    states_to_pop: 1,
+                    nonterminal_produced: 19,
                 }
             }
             38 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 21,
+                    states_to_pop: 2,
+                    nonterminal_produced: 19,
                 }
             }
             39 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
-                    nonterminal_produced: 21,
+                    nonterminal_produced: 20,
                 }
             }
             40 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 2,
+                    nonterminal_produced: 20,
+                }
+            }
+            41 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
                     nonterminal_produced: 21,
                 }
             }
-            41 => {
-                __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 6,
-                    nonterminal_produced: 22,
-                }
-            }
             42 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 5,
-                    nonterminal_produced: 22,
+                    states_to_pop: 2,
+                    nonterminal_produced: 21,
                 }
             }
             43 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 8,
+                    states_to_pop: 1,
                     nonterminal_produced: 22,
                 }
             }
             44 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
-                    nonterminal_produced: 23,
+                    nonterminal_produced: 22,
                 }
             }
             45 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 3,
-                    nonterminal_produced: 24,
+                    states_to_pop: 1,
+                    nonterminal_produced: 22,
                 }
             }
             46 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 24,
+                    states_to_pop: 6,
+                    nonterminal_produced: 23,
                 }
             }
             47 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 24,
+                    states_to_pop: 5,
+                    nonterminal_produced: 23,
                 }
             }
             48 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 24,
+                    states_to_pop: 8,
+                    nonterminal_produced: 23,
                 }
             }
             49 => {
@@ -7611,170 +8372,170 @@ mod __parse__Statement {
             }
             50 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 2,
+                    states_to_pop: 3,
                     nonterminal_produced: 25,
                 }
             }
             51 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
-                    nonterminal_produced: 26,
+                    nonterminal_produced: 25,
                 }
             }
             52 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
-                    nonterminal_produced: 26,
+                    nonterminal_produced: 25,
                 }
             }
             53 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
-                    nonterminal_produced: 27,
+                    nonterminal_produced: 25,
                 }
             }
             54 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 4,
-                    nonterminal_produced: 27,
+                    states_to_pop: 1,
+                    nonterminal_produced: 25,
                 }
             }
             55 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 28,
+                    states_to_pop: 2,
+                    nonterminal_produced: 26,
                 }
             }
             56 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
-                    nonterminal_produced: 29,
+                    nonterminal_produced: 27,
                 }
             }
             57 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 3,
-                    nonterminal_produced: 30,
+                    states_to_pop: 1,
+                    nonterminal_produced: 27,
                 }
             }
             58 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 3,
-                    nonterminal_produced: 30,
+                    states_to_pop: 1,
+                    nonterminal_produced: 28,
                 }
             }
             59 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 4,
+                    nonterminal_produced: 28,
+                }
+            }
+            60 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 1,
+                    nonterminal_produced: 29,
+                }
+            }
+            61 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
                     nonterminal_produced: 30,
                 }
             }
-            60 => {
+            62 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 3,
                     nonterminal_produced: 31,
                 }
             }
-            61 => {
-                __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 0,
-                    nonterminal_produced: 31,
-                }
-            }
-            62 => {
-                __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 2,
-                    nonterminal_produced: 32,
-                }
-            }
             63 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 0,
-                    nonterminal_produced: 32,
+                    states_to_pop: 3,
+                    nonterminal_produced: 31,
                 }
             }
             64 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
-                    nonterminal_produced: 33,
+                    nonterminal_produced: 31,
                 }
             }
             65 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 6,
-                    nonterminal_produced: 34,
+                    states_to_pop: 3,
+                    nonterminal_produced: 32,
                 }
             }
             66 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 3,
-                    nonterminal_produced: 35,
+                    states_to_pop: 0,
+                    nonterminal_produced: 32,
                 }
             }
             67 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 35,
+                    states_to_pop: 3,
+                    nonterminal_produced: 33,
                 }
             }
             68 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 36,
+                    states_to_pop: 0,
+                    nonterminal_produced: 33,
                 }
             }
             69 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 36,
+                    states_to_pop: 2,
+                    nonterminal_produced: 34,
                 }
             }
             70 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 0,
+                    nonterminal_produced: 34,
+                }
+            }
+            71 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 1,
+                    nonterminal_produced: 35,
+                }
+            }
+            72 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 7,
+                    nonterminal_produced: 36,
+                }
+            }
+            73 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 3,
+                    nonterminal_produced: 37,
+                }
+            }
+            74 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
                     nonterminal_produced: 37,
                 }
             }
-            71 => {
-                __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 3,
-                    nonterminal_produced: 38,
-                }
-            }
-            72 => {
-                __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 3,
-                    nonterminal_produced: 38,
-                }
-            }
-            73 => {
-                __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 10,
-                    nonterminal_produced: 39,
-                }
-            }
-            74 => {
-                __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 3,
-                    nonterminal_produced: 39,
-                }
-            }
             75 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 5,
-                    nonterminal_produced: 39,
+                    states_to_pop: 1,
+                    nonterminal_produced: 37,
                 }
             }
             76 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 6,
-                    nonterminal_produced: 39,
+                    states_to_pop: 1,
+                    nonterminal_produced: 38,
                 }
             }
             77 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 8,
-                    nonterminal_produced: 39,
+                    states_to_pop: 1,
+                    nonterminal_produced: 38,
                 }
             }
             78 => {
@@ -7785,27 +8546,75 @@ mod __parse__Statement {
             }
             79 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
+                    states_to_pop: 3,
                     nonterminal_produced: 40,
                 }
             }
             80 => {
                 __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 3,
+                    nonterminal_produced: 40,
+                }
+            }
+            81 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 10,
+                    nonterminal_produced: 41,
+                }
+            }
+            82 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 3,
+                    nonterminal_produced: 41,
+                }
+            }
+            83 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 5,
+                    nonterminal_produced: 41,
+                }
+            }
+            84 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 6,
+                    nonterminal_produced: 41,
+                }
+            }
+            85 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 8,
+                    nonterminal_produced: 41,
+                }
+            }
+            86 => {
+                __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
                     nonterminal_produced: 41,
                 }
             }
-            81 => __state_machine::SimulatedReduce::Accept,
-            82 => {
+            87 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 1,
+                    nonterminal_produced: 42,
+                }
+            }
+            88 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
                     nonterminal_produced: 43,
                 }
             }
-            83 => {
+            89 => __state_machine::SimulatedReduce::Accept,
+            90 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
-                    nonterminal_produced: 44,
+                    nonterminal_produced: 45,
+                }
+            }
+            91 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 1,
+                    nonterminal_produced: 46,
                 }
             }
             _ => panic!("invalid reduction index {}", __reduce_index)
@@ -7847,8 +8656,8 @@ mod __parse__Statement {
     fn __accepts<
         'input,
     >(
-        __error_state: Option<i8>,
-        __states: &[i8],
+        __error_state: Option<i16>,
+        __states: &[i16],
         __opt_integer: Option<usize>,
         _: core::marker::PhantomData<(&'input ())>,
     ) -> bool
@@ -7881,9 +8690,9 @@ mod __parse__Statement {
         'input,
     >(
         input: &'input str,
-        __action: i8,
+        __action: i16,
         __lookahead_start: Option<&usize>,
-        __states: &mut alloc::vec::Vec<i8>,
+        __states: &mut alloc::vec::Vec<i16>,
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
         _: core::marker::PhantomData<(&'input ())>,
     ) -> Option<Result<statement::Statement,__lalrpop_util::ParseError<usize, Token<'input>, &'static str>>>
@@ -8133,18 +8942,42 @@ mod __parse__Statement {
                 __reduce80(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
             }
             81 => {
-                // __Statement = Statement => ActionFn(0);
-                let __sym0 = __pop_Variant25(__symbols);
-                let __start = __sym0.0;
-                let __end = __sym0.2;
-                let __nt = super::__action0::<>(input, __sym0);
-                return Some(Ok(__nt));
+                __reduce81(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
             }
             82 => {
                 __reduce82(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
             }
             83 => {
                 __reduce83(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
+            }
+            84 => {
+                __reduce84(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
+            }
+            85 => {
+                __reduce85(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
+            }
+            86 => {
+                __reduce86(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
+            }
+            87 => {
+                __reduce87(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
+            }
+            88 => {
+                __reduce88(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
+            }
+            89 => {
+                // __Statement = Statement => ActionFn(0);
+                let __sym0 = __pop_Variant26(__symbols);
+                let __start = __sym0.0;
+                let __end = __sym0.2;
+                let __nt = super::__action0::<>(input, __sym0);
+                return Some(Ok(__nt));
+            }
+            90 => {
+                __reduce90(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
+            }
+            91 => {
+                __reduce91(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
             }
             _ => panic!("invalid action code {}", __action)
         };
@@ -8159,36 +8992,14 @@ mod __parse__Statement {
     fn __symbol_type_mismatch() -> ! {
         panic!("symbol type mismatch")
     }
-    fn __pop_Variant7<
+    fn __pop_Variant12<
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, (expression::Expression, Option<String>), usize)
+    ) -> (usize, AggregationFn, usize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant7(__v), __r)) => (__l, __v, __r),
-            _ => __symbol_type_mismatch()
-        }
-    }
-    fn __pop_Variant18<
-      'input,
-    >(
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, Option<Vec<(expression::Expression, Option<String>)>>, usize)
-     {
-        match __symbols.pop() {
-            Some((__l, __Symbol::Variant18(__v), __r)) => (__l, __v, __r),
-            _ => __symbol_type_mismatch()
-        }
-    }
-    fn __pop_Variant21<
-      'input,
-    >(
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, Option<Vec<String>>, usize)
-     {
-        match __symbols.pop() {
-            Some((__l, __Symbol::Variant21(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant12(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -8196,7 +9007,7 @@ mod __parse__Statement {
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, Option<predicate::Predicate>, usize)
+    ) -> (usize, Option<Vec<String>>, usize)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant22(__v), __r)) => (__l, __v, __r),
@@ -8207,10 +9018,32 @@ mod __parse__Statement {
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, Spec, usize)
+    ) -> (usize, Option<Vec<statement::SelectField>>, usize)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant19(__v), __r)) => (__l, __v, __r),
+            _ => __symbol_type_mismatch()
+        }
+    }
+    fn __pop_Variant23<
+      'input,
+    >(
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
+    ) -> (usize, Option<predicate::Predicate>, usize)
+     {
+        match __symbols.pop() {
+            Some((__l, __Symbol::Variant23(__v), __r)) => (__l, __v, __r),
+            _ => __symbol_type_mismatch()
+        }
+    }
+    fn __pop_Variant20<
+      'input,
+    >(
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
+    ) -> (usize, Spec, usize)
+     {
+        match __symbols.pop() {
+            Some((__l, __Symbol::Variant20(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -8240,43 +9073,10 @@ mod __parse__Statement {
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, Vec<(expression::Expression, Option<String>)>, usize)
-     {
-        match __symbols.pop() {
-            Some((__l, __Symbol::Variant16(__v), __r)) => (__l, __v, __r),
-            _ => __symbol_type_mismatch()
-        }
-    }
-    fn __pop_Variant15<
-      'input,
-    >(
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
     ) -> (usize, Vec<String>, usize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant15(__v), __r)) => (__l, __v, __r),
-            _ => __symbol_type_mismatch()
-        }
-    }
-    fn __pop_Variant13<
-      'input,
-    >(
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, Vec<Value>, usize)
-     {
-        match __symbols.pop() {
-            Some((__l, __Symbol::Variant13(__v), __r)) => (__l, __v, __r),
-            _ => __symbol_type_mismatch()
-        }
-    }
-    fn __pop_Variant12<
-      'input,
-    >(
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, Vec<predicate::Term>, usize)
-     {
-        match __symbols.pop() {
-            Some((__l, __Symbol::Variant12(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant16(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -8284,21 +9084,43 @@ mod __parse__Statement {
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, Vec<statement::FieldDefinition>, usize)
+    ) -> (usize, Vec<Value>, usize)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant14(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant8<
+    fn __pop_Variant13<
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, alloc::vec::Vec<(expression::Expression, Option<String>)>, usize)
+    ) -> (usize, Vec<predicate::Term>, usize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant8(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant13(__v), __r)) => (__l, __v, __r),
+            _ => __symbol_type_mismatch()
+        }
+    }
+    fn __pop_Variant15<
+      'input,
+    >(
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
+    ) -> (usize, Vec<statement::FieldDefinition>, usize)
+     {
+        match __symbols.pop() {
+            Some((__l, __Symbol::Variant15(__v), __r)) => (__l, __v, __r),
+            _ => __symbol_type_mismatch()
+        }
+    }
+    fn __pop_Variant17<
+      'input,
+    >(
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
+    ) -> (usize, Vec<statement::SelectField>, usize)
+     {
+        match __symbols.pop() {
+            Some((__l, __Symbol::Variant17(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -8346,6 +9168,17 @@ mod __parse__Statement {
             _ => __symbol_type_mismatch()
         }
     }
+    fn __pop_Variant8<
+      'input,
+    >(
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
+    ) -> (usize, alloc::vec::Vec<statement::SelectField>, usize)
+     {
+        match __symbols.pop() {
+            Some((__l, __Symbol::Variant8(__v), __r)) => (__l, __v, __r),
+            _ => __symbol_type_mismatch()
+        }
+    }
     fn __pop_Variant11<
       'input,
     >(
@@ -8357,25 +9190,25 @@ mod __parse__Statement {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant20<
+    fn __pop_Variant21<
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
     ) -> (usize, i32, usize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant20(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant21(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant23<
+    fn __pop_Variant24<
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
     ) -> (usize, predicate::Predicate, usize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant23(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant24(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -8390,14 +9223,14 @@ mod __parse__Statement {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant17<
+    fn __pop_Variant18<
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
     ) -> (usize, statement::CreateCommand, usize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant17(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant18(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -8412,25 +9245,25 @@ mod __parse__Statement {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant24<
+    fn __pop_Variant25<
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
     ) -> (usize, statement::QueryData, usize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant24(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant25(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant25<
+    fn __pop_Variant7<
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, statement::Statement, usize)
+    ) -> (usize, statement::SelectField, usize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant25(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant7(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -8438,10 +9271,21 @@ mod __parse__Statement {
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, statement::UpdateCommand, usize)
+    ) -> (usize, statement::Statement, usize)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant26(__v), __r)) => (__l, __v, __r),
+            _ => __symbol_type_mismatch()
+        }
+    }
+    fn __pop_Variant27<
+      'input,
+    >(
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
+    ) -> (usize, statement::UpdateCommand, usize)
+     {
+        match __symbols.pop() {
+            Some((__l, __Symbol::Variant27(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -8465,13 +9309,13 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Constant> COMMA) = Constant, COMMA => ActionFn(62);
+        // (<Constant> COMMA) = Constant, COMMA => ActionFn(70);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant1(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action62::<>(input, __sym0, __sym1);
+        let __nt = super::__action70::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant1(__nt), __end));
         (2, 0)
     }
@@ -8484,10 +9328,10 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Constant> COMMA)* =  => ActionFn(60);
+        // (<Constant> COMMA)* =  => ActionFn(68);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action60::<>(input, &__start, &__end);
+        let __nt = super::__action68::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant2(__nt), __end));
         (0, 1)
     }
@@ -8500,11 +9344,11 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Constant> COMMA)* = (<Constant> COMMA)+ => ActionFn(61);
+        // (<Constant> COMMA)* = (<Constant> COMMA)+ => ActionFn(69);
         let __sym0 = __pop_Variant2(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action61::<>(input, __sym0);
+        let __nt = super::__action69::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant2(__nt), __end));
         (1, 1)
     }
@@ -8517,13 +9361,13 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Constant> COMMA)+ = Constant, COMMA => ActionFn(79);
+        // (<Constant> COMMA)+ = Constant, COMMA => ActionFn(87);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant1(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action79::<>(input, __sym0, __sym1);
+        let __nt = super::__action87::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant2(__nt), __end));
         (2, 2)
     }
@@ -8536,14 +9380,14 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Constant> COMMA)+ = (<Constant> COMMA)+, Constant, COMMA => ActionFn(80);
+        // (<Constant> COMMA)+ = (<Constant> COMMA)+, Constant, COMMA => ActionFn(88);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant1(__symbols);
         let __sym0 = __pop_Variant2(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action80::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action88::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant2(__nt), __end));
         (3, 2)
     }
@@ -8556,13 +9400,13 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<FieldDefinition> COMMA) = FieldDefinition, COMMA => ActionFn(65);
+        // (<FieldDefinition> COMMA) = FieldDefinition, COMMA => ActionFn(73);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant3(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action65::<>(input, __sym0, __sym1);
+        let __nt = super::__action73::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant3(__nt), __end));
         (2, 3)
     }
@@ -8575,10 +9419,10 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<FieldDefinition> COMMA)* =  => ActionFn(63);
+        // (<FieldDefinition> COMMA)* =  => ActionFn(71);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action63::<>(input, &__start, &__end);
+        let __nt = super::__action71::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant4(__nt), __end));
         (0, 4)
     }
@@ -8591,11 +9435,11 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<FieldDefinition> COMMA)* = (<FieldDefinition> COMMA)+ => ActionFn(64);
+        // (<FieldDefinition> COMMA)* = (<FieldDefinition> COMMA)+ => ActionFn(72);
         let __sym0 = __pop_Variant4(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action64::<>(input, __sym0);
+        let __nt = super::__action72::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant4(__nt), __end));
         (1, 4)
     }
@@ -8608,13 +9452,13 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<FieldDefinition> COMMA)+ = FieldDefinition, COMMA => ActionFn(83);
+        // (<FieldDefinition> COMMA)+ = FieldDefinition, COMMA => ActionFn(91);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant3(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action83::<>(input, __sym0, __sym1);
+        let __nt = super::__action91::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant4(__nt), __end));
         (2, 5)
     }
@@ -8627,14 +9471,14 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<FieldDefinition> COMMA)+ = (<FieldDefinition> COMMA)+, FieldDefinition, COMMA => ActionFn(84);
+        // (<FieldDefinition> COMMA)+ = (<FieldDefinition> COMMA)+, FieldDefinition, COMMA => ActionFn(92);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant3(__symbols);
         let __sym0 = __pop_Variant4(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action84::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action92::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant4(__nt), __end));
         (3, 5)
     }
@@ -8647,13 +9491,13 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<IdToken> COMMA) = IdToken, COMMA => ActionFn(56);
+        // (<IdToken> COMMA) = IdToken, COMMA => ActionFn(64);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action56::<>(input, __sym0, __sym1);
+        let __nt = super::__action64::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant5(__nt), __end));
         (2, 6)
     }
@@ -8666,10 +9510,10 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<IdToken> COMMA)* =  => ActionFn(54);
+        // (<IdToken> COMMA)* =  => ActionFn(62);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action54::<>(input, &__start, &__end);
+        let __nt = super::__action62::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant6(__nt), __end));
         (0, 7)
     }
@@ -8682,11 +9526,11 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<IdToken> COMMA)* = (<IdToken> COMMA)+ => ActionFn(55);
+        // (<IdToken> COMMA)* = (<IdToken> COMMA)+ => ActionFn(63);
         let __sym0 = __pop_Variant6(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action55::<>(input, __sym0);
+        let __nt = super::__action63::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant6(__nt), __end));
         (1, 7)
     }
@@ -8699,13 +9543,13 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<IdToken> COMMA)+ = IdToken, COMMA => ActionFn(87);
+        // (<IdToken> COMMA)+ = IdToken, COMMA => ActionFn(95);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action87::<>(input, __sym0, __sym1);
+        let __nt = super::__action95::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant6(__nt), __end));
         (2, 8)
     }
@@ -8718,14 +9562,14 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<IdToken> COMMA)+ = (<IdToken> COMMA)+, IdToken, COMMA => ActionFn(88);
+        // (<IdToken> COMMA)+ = (<IdToken> COMMA)+, IdToken, COMMA => ActionFn(96);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant5(__symbols);
         let __sym0 = __pop_Variant6(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action88::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action96::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant6(__nt), __end));
         (3, 8)
     }
@@ -8738,13 +9582,13 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<SelectField> COMMA) = SelectField, COMMA => ActionFn(59);
+        // (<SelectField> COMMA) = SelectField, COMMA => ActionFn(67);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant7(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action59::<>(input, __sym0, __sym1);
+        let __nt = super::__action67::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant7(__nt), __end));
         (2, 9)
     }
@@ -8757,10 +9601,10 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<SelectField> COMMA)* =  => ActionFn(57);
+        // (<SelectField> COMMA)* =  => ActionFn(65);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action57::<>(input, &__start, &__end);
+        let __nt = super::__action65::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant8(__nt), __end));
         (0, 10)
     }
@@ -8773,11 +9617,11 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<SelectField> COMMA)* = (<SelectField> COMMA)+ => ActionFn(58);
+        // (<SelectField> COMMA)* = (<SelectField> COMMA)+ => ActionFn(66);
         let __sym0 = __pop_Variant8(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action58::<>(input, __sym0);
+        let __nt = super::__action66::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant8(__nt), __end));
         (1, 10)
     }
@@ -8790,13 +9634,13 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<SelectField> COMMA)+ = SelectField, COMMA => ActionFn(91);
+        // (<SelectField> COMMA)+ = SelectField, COMMA => ActionFn(99);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant7(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action91::<>(input, __sym0, __sym1);
+        let __nt = super::__action99::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant8(__nt), __end));
         (2, 11)
     }
@@ -8809,14 +9653,14 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<SelectField> COMMA)+ = (<SelectField> COMMA)+, SelectField, COMMA => ActionFn(92);
+        // (<SelectField> COMMA)+ = (<SelectField> COMMA)+, SelectField, COMMA => ActionFn(100);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant7(__symbols);
         let __sym0 = __pop_Variant8(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action92::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action100::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant8(__nt), __end));
         (3, 11)
     }
@@ -8829,13 +9673,13 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Term> AND) = Term, AND => ActionFn(68);
+        // (<Term> AND) = Term, AND => ActionFn(76);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant9(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action68::<>(input, __sym0, __sym1);
+        let __nt = super::__action76::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant9(__nt), __end));
         (2, 12)
     }
@@ -8848,10 +9692,10 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Term> AND)* =  => ActionFn(66);
+        // (<Term> AND)* =  => ActionFn(74);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action66::<>(input, &__start, &__end);
+        let __nt = super::__action74::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant10(__nt), __end));
         (0, 13)
     }
@@ -8864,11 +9708,11 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Term> AND)* = (<Term> AND)+ => ActionFn(67);
+        // (<Term> AND)* = (<Term> AND)+ => ActionFn(75);
         let __sym0 = __pop_Variant10(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action67::<>(input, __sym0);
+        let __nt = super::__action75::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant10(__nt), __end));
         (1, 13)
     }
@@ -8881,13 +9725,13 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Term> AND)+ = Term, AND => ActionFn(95);
+        // (<Term> AND)+ = Term, AND => ActionFn(103);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant9(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action95::<>(input, __sym0, __sym1);
+        let __nt = super::__action103::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant10(__nt), __end));
         (2, 14)
     }
@@ -8900,14 +9744,14 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Term> AND)+ = (<Term> AND)+, Term, AND => ActionFn(96);
+        // (<Term> AND)+ = (<Term> AND)+, Term, AND => ActionFn(104);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant9(__symbols);
         let __sym0 = __pop_Variant10(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action96::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action104::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant10(__nt), __end));
         (3, 14)
     }
@@ -8920,14 +9764,14 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AddExpr = AddExpr, PLUS, MulExpr => ActionFn(32);
+        // AddExpr = AddExpr, PLUS, MulExpr => ActionFn(40);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant11(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action32::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action40::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (3, 15)
     }
@@ -8940,14 +9784,14 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AddExpr = AddExpr, MINUS, MulExpr => ActionFn(33);
+        // AddExpr = AddExpr, MINUS, MulExpr => ActionFn(41);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant11(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action33::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action41::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (3, 15)
     }
@@ -8960,11 +9804,11 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AddExpr = MulExpr => ActionFn(34);
+        // AddExpr = MulExpr => ActionFn(42);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action34::<>(input, __sym0);
+        let __nt = super::__action42::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (1, 15)
     }
@@ -8977,13 +9821,17 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // And<Term> = Term => ActionFn(97);
-        let __sym0 = __pop_Variant9(__symbols);
+        // AggregationFn = MAX, LPAREN, IdToken, RPAREN => ActionFn(13);
+        assert!(__symbols.len() >= 4);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action97::<>(input, __sym0);
+        let __end = __sym3.2;
+        let __nt = super::__action13::<>(input, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant12(__nt), __end));
-        (1, 16)
+        (4, 16)
     }
     fn __reduce29<
         'input,
@@ -8994,15 +9842,17 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // And<Term> = (<Term> AND)+, Term => ActionFn(98);
-        assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant9(__symbols);
-        let __sym0 = __pop_Variant10(__symbols);
+        // AggregationFn = MIN, LPAREN, IdToken, RPAREN => ActionFn(14);
+        assert!(__symbols.len() >= 4);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym1.2;
-        let __nt = super::__action98::<>(input, __sym0, __sym1);
+        let __end = __sym3.2;
+        let __nt = super::__action14::<>(input, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant12(__nt), __end));
-        (2, 16)
+        (4, 16)
     }
     fn __reduce30<
         'input,
@@ -9013,13 +9863,17 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<Constant> = Constant => ActionFn(81);
-        let __sym0 = __pop_Variant1(__symbols);
+        // AggregationFn = SUM, LPAREN, IdToken, RPAREN => ActionFn(15);
+        assert!(__symbols.len() >= 4);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action81::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant13(__nt), __end));
-        (1, 17)
+        let __end = __sym3.2;
+        let __nt = super::__action15::<>(input, __sym0, __sym1, __sym2, __sym3);
+        __symbols.push((__start, __Symbol::Variant12(__nt), __end));
+        (4, 16)
     }
     fn __reduce31<
         'input,
@@ -9030,15 +9884,17 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<Constant> = (<Constant> COMMA)+, Constant => ActionFn(82);
-        assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant1(__symbols);
-        let __sym0 = __pop_Variant2(__symbols);
+        // AggregationFn = COUNT, LPAREN, IdToken, RPAREN => ActionFn(16);
+        assert!(__symbols.len() >= 4);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym1.2;
-        let __nt = super::__action82::<>(input, __sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant13(__nt), __end));
-        (2, 17)
+        let __end = __sym3.2;
+        let __nt = super::__action16::<>(input, __sym0, __sym1, __sym2, __sym3);
+        __symbols.push((__start, __Symbol::Variant12(__nt), __end));
+        (4, 16)
     }
     fn __reduce32<
         'input,
@@ -9049,13 +9905,17 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<FieldDefinition> = FieldDefinition => ActionFn(85);
-        let __sym0 = __pop_Variant3(__symbols);
+        // AggregationFn = AVG, LPAREN, IdToken, RPAREN => ActionFn(17);
+        assert!(__symbols.len() >= 4);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action85::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant14(__nt), __end));
-        (1, 18)
+        let __end = __sym3.2;
+        let __nt = super::__action17::<>(input, __sym0, __sym1, __sym2, __sym3);
+        __symbols.push((__start, __Symbol::Variant12(__nt), __end));
+        (4, 16)
     }
     fn __reduce33<
         'input,
@@ -9066,15 +9926,13 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<FieldDefinition> = (<FieldDefinition> COMMA)+, FieldDefinition => ActionFn(86);
-        assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant3(__symbols);
-        let __sym0 = __pop_Variant4(__symbols);
+        // And<Term> = Term => ActionFn(105);
+        let __sym0 = __pop_Variant9(__symbols);
         let __start = __sym0.0;
-        let __end = __sym1.2;
-        let __nt = super::__action86::<>(input, __sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant14(__nt), __end));
-        (2, 18)
+        let __end = __sym0.2;
+        let __nt = super::__action105::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant13(__nt), __end));
+        (1, 17)
     }
     fn __reduce34<
         'input,
@@ -9085,13 +9943,15 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<IdToken> = IdToken => ActionFn(89);
-        let __sym0 = __pop_Variant5(__symbols);
+        // And<Term> = (<Term> AND)+, Term => ActionFn(106);
+        assert!(__symbols.len() >= 2);
+        let __sym1 = __pop_Variant9(__symbols);
+        let __sym0 = __pop_Variant10(__symbols);
         let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action89::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant15(__nt), __end));
-        (1, 19)
+        let __end = __sym1.2;
+        let __nt = super::__action106::<>(input, __sym0, __sym1);
+        __symbols.push((__start, __Symbol::Variant13(__nt), __end));
+        (2, 17)
     }
     fn __reduce35<
         'input,
@@ -9102,15 +9962,13 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<IdToken> = (<IdToken> COMMA)+, IdToken => ActionFn(90);
-        assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant5(__symbols);
-        let __sym0 = __pop_Variant6(__symbols);
+        // Comma<Constant> = Constant => ActionFn(89);
+        let __sym0 = __pop_Variant1(__symbols);
         let __start = __sym0.0;
-        let __end = __sym1.2;
-        let __nt = super::__action90::<>(input, __sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant15(__nt), __end));
-        (2, 19)
+        let __end = __sym0.2;
+        let __nt = super::__action89::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant14(__nt), __end));
+        (1, 18)
     }
     fn __reduce36<
         'input,
@@ -9121,13 +9979,15 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<SelectField> = SelectField => ActionFn(93);
-        let __sym0 = __pop_Variant7(__symbols);
+        // Comma<Constant> = (<Constant> COMMA)+, Constant => ActionFn(90);
+        assert!(__symbols.len() >= 2);
+        let __sym1 = __pop_Variant1(__symbols);
+        let __sym0 = __pop_Variant2(__symbols);
         let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action93::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant16(__nt), __end));
-        (1, 20)
+        let __end = __sym1.2;
+        let __nt = super::__action90::<>(input, __sym0, __sym1);
+        __symbols.push((__start, __Symbol::Variant14(__nt), __end));
+        (2, 18)
     }
     fn __reduce37<
         'input,
@@ -9138,15 +9998,13 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<SelectField> = (<SelectField> COMMA)+, SelectField => ActionFn(94);
-        assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant7(__symbols);
-        let __sym0 = __pop_Variant8(__symbols);
+        // Comma<FieldDefinition> = FieldDefinition => ActionFn(93);
+        let __sym0 = __pop_Variant3(__symbols);
         let __start = __sym0.0;
-        let __end = __sym1.2;
-        let __nt = super::__action94::<>(input, __sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant16(__nt), __end));
-        (2, 20)
+        let __end = __sym0.2;
+        let __nt = super::__action93::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant15(__nt), __end));
+        (1, 19)
     }
     fn __reduce38<
         'input,
@@ -9157,13 +10015,15 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Constant = NULL => ActionFn(43);
-        let __sym0 = __pop_Variant0(__symbols);
+        // Comma<FieldDefinition> = (<FieldDefinition> COMMA)+, FieldDefinition => ActionFn(94);
+        assert!(__symbols.len() >= 2);
+        let __sym1 = __pop_Variant3(__symbols);
+        let __sym0 = __pop_Variant4(__symbols);
         let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action43::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant1(__nt), __end));
-        (1, 21)
+        let __end = __sym1.2;
+        let __nt = super::__action94::<>(input, __sym0, __sym1);
+        __symbols.push((__start, __Symbol::Variant15(__nt), __end));
+        (2, 19)
     }
     fn __reduce39<
         'input,
@@ -9174,13 +10034,13 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Constant = I32Constant => ActionFn(44);
-        let __sym0 = __pop_Variant20(__symbols);
+        // Comma<IdToken> = IdToken => ActionFn(97);
+        let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action44::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant1(__nt), __end));
-        (1, 21)
+        let __nt = super::__action97::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant16(__nt), __end));
+        (1, 20)
     }
     fn __reduce40<
         'input,
@@ -9191,13 +10051,15 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Constant = StringConstant => ActionFn(45);
-        let __sym0 = __pop_Variant5(__symbols);
+        // Comma<IdToken> = (<IdToken> COMMA)+, IdToken => ActionFn(98);
+        assert!(__symbols.len() >= 2);
+        let __sym1 = __pop_Variant5(__symbols);
+        let __sym0 = __pop_Variant6(__symbols);
         let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action45::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant1(__nt), __end));
-        (1, 21)
+        let __end = __sym1.2;
+        let __nt = super::__action98::<>(input, __sym0, __sym1);
+        __symbols.push((__start, __Symbol::Variant16(__nt), __end));
+        (2, 20)
     }
     fn __reduce41<
         'input,
@@ -9208,19 +10070,13 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // CreateCommand = CREATE, TABLE, IdToken, LPAREN, Comma<FieldDefinition>, RPAREN => ActionFn(22);
-        assert!(__symbols.len() >= 6);
-        let __sym5 = __pop_Variant0(__symbols);
-        let __sym4 = __pop_Variant14(__symbols);
-        let __sym3 = __pop_Variant0(__symbols);
-        let __sym2 = __pop_Variant5(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
+        // Comma<SelectField> = SelectField => ActionFn(101);
+        let __sym0 = __pop_Variant7(__symbols);
         let __start = __sym0.0;
-        let __end = __sym5.2;
-        let __nt = super::__action22::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
+        let __end = __sym0.2;
+        let __nt = super::__action101::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant17(__nt), __end));
-        (6, 22)
+        (1, 21)
     }
     fn __reduce42<
         'input,
@@ -9231,18 +10087,15 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // CreateCommand = CREATE, VIEW, IdToken, AS, Query => ActionFn(23);
-        assert!(__symbols.len() >= 5);
-        let __sym4 = __pop_Variant24(__symbols);
-        let __sym3 = __pop_Variant0(__symbols);
-        let __sym2 = __pop_Variant5(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
+        // Comma<SelectField> = (<SelectField> COMMA)+, SelectField => ActionFn(102);
+        assert!(__symbols.len() >= 2);
+        let __sym1 = __pop_Variant7(__symbols);
+        let __sym0 = __pop_Variant8(__symbols);
         let __start = __sym0.0;
-        let __end = __sym4.2;
-        let __nt = super::__action23::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4);
+        let __end = __sym1.2;
+        let __nt = super::__action102::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant17(__nt), __end));
-        (5, 22)
+        (2, 21)
     }
     fn __reduce43<
         'input,
@@ -9253,7 +10106,103 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // CreateCommand = CREATE, INDEX, IdToken, ON, IdToken, LPAREN, IdToken, RPAREN => ActionFn(24);
+        // Constant = NULL => ActionFn(51);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action51::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant1(__nt), __end));
+        (1, 22)
+    }
+    fn __reduce44<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // Constant = I32Constant => ActionFn(52);
+        let __sym0 = __pop_Variant21(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action52::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant1(__nt), __end));
+        (1, 22)
+    }
+    fn __reduce45<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // Constant = StringConstant => ActionFn(53);
+        let __sym0 = __pop_Variant5(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action53::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant1(__nt), __end));
+        (1, 22)
+    }
+    fn __reduce46<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // CreateCommand = CREATE, TABLE, IdToken, LPAREN, Comma<FieldDefinition>, RPAREN => ActionFn(30);
+        assert!(__symbols.len() >= 6);
+        let __sym5 = __pop_Variant0(__symbols);
+        let __sym4 = __pop_Variant15(__symbols);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym5.2;
+        let __nt = super::__action30::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
+        __symbols.push((__start, __Symbol::Variant18(__nt), __end));
+        (6, 23)
+    }
+    fn __reduce47<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // CreateCommand = CREATE, VIEW, IdToken, AS, Query => ActionFn(31);
+        assert!(__symbols.len() >= 5);
+        let __sym4 = __pop_Variant25(__symbols);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym4.2;
+        let __nt = super::__action31::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4);
+        __symbols.push((__start, __Symbol::Variant18(__nt), __end));
+        (5, 23)
+    }
+    fn __reduce48<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // CreateCommand = CREATE, INDEX, IdToken, ON, IdToken, LPAREN, IdToken, RPAREN => ActionFn(32);
         assert!(__symbols.len() >= 8);
         let __sym7 = __pop_Variant0(__symbols);
         let __sym6 = __pop_Variant5(__symbols);
@@ -9265,97 +10214,9 @@ mod __parse__Statement {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym7.2;
-        let __nt = super::__action24::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
-        __symbols.push((__start, __Symbol::Variant17(__nt), __end));
-        (8, 22)
-    }
-    fn __reduce44<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // Expression = AddExpr => ActionFn(31);
-        let __sym0 = __pop_Variant11(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action31::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
-        (1, 23)
-    }
-    fn __reduce45<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // Factor = LPAREN, Expression, RPAREN => ActionFn(38);
-        assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant11(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym2.2;
-        let __nt = super::__action38::<>(input, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
-        (3, 24)
-    }
-    fn __reduce46<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // Factor = NULL => ActionFn(39);
-        let __sym0 = __pop_Variant0(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action39::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
-        (1, 24)
-    }
-    fn __reduce47<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // Factor = I32Constant => ActionFn(40);
-        let __sym0 = __pop_Variant20(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action40::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
-        (1, 24)
-    }
-    fn __reduce48<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // Factor = StringConstant => ActionFn(41);
-        let __sym0 = __pop_Variant5(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action41::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
-        (1, 24)
+        let __nt = super::__action32::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
+        __symbols.push((__start, __Symbol::Variant18(__nt), __end));
+        (8, 23)
     }
     fn __reduce49<
         'input,
@@ -9366,11 +10227,11 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Factor = IdToken => ActionFn(42);
-        let __sym0 = __pop_Variant5(__symbols);
+        // Expression = AddExpr => ActionFn(39);
+        let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action42::<>(input, __sym0);
+        let __nt = super::__action39::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (1, 24)
     }
@@ -9383,17 +10244,105 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // FieldDefinition = IdToken, FieldType => ActionFn(25);
+        // Factor = LPAREN, Expression, RPAREN => ActionFn(46);
+        assert!(__symbols.len() >= 3);
+        let __sym2 = __pop_Variant0(__symbols);
+        let __sym1 = __pop_Variant11(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym2.2;
+        let __nt = super::__action46::<>(input, __sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
+        (3, 25)
+    }
+    fn __reduce51<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // Factor = NULL => ActionFn(47);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action47::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
+        (1, 25)
+    }
+    fn __reduce52<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // Factor = I32Constant => ActionFn(48);
+        let __sym0 = __pop_Variant21(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action48::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
+        (1, 25)
+    }
+    fn __reduce53<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // Factor = StringConstant => ActionFn(49);
+        let __sym0 = __pop_Variant5(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action49::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
+        (1, 25)
+    }
+    fn __reduce54<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // Factor = IdToken => ActionFn(50);
+        let __sym0 = __pop_Variant5(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action50::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
+        (1, 25)
+    }
+    fn __reduce55<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // FieldDefinition = IdToken, FieldType => ActionFn(33);
         assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant19(__symbols);
+        let __sym1 = __pop_Variant20(__symbols);
         let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action25::<>(input, __sym0, __sym1);
+        let __nt = super::__action33::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant3(__nt), __end));
-        (2, 25)
+        (2, 26)
     }
-    fn __reduce51<
+    fn __reduce56<
         'input,
     >(
         input: &'input str,
@@ -9407,97 +10356,8 @@ mod __parse__Statement {
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action8::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant18(__nt), __end));
-        (1, 26)
-    }
-    fn __reduce52<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // FieldList = Comma<SelectField> => ActionFn(9);
-        let __sym0 = __pop_Variant16(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action9::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant18(__nt), __end));
-        (1, 26)
-    }
-    fn __reduce53<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // FieldType = I32 => ActionFn(26);
-        let __sym0 = __pop_Variant0(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action26::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant19(__nt), __end));
         (1, 27)
-    }
-    fn __reduce54<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // FieldType = VARCHAR, LPAREN, I32Constant, RPAREN => ActionFn(27);
-        assert!(__symbols.len() >= 4);
-        let __sym3 = __pop_Variant0(__symbols);
-        let __sym2 = __pop_Variant20(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym3.2;
-        let __nt = super::__action27::<>(input, __sym0, __sym1, __sym2, __sym3);
-        __symbols.push((__start, __Symbol::Variant19(__nt), __end));
-        (4, 27)
-    }
-    fn __reduce55<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // I32Constant = I32_LITERAL => ActionFn(46);
-        let __sym0 = __pop_Variant0(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action46::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant20(__nt), __end));
-        (1, 28)
-    }
-    fn __reduce56<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // IdToken = ID => ActionFn(48);
-        let __sym0 = __pop_Variant0(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action48::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant5(__nt), __end));
-        (1, 29)
     }
     fn __reduce57<
         'input,
@@ -9508,16 +10368,13 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // MulExpr = MulExpr, STAR, Factor => ActionFn(35);
-        assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant11(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant11(__symbols);
+        // FieldList = Comma<SelectField> => ActionFn(9);
+        let __sym0 = __pop_Variant17(__symbols);
         let __start = __sym0.0;
-        let __end = __sym2.2;
-        let __nt = super::__action35::<>(input, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
-        (3, 30)
+        let __end = __sym0.2;
+        let __nt = super::__action9::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant19(__nt), __end));
+        (1, 27)
     }
     fn __reduce58<
         'input,
@@ -9528,16 +10385,13 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // MulExpr = MulExpr, SLASH, Factor => ActionFn(36);
-        assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant11(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant11(__symbols);
+        // FieldType = I32 => ActionFn(34);
+        let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym2.2;
-        let __nt = super::__action36::<>(input, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
-        (3, 30)
+        let __end = __sym0.2;
+        let __nt = super::__action34::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant20(__nt), __end));
+        (1, 28)
     }
     fn __reduce59<
         'input,
@@ -9548,13 +10402,17 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // MulExpr = Factor => ActionFn(37);
-        let __sym0 = __pop_Variant11(__symbols);
+        // FieldType = VARCHAR, LPAREN, I32Constant, RPAREN => ActionFn(35);
+        assert!(__symbols.len() >= 4);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant21(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action37::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
-        (1, 30)
+        let __end = __sym3.2;
+        let __nt = super::__action35::<>(input, __sym0, __sym1, __sym2, __sym3);
+        __symbols.push((__start, __Symbol::Variant20(__nt), __end));
+        (4, 28)
     }
     fn __reduce60<
         'input,
@@ -9565,16 +10423,13 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // OptOrderBy = ORDER, BY, Comma<IdToken> => ActionFn(14);
-        assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant15(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
+        // I32Constant = I32_LITERAL => ActionFn(54);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym2.2;
-        let __nt = super::__action14::<>(input, __sym0, __sym1, __sym2);
+        let __end = __sym0.2;
+        let __nt = super::__action54::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant21(__nt), __end));
-        (3, 31)
+        (1, 29)
     }
     fn __reduce61<
         'input,
@@ -9585,12 +10440,13 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // OptOrderBy =  => ActionFn(15);
-        let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
-        let __end = __start;
-        let __nt = super::__action15::<>(input, &__start, &__end);
-        __symbols.push((__start, __Symbol::Variant21(__nt), __end));
-        (0, 31)
+        // IdToken = ID => ActionFn(56);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action56::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant5(__nt), __end));
+        (1, 30)
     }
     fn __reduce62<
         'input,
@@ -9601,15 +10457,16 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // OptPredicate = WHERE, Predicate => ActionFn(12);
-        assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant23(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
+        // MulExpr = MulExpr, STAR, Factor => ActionFn(43);
+        assert!(__symbols.len() >= 3);
+        let __sym2 = __pop_Variant11(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
-        let __end = __sym1.2;
-        let __nt = super::__action12::<>(input, __sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant22(__nt), __end));
-        (2, 32)
+        let __end = __sym2.2;
+        let __nt = super::__action43::<>(input, __sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
+        (3, 31)
     }
     fn __reduce63<
         'input,
@@ -9620,12 +10477,16 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // OptPredicate =  => ActionFn(13);
-        let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
-        let __end = __start;
-        let __nt = super::__action13::<>(input, &__start, &__end);
-        __symbols.push((__start, __Symbol::Variant22(__nt), __end));
-        (0, 32)
+        // MulExpr = MulExpr, SLASH, Factor => ActionFn(44);
+        assert!(__symbols.len() >= 3);
+        let __sym2 = __pop_Variant11(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant11(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym2.2;
+        let __nt = super::__action44::<>(input, __sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
+        (3, 31)
     }
     fn __reduce64<
         'input,
@@ -9636,13 +10497,13 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Predicate = And<Term> => ActionFn(28);
-        let __sym0 = __pop_Variant12(__symbols);
+        // MulExpr = Factor => ActionFn(45);
+        let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action28::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant23(__nt), __end));
-        (1, 33)
+        let __nt = super::__action45::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
+        (1, 31)
     }
     fn __reduce65<
         'input,
@@ -9653,21 +10514,146 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Query = SELECT, FieldList, FROM, Comma<IdToken>, OptPredicate, OptOrderBy => ActionFn(7);
-        assert!(__symbols.len() >= 6);
-        let __sym5 = __pop_Variant21(__symbols);
-        let __sym4 = __pop_Variant22(__symbols);
-        let __sym3 = __pop_Variant15(__symbols);
-        let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant18(__symbols);
+        // OptGroupBy = GROUP, BY, Comma<IdToken> => ActionFn(20);
+        assert!(__symbols.len() >= 3);
+        let __sym2 = __pop_Variant16(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym5.2;
-        let __nt = super::__action7::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
-        __symbols.push((__start, __Symbol::Variant24(__nt), __end));
-        (6, 34)
+        let __end = __sym2.2;
+        let __nt = super::__action20::<>(input, __sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant22(__nt), __end));
+        (3, 32)
     }
     fn __reduce66<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // OptGroupBy =  => ActionFn(21);
+        let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
+        let __end = __start;
+        let __nt = super::__action21::<>(input, &__start, &__end);
+        __symbols.push((__start, __Symbol::Variant22(__nt), __end));
+        (0, 32)
+    }
+    fn __reduce67<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // OptOrderBy = ORDER, BY, Comma<IdToken> => ActionFn(22);
+        assert!(__symbols.len() >= 3);
+        let __sym2 = __pop_Variant16(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym2.2;
+        let __nt = super::__action22::<>(input, __sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant22(__nt), __end));
+        (3, 33)
+    }
+    fn __reduce68<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // OptOrderBy =  => ActionFn(23);
+        let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
+        let __end = __start;
+        let __nt = super::__action23::<>(input, &__start, &__end);
+        __symbols.push((__start, __Symbol::Variant22(__nt), __end));
+        (0, 33)
+    }
+    fn __reduce69<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // OptPredicate = WHERE, Predicate => ActionFn(18);
+        assert!(__symbols.len() >= 2);
+        let __sym1 = __pop_Variant24(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym1.2;
+        let __nt = super::__action18::<>(input, __sym0, __sym1);
+        __symbols.push((__start, __Symbol::Variant23(__nt), __end));
+        (2, 34)
+    }
+    fn __reduce70<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // OptPredicate =  => ActionFn(19);
+        let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
+        let __end = __start;
+        let __nt = super::__action19::<>(input, &__start, &__end);
+        __symbols.push((__start, __Symbol::Variant23(__nt), __end));
+        (0, 34)
+    }
+    fn __reduce71<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // Predicate = And<Term> => ActionFn(36);
+        let __sym0 = __pop_Variant13(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action36::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant24(__nt), __end));
+        (1, 35)
+    }
+    fn __reduce72<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // Query = SELECT, FieldList, FROM, Comma<IdToken>, OptPredicate, OptGroupBy, OptOrderBy => ActionFn(7);
+        assert!(__symbols.len() >= 7);
+        let __sym6 = __pop_Variant22(__symbols);
+        let __sym5 = __pop_Variant22(__symbols);
+        let __sym4 = __pop_Variant23(__symbols);
+        let __sym3 = __pop_Variant16(__symbols);
+        let __sym2 = __pop_Variant0(__symbols);
+        let __sym1 = __pop_Variant19(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym6.2;
+        let __nt = super::__action7::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6);
+        __symbols.push((__start, __Symbol::Variant25(__nt), __end));
+        (7, 36)
+    }
+    fn __reduce73<
         'input,
     >(
         input: &'input str,
@@ -9685,142 +10671,7 @@ mod __parse__Statement {
         let __end = __sym2.2;
         let __nt = super::__action10::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant7(__nt), __end));
-        (3, 35)
-    }
-    fn __reduce67<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // SelectField = IdToken => ActionFn(11);
-        let __sym0 = __pop_Variant5(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action11::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant7(__nt), __end));
-        (1, 35)
-    }
-    fn __reduce68<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // Statement = Query => ActionFn(5);
-        let __sym0 = __pop_Variant24(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action5::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant25(__nt), __end));
-        (1, 36)
-    }
-    fn __reduce69<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // Statement = UpdateCommand => ActionFn(6);
-        let __sym0 = __pop_Variant26(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action6::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant25(__nt), __end));
-        (1, 36)
-    }
-    fn __reduce70<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // StringConstant = STRING_LITERAL => ActionFn(47);
-        let __sym0 = __pop_Variant0(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action47::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant5(__nt), __end));
-        (1, 37)
-    }
-    fn __reduce71<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // Term = Expression, IS, NULL => ActionFn(29);
-        assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant11(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym2.2;
-        let __nt = super::__action29::<>(input, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant9(__nt), __end));
-        (3, 38)
-    }
-    fn __reduce72<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // Term = Expression, EQ, Expression => ActionFn(30);
-        assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant11(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant11(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym2.2;
-        let __nt = super::__action30::<>(input, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant9(__nt), __end));
-        (3, 38)
-    }
-    fn __reduce73<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // UpdateCommand = INSERT, INTO, IdToken, LPAREN, Comma<IdToken>, RPAREN, VALUES, LPAREN, Comma<Constant>, RPAREN => ActionFn(16);
-        assert!(__symbols.len() >= 10);
-        let __sym9 = __pop_Variant0(__symbols);
-        let __sym8 = __pop_Variant13(__symbols);
-        let __sym7 = __pop_Variant0(__symbols);
-        let __sym6 = __pop_Variant0(__symbols);
-        let __sym5 = __pop_Variant0(__symbols);
-        let __sym4 = __pop_Variant15(__symbols);
-        let __sym3 = __pop_Variant0(__symbols);
-        let __sym2 = __pop_Variant5(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym9.2;
-        let __nt = super::__action16::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9);
-        __symbols.push((__start, __Symbol::Variant26(__nt), __end));
-        (10, 39)
+        (3, 37)
     }
     fn __reduce74<
         'input,
@@ -9831,16 +10682,13 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // UpdateCommand = DELETE, FROM, IdToken => ActionFn(17);
-        assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant5(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
+        // SelectField = Expression => ActionFn(11);
+        let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
-        let __end = __sym2.2;
-        let __nt = super::__action17::<>(input, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant26(__nt), __end));
-        (3, 39)
+        let __end = __sym0.2;
+        let __nt = super::__action11::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant7(__nt), __end));
+        (1, 37)
     }
     fn __reduce75<
         'input,
@@ -9851,18 +10699,13 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // UpdateCommand = DELETE, FROM, IdToken, WHERE, Predicate => ActionFn(18);
-        assert!(__symbols.len() >= 5);
-        let __sym4 = __pop_Variant23(__symbols);
-        let __sym3 = __pop_Variant0(__symbols);
-        let __sym2 = __pop_Variant5(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
+        // SelectField = AggregationFn => ActionFn(12);
+        let __sym0 = __pop_Variant12(__symbols);
         let __start = __sym0.0;
-        let __end = __sym4.2;
-        let __nt = super::__action18::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4);
-        __symbols.push((__start, __Symbol::Variant26(__nt), __end));
-        (5, 39)
+        let __end = __sym0.2;
+        let __nt = super::__action12::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant7(__nt), __end));
+        (1, 37)
     }
     fn __reduce76<
         'input,
@@ -9873,19 +10716,13 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // UpdateCommand = MODIFY, IdToken, SET, IdToken, EQ, Expression => ActionFn(19);
-        assert!(__symbols.len() >= 6);
-        let __sym5 = __pop_Variant11(__symbols);
-        let __sym4 = __pop_Variant0(__symbols);
-        let __sym3 = __pop_Variant5(__symbols);
-        let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant5(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
+        // Statement = Query => ActionFn(5);
+        let __sym0 = __pop_Variant25(__symbols);
         let __start = __sym0.0;
-        let __end = __sym5.2;
-        let __nt = super::__action19::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
+        let __end = __sym0.2;
+        let __nt = super::__action5::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant26(__nt), __end));
-        (6, 39)
+        (1, 38)
     }
     fn __reduce77<
         'input,
@@ -9896,21 +10733,13 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // UpdateCommand = MODIFY, IdToken, SET, IdToken, EQ, Expression, WHERE, Predicate => ActionFn(20);
-        assert!(__symbols.len() >= 8);
-        let __sym7 = __pop_Variant23(__symbols);
-        let __sym6 = __pop_Variant0(__symbols);
-        let __sym5 = __pop_Variant11(__symbols);
-        let __sym4 = __pop_Variant0(__symbols);
-        let __sym3 = __pop_Variant5(__symbols);
-        let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant5(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
+        // Statement = UpdateCommand => ActionFn(6);
+        let __sym0 = __pop_Variant27(__symbols);
         let __start = __sym0.0;
-        let __end = __sym7.2;
-        let __nt = super::__action20::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
+        let __end = __sym0.2;
+        let __nt = super::__action6::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant26(__nt), __end));
-        (8, 39)
+        (1, 38)
     }
     fn __reduce78<
         'input,
@@ -9921,12 +10750,12 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // UpdateCommand = CreateCommand => ActionFn(21);
-        let __sym0 = __pop_Variant17(__symbols);
+        // StringConstant = STRING_LITERAL => ActionFn(55);
+        let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action21::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant26(__nt), __end));
+        let __nt = super::__action55::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant5(__nt), __end));
         (1, 39)
     }
     fn __reduce79<
@@ -9938,13 +10767,16 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // __Predicate = Predicate => ActionFn(3);
-        let __sym0 = __pop_Variant23(__symbols);
+        // Term = Expression, IS, NULL => ActionFn(37);
+        assert!(__symbols.len() >= 3);
+        let __sym2 = __pop_Variant0(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action3::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant23(__nt), __end));
-        (1, 40)
+        let __end = __sym2.2;
+        let __nt = super::__action37::<>(input, __sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant9(__nt), __end));
+        (3, 40)
     }
     fn __reduce80<
         'input,
@@ -9955,15 +10787,186 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // __Query = Query => ActionFn(1);
+        // Term = Expression, EQ, Expression => ActionFn(38);
+        assert!(__symbols.len() >= 3);
+        let __sym2 = __pop_Variant11(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant11(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym2.2;
+        let __nt = super::__action38::<>(input, __sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant9(__nt), __end));
+        (3, 40)
+    }
+    fn __reduce81<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // UpdateCommand = INSERT, INTO, IdToken, LPAREN, Comma<IdToken>, RPAREN, VALUES, LPAREN, Comma<Constant>, RPAREN => ActionFn(24);
+        assert!(__symbols.len() >= 10);
+        let __sym9 = __pop_Variant0(__symbols);
+        let __sym8 = __pop_Variant14(__symbols);
+        let __sym7 = __pop_Variant0(__symbols);
+        let __sym6 = __pop_Variant0(__symbols);
+        let __sym5 = __pop_Variant0(__symbols);
+        let __sym4 = __pop_Variant16(__symbols);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym9.2;
+        let __nt = super::__action24::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9);
+        __symbols.push((__start, __Symbol::Variant27(__nt), __end));
+        (10, 41)
+    }
+    fn __reduce82<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // UpdateCommand = DELETE, FROM, IdToken => ActionFn(25);
+        assert!(__symbols.len() >= 3);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym2.2;
+        let __nt = super::__action25::<>(input, __sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant27(__nt), __end));
+        (3, 41)
+    }
+    fn __reduce83<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // UpdateCommand = DELETE, FROM, IdToken, WHERE, Predicate => ActionFn(26);
+        assert!(__symbols.len() >= 5);
+        let __sym4 = __pop_Variant24(__symbols);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym4.2;
+        let __nt = super::__action26::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4);
+        __symbols.push((__start, __Symbol::Variant27(__nt), __end));
+        (5, 41)
+    }
+    fn __reduce84<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // UpdateCommand = MODIFY, IdToken, SET, IdToken, EQ, Expression => ActionFn(27);
+        assert!(__symbols.len() >= 6);
+        let __sym5 = __pop_Variant11(__symbols);
+        let __sym4 = __pop_Variant0(__symbols);
+        let __sym3 = __pop_Variant5(__symbols);
+        let __sym2 = __pop_Variant0(__symbols);
+        let __sym1 = __pop_Variant5(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym5.2;
+        let __nt = super::__action27::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
+        __symbols.push((__start, __Symbol::Variant27(__nt), __end));
+        (6, 41)
+    }
+    fn __reduce85<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // UpdateCommand = MODIFY, IdToken, SET, IdToken, EQ, Expression, WHERE, Predicate => ActionFn(28);
+        assert!(__symbols.len() >= 8);
+        let __sym7 = __pop_Variant24(__symbols);
+        let __sym6 = __pop_Variant0(__symbols);
+        let __sym5 = __pop_Variant11(__symbols);
+        let __sym4 = __pop_Variant0(__symbols);
+        let __sym3 = __pop_Variant5(__symbols);
+        let __sym2 = __pop_Variant0(__symbols);
+        let __sym1 = __pop_Variant5(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym7.2;
+        let __nt = super::__action28::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
+        __symbols.push((__start, __Symbol::Variant27(__nt), __end));
+        (8, 41)
+    }
+    fn __reduce86<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // UpdateCommand = CreateCommand => ActionFn(29);
+        let __sym0 = __pop_Variant18(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action29::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant27(__nt), __end));
+        (1, 41)
+    }
+    fn __reduce87<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // __Predicate = Predicate => ActionFn(3);
         let __sym0 = __pop_Variant24(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1::<>(input, __sym0);
+        let __nt = super::__action3::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant24(__nt), __end));
-        (1, 41)
+        (1, 42)
     }
-    fn __reduce82<
+    fn __reduce88<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // __Query = Query => ActionFn(1);
+        let __sym0 = __pop_Variant25(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action1::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant25(__nt), __end));
+        (1, 43)
+    }
+    fn __reduce90<
         'input,
     >(
         input: &'input str,
@@ -9978,9 +10981,9 @@ mod __parse__Statement {
         let __end = __sym0.2;
         let __nt = super::__action4::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant9(__nt), __end));
-        (1, 43)
+        (1, 45)
     }
-    fn __reduce83<
+    fn __reduce91<
         'input,
     >(
         input: &'input str,
@@ -9990,12 +10993,12 @@ mod __parse__Statement {
     ) -> (usize, usize)
     {
         // __UpdateCommand = UpdateCommand => ActionFn(2);
-        let __sym0 = __pop_Variant26(__symbols);
+        let __sym0 = __pop_Variant27(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action2::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant26(__nt), __end));
-        (1, 44)
+        __symbols.push((__start, __Symbol::Variant27(__nt), __end));
+        (1, 46)
     }
 }
 #[allow(unused_imports)]
@@ -10010,6 +11013,15 @@ mod __parse__Term {
     use super::super::predicate;
     use super::super::expression;
     use crate::record::field::{Spec, Value};
+    use crate::materialization::{
+    aggregation_function::AggregationFn,
+    aggregation_function::AggregationFnControl,
+    avg_function::AvgFn,
+    count_function::CountFn,
+    max_function::MaxFn,
+    min_function::MinFn,
+    sum_function::SumFn,
+};
     #[allow(unused_extern_crates)]
     extern crate lalrpop_util as __lalrpop_util;
     #[allow(unused_imports)]
@@ -10027,87 +11039,88 @@ mod __parse__Term {
         Variant4(alloc::vec::Vec<statement::FieldDefinition>),
         Variant5(String),
         Variant6(alloc::vec::Vec<String>),
-        Variant7((expression::Expression, Option<String>)),
-        Variant8(alloc::vec::Vec<(expression::Expression, Option<String>)>),
+        Variant7(statement::SelectField),
+        Variant8(alloc::vec::Vec<statement::SelectField>),
         Variant9(predicate::Term),
         Variant10(alloc::vec::Vec<predicate::Term>),
         Variant11(expression::Expression),
-        Variant12(Vec<predicate::Term>),
-        Variant13(Vec<Value>),
-        Variant14(Vec<statement::FieldDefinition>),
-        Variant15(Vec<String>),
-        Variant16(Vec<(expression::Expression, Option<String>)>),
-        Variant17(statement::CreateCommand),
-        Variant18(Option<Vec<(expression::Expression, Option<String>)>>),
-        Variant19(Spec),
-        Variant20(i32),
-        Variant21(Option<Vec<String>>),
-        Variant22(Option<predicate::Predicate>),
-        Variant23(predicate::Predicate),
-        Variant24(statement::QueryData),
-        Variant25(statement::Statement),
-        Variant26(statement::UpdateCommand),
+        Variant12(AggregationFn),
+        Variant13(Vec<predicate::Term>),
+        Variant14(Vec<Value>),
+        Variant15(Vec<statement::FieldDefinition>),
+        Variant16(Vec<String>),
+        Variant17(Vec<statement::SelectField>),
+        Variant18(statement::CreateCommand),
+        Variant19(Option<Vec<statement::SelectField>>),
+        Variant20(Spec),
+        Variant21(i32),
+        Variant22(Option<Vec<String>>),
+        Variant23(Option<predicate::Predicate>),
+        Variant24(predicate::Predicate),
+        Variant25(statement::QueryData),
+        Variant26(statement::Statement),
+        Variant27(statement::UpdateCommand),
     }
     const __ACTION: &[i8] = &[
         // State 0
-        0, 17, 19, 16, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 17, 19, 16, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 1
-        0, 17, 19, 16, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 17, 19, 16, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 2
-        0, 17, 19, 16, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 17, 19, 16, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 3
-        0, 17, 19, 16, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 17, 19, 16, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 4
-        0, 17, 19, 16, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 17, 19, 16, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 5
-        0, 17, 19, 16, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 17, 19, 16, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 6
-        0, 17, 19, 16, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 17, 19, 16, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 7
-        0, 0, 0, 0, 3, 0, -45, 0, 4, 0, 0, -45, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -45, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 3, 0, -50, 0, 4, 0, 0, -50, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -50, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 8
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 20, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 20, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 9
-        0, 0, 0, 0, -60, 0, -60, -60, -60, 0, -60, -60, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -60, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -65, 0, -65, -65, -65, 0, -65, -65, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -65, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 10
-        0, 0, 0, 0, -48, 0, -48, -48, -48, 0, -48, -48, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -48, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -53, 0, -53, -53, -53, 0, -53, -53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 11
-        0, 0, 0, 0, -50, 0, -50, -50, -50, 0, -50, -50, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -50, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -55, 0, -55, -55, -55, 0, -55, -55, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -55, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 12
-        0, 0, 0, 0, -28, 0, -28, 7, -28, 0, 6, -28, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -28, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -28, 0, -28, 7, -28, 0, 6, -28, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -28, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 13
-        0, 0, 0, 0, -49, 0, -49, -49, -49, 0, -49, -49, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -49, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -54, 0, -54, -54, -54, 0, -54, -54, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -54, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 14
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 15
-        0, 0, 0, 0, -56, 0, -56, -56, -56, 0, -56, -56, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -56, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -61, 0, -61, -61, -61, 0, -61, -61, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -61, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 16
-        0, 0, 0, 0, -57, 0, -57, -57, -57, 0, -57, -57, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -57, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -62, 0, -62, -62, -62, 0, -62, -62, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -62, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 17
-        0, 0, 0, 0, -47, 0, -47, -47, -47, 0, -47, -47, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -47, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -52, 0, -52, -52, -52, 0, -52, -52, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -52, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 18
-        0, 0, 0, 0, -71, 0, -71, -71, -71, 0, -71, -71, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -71, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -79, 0, -79, -79, -79, 0, -79, -79, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -79, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 19
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 25, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 20
-        0, 0, 0, 0, 0, 0, 28, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 28, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 21
-        0, 0, 0, 0, -27, 0, -27, 7, -27, 0, 6, -27, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -27, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -27, 0, -27, 7, -27, 0, 6, -27, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -27, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 22
-        0, 0, 0, 0, -26, 0, -26, 7, -26, 0, 6, -26, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -26, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -26, 0, -26, 7, -26, 0, 6, -26, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -26, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 23
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 24
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 25
-        0, 0, 0, 0, -59, 0, -59, -59, -59, 0, -59, -59, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -59, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -64, 0, -64, -64, -64, 0, -64, -64, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -64, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 26
-        0, 0, 0, 0, -58, 0, -58, -58, -58, 0, -58, -58, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -58, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -63, 0, -63, -63, -63, 0, -63, -63, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -63, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 27
-        0, 0, 0, 0, -46, 0, -46, -46, -46, 0, -46, -46, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -46, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -51, 0, -51, -51, -51, 0, -51, -51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     ];
     fn __action(state: i8, integer: usize) -> i8 {
-        __ACTION[(state as usize) * 34 + integer]
+        __ACTION[(state as usize) * 40 + integer]
     }
     const __EOF_ACTION: &[i8] = &[
         // State 0
@@ -10125,29 +11138,29 @@ mod __parse__Term {
         // State 6
         0,
         // State 7
-        -45,
+        -50,
         // State 8
         0,
         // State 9
-        -60,
+        -65,
         // State 10
-        -48,
+        -53,
         // State 11
-        -50,
+        -55,
         // State 12
         -28,
         // State 13
-        -49,
+        -54,
         // State 14
-        -83,
+        -91,
         // State 15
-        -56,
+        -61,
         // State 16
-        -57,
+        -62,
         // State 17
-        -47,
+        -52,
         // State 18
-        -71,
+        -79,
         // State 19
         0,
         // State 20
@@ -10157,38 +11170,38 @@ mod __parse__Term {
         // State 22
         -26,
         // State 23
-        -73,
+        -81,
         // State 24
-        -72,
+        -80,
         // State 25
-        -59,
+        -64,
         // State 26
-        -58,
+        -63,
         // State 27
-        -46,
+        -51,
     ];
     fn __goto(state: i8, nt: usize) -> i8 {
         match nt {
             15 => 7,
-            23 => match state {
+            24 => match state {
                 1 => 20,
                 4 => 23,
                 _ => 8,
             },
-            24 => match state {
+            25 => match state {
                 5 => 25,
                 6 => 26,
                 _ => 9,
             },
-            28 => 10,
-            29 => 11,
-            30 => match state {
+            29 => 10,
+            30 => 11,
+            31 => match state {
                 2 => 21,
                 3 => 22,
                 _ => 12,
             },
-            37 => 13,
-            38 => 14,
+            39 => 13,
+            40 => 14,
             _ => 0,
         }
     }
@@ -10207,21 +11220,27 @@ mod __parse__Term {
         r###"EQ"###,
         r###"AND"###,
         r###"AS"###,
+        r###"AVG"###,
         r###"BY"###,
+        r###"COUNT"###,
         r###"CREATE"###,
         r###"DELETE"###,
         r###"FROM"###,
+        r###"GROUP"###,
         r###"I32"###,
         r###"INDEX"###,
         r###"INSERT"###,
         r###"INTO"###,
         r###"IS"###,
+        r###"MAX"###,
+        r###"MIN"###,
         r###"MODIFY"###,
         r###"NULL"###,
         r###"ON"###,
         r###"ORDER"###,
         r###"SELECT"###,
         r###"SET"###,
+        r###"SUM"###,
         r###"TABLE"###,
         r###"VALUES"###,
         r###"VARCHAR"###,
@@ -10295,7 +11314,7 @@ mod __parse__Term {
 
         #[inline]
         fn error_action(&self, state: i8) -> i8 {
-            __action(state, 34 - 1)
+            __action(state, 40 - 1)
         }
 
         #[inline]
@@ -10397,6 +11416,12 @@ mod __parse__Term {
             Token(31, _) if true => Some(31),
             Token(32, _) if true => Some(32),
             Token(33, _) if true => Some(33),
+            Token(34, _) if true => Some(34),
+            Token(35, _) if true => Some(35),
+            Token(36, _) if true => Some(36),
+            Token(37, _) if true => Some(37),
+            Token(38, _) if true => Some(38),
+            Token(39, _) if true => Some(39),
             _ => None,
         }
     }
@@ -10409,8 +11434,8 @@ mod __parse__Term {
     ) -> __Symbol<'input>
     {
         #[allow(clippy::manual_range_patterns)]match __token_index {
-            0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20 | 21 | 22 | 23 | 24 | 25 | 26 | 27 | 28 | 29 | 30 | 31 | 32 | 33 => match __token {
-                Token(0, __tok0) | Token(1, __tok0) | Token(2, __tok0) | Token(3, __tok0) | Token(4, __tok0) | Token(5, __tok0) | Token(6, __tok0) | Token(7, __tok0) | Token(8, __tok0) | Token(9, __tok0) | Token(10, __tok0) | Token(11, __tok0) | Token(12, __tok0) | Token(13, __tok0) | Token(14, __tok0) | Token(15, __tok0) | Token(16, __tok0) | Token(17, __tok0) | Token(18, __tok0) | Token(19, __tok0) | Token(20, __tok0) | Token(21, __tok0) | Token(22, __tok0) | Token(23, __tok0) | Token(24, __tok0) | Token(25, __tok0) | Token(26, __tok0) | Token(27, __tok0) | Token(28, __tok0) | Token(29, __tok0) | Token(30, __tok0) | Token(31, __tok0) | Token(32, __tok0) | Token(33, __tok0) if true => __Symbol::Variant0(__tok0),
+            0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20 | 21 | 22 | 23 | 24 | 25 | 26 | 27 | 28 | 29 | 30 | 31 | 32 | 33 | 34 | 35 | 36 | 37 | 38 | 39 => match __token {
+                Token(0, __tok0) | Token(1, __tok0) | Token(2, __tok0) | Token(3, __tok0) | Token(4, __tok0) | Token(5, __tok0) | Token(6, __tok0) | Token(7, __tok0) | Token(8, __tok0) | Token(9, __tok0) | Token(10, __tok0) | Token(11, __tok0) | Token(12, __tok0) | Token(13, __tok0) | Token(14, __tok0) | Token(15, __tok0) | Token(16, __tok0) | Token(17, __tok0) | Token(18, __tok0) | Token(19, __tok0) | Token(20, __tok0) | Token(21, __tok0) | Token(22, __tok0) | Token(23, __tok0) | Token(24, __tok0) | Token(25, __tok0) | Token(26, __tok0) | Token(27, __tok0) | Token(28, __tok0) | Token(29, __tok0) | Token(30, __tok0) | Token(31, __tok0) | Token(32, __tok0) | Token(33, __tok0) | Token(34, __tok0) | Token(35, __tok0) | Token(36, __tok0) | Token(37, __tok0) | Token(38, __tok0) | Token(39, __tok0) if true => __Symbol::Variant0(__tok0),
                 _ => unreachable!(),
             },
             _ => unreachable!(),
@@ -10594,128 +11619,128 @@ mod __parse__Term {
             }
             28 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
+                    states_to_pop: 4,
                     nonterminal_produced: 16,
                 }
             }
             29 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 2,
+                    states_to_pop: 4,
                     nonterminal_produced: 16,
                 }
             }
             30 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 17,
+                    states_to_pop: 4,
+                    nonterminal_produced: 16,
                 }
             }
             31 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 2,
-                    nonterminal_produced: 17,
+                    states_to_pop: 4,
+                    nonterminal_produced: 16,
                 }
             }
             32 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 18,
+                    states_to_pop: 4,
+                    nonterminal_produced: 16,
                 }
             }
             33 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 2,
-                    nonterminal_produced: 18,
+                    states_to_pop: 1,
+                    nonterminal_produced: 17,
                 }
             }
             34 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 19,
+                    states_to_pop: 2,
+                    nonterminal_produced: 17,
                 }
             }
             35 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 2,
-                    nonterminal_produced: 19,
+                    states_to_pop: 1,
+                    nonterminal_produced: 18,
                 }
             }
             36 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 20,
+                    states_to_pop: 2,
+                    nonterminal_produced: 18,
                 }
             }
             37 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 2,
-                    nonterminal_produced: 20,
+                    states_to_pop: 1,
+                    nonterminal_produced: 19,
                 }
             }
             38 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 21,
+                    states_to_pop: 2,
+                    nonterminal_produced: 19,
                 }
             }
             39 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
-                    nonterminal_produced: 21,
+                    nonterminal_produced: 20,
                 }
             }
             40 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 2,
+                    nonterminal_produced: 20,
+                }
+            }
+            41 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
                     nonterminal_produced: 21,
                 }
             }
-            41 => {
-                __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 6,
-                    nonterminal_produced: 22,
-                }
-            }
             42 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 5,
-                    nonterminal_produced: 22,
+                    states_to_pop: 2,
+                    nonterminal_produced: 21,
                 }
             }
             43 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 8,
+                    states_to_pop: 1,
                     nonterminal_produced: 22,
                 }
             }
             44 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
-                    nonterminal_produced: 23,
+                    nonterminal_produced: 22,
                 }
             }
             45 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 3,
-                    nonterminal_produced: 24,
+                    states_to_pop: 1,
+                    nonterminal_produced: 22,
                 }
             }
             46 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 24,
+                    states_to_pop: 6,
+                    nonterminal_produced: 23,
                 }
             }
             47 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 24,
+                    states_to_pop: 5,
+                    nonterminal_produced: 23,
                 }
             }
             48 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 24,
+                    states_to_pop: 8,
+                    nonterminal_produced: 23,
                 }
             }
             49 => {
@@ -10726,170 +11751,170 @@ mod __parse__Term {
             }
             50 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 2,
+                    states_to_pop: 3,
                     nonterminal_produced: 25,
                 }
             }
             51 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
-                    nonterminal_produced: 26,
+                    nonterminal_produced: 25,
                 }
             }
             52 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
-                    nonterminal_produced: 26,
+                    nonterminal_produced: 25,
                 }
             }
             53 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
-                    nonterminal_produced: 27,
+                    nonterminal_produced: 25,
                 }
             }
             54 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 4,
-                    nonterminal_produced: 27,
+                    states_to_pop: 1,
+                    nonterminal_produced: 25,
                 }
             }
             55 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 28,
+                    states_to_pop: 2,
+                    nonterminal_produced: 26,
                 }
             }
             56 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
-                    nonterminal_produced: 29,
+                    nonterminal_produced: 27,
                 }
             }
             57 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 3,
-                    nonterminal_produced: 30,
+                    states_to_pop: 1,
+                    nonterminal_produced: 27,
                 }
             }
             58 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 3,
-                    nonterminal_produced: 30,
+                    states_to_pop: 1,
+                    nonterminal_produced: 28,
                 }
             }
             59 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 4,
+                    nonterminal_produced: 28,
+                }
+            }
+            60 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 1,
+                    nonterminal_produced: 29,
+                }
+            }
+            61 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
                     nonterminal_produced: 30,
                 }
             }
-            60 => {
+            62 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 3,
                     nonterminal_produced: 31,
                 }
             }
-            61 => {
-                __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 0,
-                    nonterminal_produced: 31,
-                }
-            }
-            62 => {
-                __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 2,
-                    nonterminal_produced: 32,
-                }
-            }
             63 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 0,
-                    nonterminal_produced: 32,
+                    states_to_pop: 3,
+                    nonterminal_produced: 31,
                 }
             }
             64 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
-                    nonterminal_produced: 33,
+                    nonterminal_produced: 31,
                 }
             }
             65 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 6,
-                    nonterminal_produced: 34,
+                    states_to_pop: 3,
+                    nonterminal_produced: 32,
                 }
             }
             66 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 3,
-                    nonterminal_produced: 35,
+                    states_to_pop: 0,
+                    nonterminal_produced: 32,
                 }
             }
             67 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 35,
+                    states_to_pop: 3,
+                    nonterminal_produced: 33,
                 }
             }
             68 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 36,
+                    states_to_pop: 0,
+                    nonterminal_produced: 33,
                 }
             }
             69 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 36,
+                    states_to_pop: 2,
+                    nonterminal_produced: 34,
                 }
             }
             70 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 0,
+                    nonterminal_produced: 34,
+                }
+            }
+            71 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 1,
+                    nonterminal_produced: 35,
+                }
+            }
+            72 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 7,
+                    nonterminal_produced: 36,
+                }
+            }
+            73 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 3,
+                    nonterminal_produced: 37,
+                }
+            }
+            74 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
                     nonterminal_produced: 37,
                 }
             }
-            71 => {
-                __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 3,
-                    nonterminal_produced: 38,
-                }
-            }
-            72 => {
-                __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 3,
-                    nonterminal_produced: 38,
-                }
-            }
-            73 => {
-                __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 10,
-                    nonterminal_produced: 39,
-                }
-            }
-            74 => {
-                __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 3,
-                    nonterminal_produced: 39,
-                }
-            }
             75 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 5,
-                    nonterminal_produced: 39,
+                    states_to_pop: 1,
+                    nonterminal_produced: 37,
                 }
             }
             76 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 6,
-                    nonterminal_produced: 39,
+                    states_to_pop: 1,
+                    nonterminal_produced: 38,
                 }
             }
             77 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 8,
-                    nonterminal_produced: 39,
+                    states_to_pop: 1,
+                    nonterminal_produced: 38,
                 }
             }
             78 => {
@@ -10900,27 +11925,75 @@ mod __parse__Term {
             }
             79 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
+                    states_to_pop: 3,
                     nonterminal_produced: 40,
                 }
             }
             80 => {
                 __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 3,
+                    nonterminal_produced: 40,
+                }
+            }
+            81 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 10,
+                    nonterminal_produced: 41,
+                }
+            }
+            82 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 3,
+                    nonterminal_produced: 41,
+                }
+            }
+            83 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 5,
+                    nonterminal_produced: 41,
+                }
+            }
+            84 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 6,
+                    nonterminal_produced: 41,
+                }
+            }
+            85 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 8,
+                    nonterminal_produced: 41,
+                }
+            }
+            86 => {
+                __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
                     nonterminal_produced: 41,
                 }
             }
-            81 => {
+            87 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
                     nonterminal_produced: 42,
                 }
             }
-            82 => __state_machine::SimulatedReduce::Accept,
-            83 => {
+            88 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 1,
+                    nonterminal_produced: 43,
+                }
+            }
+            89 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
                     nonterminal_produced: 44,
+                }
+            }
+            90 => __state_machine::SimulatedReduce::Accept,
+            91 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 1,
+                    nonterminal_produced: 46,
                 }
             }
             _ => panic!("invalid reduction index {}", __reduce_index)
@@ -11251,6 +12324,30 @@ mod __parse__Term {
                 __reduce81(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
             }
             82 => {
+                __reduce82(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
+            }
+            83 => {
+                __reduce83(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
+            }
+            84 => {
+                __reduce84(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
+            }
+            85 => {
+                __reduce85(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
+            }
+            86 => {
+                __reduce86(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
+            }
+            87 => {
+                __reduce87(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
+            }
+            88 => {
+                __reduce88(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
+            }
+            89 => {
+                __reduce89(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
+            }
+            90 => {
                 // __Term = Term => ActionFn(4);
                 let __sym0 = __pop_Variant9(__symbols);
                 let __start = __sym0.0;
@@ -11258,8 +12355,8 @@ mod __parse__Term {
                 let __nt = super::__action4::<>(input, __sym0);
                 return Some(Ok(__nt));
             }
-            83 => {
-                __reduce83(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
+            91 => {
+                __reduce91(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
             }
             _ => panic!("invalid action code {}", __action)
         };
@@ -11274,36 +12371,14 @@ mod __parse__Term {
     fn __symbol_type_mismatch() -> ! {
         panic!("symbol type mismatch")
     }
-    fn __pop_Variant7<
+    fn __pop_Variant12<
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, (expression::Expression, Option<String>), usize)
+    ) -> (usize, AggregationFn, usize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant7(__v), __r)) => (__l, __v, __r),
-            _ => __symbol_type_mismatch()
-        }
-    }
-    fn __pop_Variant18<
-      'input,
-    >(
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, Option<Vec<(expression::Expression, Option<String>)>>, usize)
-     {
-        match __symbols.pop() {
-            Some((__l, __Symbol::Variant18(__v), __r)) => (__l, __v, __r),
-            _ => __symbol_type_mismatch()
-        }
-    }
-    fn __pop_Variant21<
-      'input,
-    >(
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, Option<Vec<String>>, usize)
-     {
-        match __symbols.pop() {
-            Some((__l, __Symbol::Variant21(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant12(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -11311,7 +12386,7 @@ mod __parse__Term {
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, Option<predicate::Predicate>, usize)
+    ) -> (usize, Option<Vec<String>>, usize)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant22(__v), __r)) => (__l, __v, __r),
@@ -11322,10 +12397,32 @@ mod __parse__Term {
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, Spec, usize)
+    ) -> (usize, Option<Vec<statement::SelectField>>, usize)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant19(__v), __r)) => (__l, __v, __r),
+            _ => __symbol_type_mismatch()
+        }
+    }
+    fn __pop_Variant23<
+      'input,
+    >(
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
+    ) -> (usize, Option<predicate::Predicate>, usize)
+     {
+        match __symbols.pop() {
+            Some((__l, __Symbol::Variant23(__v), __r)) => (__l, __v, __r),
+            _ => __symbol_type_mismatch()
+        }
+    }
+    fn __pop_Variant20<
+      'input,
+    >(
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
+    ) -> (usize, Spec, usize)
+     {
+        match __symbols.pop() {
+            Some((__l, __Symbol::Variant20(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -11355,43 +12452,10 @@ mod __parse__Term {
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, Vec<(expression::Expression, Option<String>)>, usize)
-     {
-        match __symbols.pop() {
-            Some((__l, __Symbol::Variant16(__v), __r)) => (__l, __v, __r),
-            _ => __symbol_type_mismatch()
-        }
-    }
-    fn __pop_Variant15<
-      'input,
-    >(
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
     ) -> (usize, Vec<String>, usize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant15(__v), __r)) => (__l, __v, __r),
-            _ => __symbol_type_mismatch()
-        }
-    }
-    fn __pop_Variant13<
-      'input,
-    >(
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, Vec<Value>, usize)
-     {
-        match __symbols.pop() {
-            Some((__l, __Symbol::Variant13(__v), __r)) => (__l, __v, __r),
-            _ => __symbol_type_mismatch()
-        }
-    }
-    fn __pop_Variant12<
-      'input,
-    >(
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, Vec<predicate::Term>, usize)
-     {
-        match __symbols.pop() {
-            Some((__l, __Symbol::Variant12(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant16(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -11399,21 +12463,43 @@ mod __parse__Term {
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, Vec<statement::FieldDefinition>, usize)
+    ) -> (usize, Vec<Value>, usize)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant14(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant8<
+    fn __pop_Variant13<
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, alloc::vec::Vec<(expression::Expression, Option<String>)>, usize)
+    ) -> (usize, Vec<predicate::Term>, usize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant8(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant13(__v), __r)) => (__l, __v, __r),
+            _ => __symbol_type_mismatch()
+        }
+    }
+    fn __pop_Variant15<
+      'input,
+    >(
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
+    ) -> (usize, Vec<statement::FieldDefinition>, usize)
+     {
+        match __symbols.pop() {
+            Some((__l, __Symbol::Variant15(__v), __r)) => (__l, __v, __r),
+            _ => __symbol_type_mismatch()
+        }
+    }
+    fn __pop_Variant17<
+      'input,
+    >(
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
+    ) -> (usize, Vec<statement::SelectField>, usize)
+     {
+        match __symbols.pop() {
+            Some((__l, __Symbol::Variant17(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -11461,6 +12547,17 @@ mod __parse__Term {
             _ => __symbol_type_mismatch()
         }
     }
+    fn __pop_Variant8<
+      'input,
+    >(
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
+    ) -> (usize, alloc::vec::Vec<statement::SelectField>, usize)
+     {
+        match __symbols.pop() {
+            Some((__l, __Symbol::Variant8(__v), __r)) => (__l, __v, __r),
+            _ => __symbol_type_mismatch()
+        }
+    }
     fn __pop_Variant11<
       'input,
     >(
@@ -11472,25 +12569,25 @@ mod __parse__Term {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant20<
+    fn __pop_Variant21<
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
     ) -> (usize, i32, usize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant20(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant21(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant23<
+    fn __pop_Variant24<
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
     ) -> (usize, predicate::Predicate, usize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant23(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant24(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -11505,14 +12602,14 @@ mod __parse__Term {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant17<
+    fn __pop_Variant18<
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
     ) -> (usize, statement::CreateCommand, usize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant17(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant18(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -11527,25 +12624,25 @@ mod __parse__Term {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant24<
+    fn __pop_Variant25<
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
     ) -> (usize, statement::QueryData, usize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant24(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant25(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant25<
+    fn __pop_Variant7<
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, statement::Statement, usize)
+    ) -> (usize, statement::SelectField, usize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant25(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant7(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -11553,10 +12650,21 @@ mod __parse__Term {
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, statement::UpdateCommand, usize)
+    ) -> (usize, statement::Statement, usize)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant26(__v), __r)) => (__l, __v, __r),
+            _ => __symbol_type_mismatch()
+        }
+    }
+    fn __pop_Variant27<
+      'input,
+    >(
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
+    ) -> (usize, statement::UpdateCommand, usize)
+     {
+        match __symbols.pop() {
+            Some((__l, __Symbol::Variant27(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -11580,13 +12688,13 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Constant> COMMA) = Constant, COMMA => ActionFn(62);
+        // (<Constant> COMMA) = Constant, COMMA => ActionFn(70);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant1(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action62::<>(input, __sym0, __sym1);
+        let __nt = super::__action70::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant1(__nt), __end));
         (2, 0)
     }
@@ -11599,10 +12707,10 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Constant> COMMA)* =  => ActionFn(60);
+        // (<Constant> COMMA)* =  => ActionFn(68);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action60::<>(input, &__start, &__end);
+        let __nt = super::__action68::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant2(__nt), __end));
         (0, 1)
     }
@@ -11615,11 +12723,11 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Constant> COMMA)* = (<Constant> COMMA)+ => ActionFn(61);
+        // (<Constant> COMMA)* = (<Constant> COMMA)+ => ActionFn(69);
         let __sym0 = __pop_Variant2(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action61::<>(input, __sym0);
+        let __nt = super::__action69::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant2(__nt), __end));
         (1, 1)
     }
@@ -11632,13 +12740,13 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Constant> COMMA)+ = Constant, COMMA => ActionFn(79);
+        // (<Constant> COMMA)+ = Constant, COMMA => ActionFn(87);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant1(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action79::<>(input, __sym0, __sym1);
+        let __nt = super::__action87::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant2(__nt), __end));
         (2, 2)
     }
@@ -11651,14 +12759,14 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Constant> COMMA)+ = (<Constant> COMMA)+, Constant, COMMA => ActionFn(80);
+        // (<Constant> COMMA)+ = (<Constant> COMMA)+, Constant, COMMA => ActionFn(88);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant1(__symbols);
         let __sym0 = __pop_Variant2(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action80::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action88::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant2(__nt), __end));
         (3, 2)
     }
@@ -11671,13 +12779,13 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<FieldDefinition> COMMA) = FieldDefinition, COMMA => ActionFn(65);
+        // (<FieldDefinition> COMMA) = FieldDefinition, COMMA => ActionFn(73);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant3(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action65::<>(input, __sym0, __sym1);
+        let __nt = super::__action73::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant3(__nt), __end));
         (2, 3)
     }
@@ -11690,10 +12798,10 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<FieldDefinition> COMMA)* =  => ActionFn(63);
+        // (<FieldDefinition> COMMA)* =  => ActionFn(71);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action63::<>(input, &__start, &__end);
+        let __nt = super::__action71::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant4(__nt), __end));
         (0, 4)
     }
@@ -11706,11 +12814,11 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<FieldDefinition> COMMA)* = (<FieldDefinition> COMMA)+ => ActionFn(64);
+        // (<FieldDefinition> COMMA)* = (<FieldDefinition> COMMA)+ => ActionFn(72);
         let __sym0 = __pop_Variant4(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action64::<>(input, __sym0);
+        let __nt = super::__action72::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant4(__nt), __end));
         (1, 4)
     }
@@ -11723,13 +12831,13 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<FieldDefinition> COMMA)+ = FieldDefinition, COMMA => ActionFn(83);
+        // (<FieldDefinition> COMMA)+ = FieldDefinition, COMMA => ActionFn(91);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant3(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action83::<>(input, __sym0, __sym1);
+        let __nt = super::__action91::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant4(__nt), __end));
         (2, 5)
     }
@@ -11742,14 +12850,14 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<FieldDefinition> COMMA)+ = (<FieldDefinition> COMMA)+, FieldDefinition, COMMA => ActionFn(84);
+        // (<FieldDefinition> COMMA)+ = (<FieldDefinition> COMMA)+, FieldDefinition, COMMA => ActionFn(92);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant3(__symbols);
         let __sym0 = __pop_Variant4(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action84::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action92::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant4(__nt), __end));
         (3, 5)
     }
@@ -11762,13 +12870,13 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<IdToken> COMMA) = IdToken, COMMA => ActionFn(56);
+        // (<IdToken> COMMA) = IdToken, COMMA => ActionFn(64);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action56::<>(input, __sym0, __sym1);
+        let __nt = super::__action64::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant5(__nt), __end));
         (2, 6)
     }
@@ -11781,10 +12889,10 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<IdToken> COMMA)* =  => ActionFn(54);
+        // (<IdToken> COMMA)* =  => ActionFn(62);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action54::<>(input, &__start, &__end);
+        let __nt = super::__action62::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant6(__nt), __end));
         (0, 7)
     }
@@ -11797,11 +12905,11 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<IdToken> COMMA)* = (<IdToken> COMMA)+ => ActionFn(55);
+        // (<IdToken> COMMA)* = (<IdToken> COMMA)+ => ActionFn(63);
         let __sym0 = __pop_Variant6(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action55::<>(input, __sym0);
+        let __nt = super::__action63::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant6(__nt), __end));
         (1, 7)
     }
@@ -11814,13 +12922,13 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<IdToken> COMMA)+ = IdToken, COMMA => ActionFn(87);
+        // (<IdToken> COMMA)+ = IdToken, COMMA => ActionFn(95);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action87::<>(input, __sym0, __sym1);
+        let __nt = super::__action95::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant6(__nt), __end));
         (2, 8)
     }
@@ -11833,14 +12941,14 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<IdToken> COMMA)+ = (<IdToken> COMMA)+, IdToken, COMMA => ActionFn(88);
+        // (<IdToken> COMMA)+ = (<IdToken> COMMA)+, IdToken, COMMA => ActionFn(96);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant5(__symbols);
         let __sym0 = __pop_Variant6(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action88::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action96::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant6(__nt), __end));
         (3, 8)
     }
@@ -11853,13 +12961,13 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<SelectField> COMMA) = SelectField, COMMA => ActionFn(59);
+        // (<SelectField> COMMA) = SelectField, COMMA => ActionFn(67);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant7(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action59::<>(input, __sym0, __sym1);
+        let __nt = super::__action67::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant7(__nt), __end));
         (2, 9)
     }
@@ -11872,10 +12980,10 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<SelectField> COMMA)* =  => ActionFn(57);
+        // (<SelectField> COMMA)* =  => ActionFn(65);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action57::<>(input, &__start, &__end);
+        let __nt = super::__action65::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant8(__nt), __end));
         (0, 10)
     }
@@ -11888,11 +12996,11 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<SelectField> COMMA)* = (<SelectField> COMMA)+ => ActionFn(58);
+        // (<SelectField> COMMA)* = (<SelectField> COMMA)+ => ActionFn(66);
         let __sym0 = __pop_Variant8(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action58::<>(input, __sym0);
+        let __nt = super::__action66::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant8(__nt), __end));
         (1, 10)
     }
@@ -11905,13 +13013,13 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<SelectField> COMMA)+ = SelectField, COMMA => ActionFn(91);
+        // (<SelectField> COMMA)+ = SelectField, COMMA => ActionFn(99);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant7(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action91::<>(input, __sym0, __sym1);
+        let __nt = super::__action99::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant8(__nt), __end));
         (2, 11)
     }
@@ -11924,14 +13032,14 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<SelectField> COMMA)+ = (<SelectField> COMMA)+, SelectField, COMMA => ActionFn(92);
+        // (<SelectField> COMMA)+ = (<SelectField> COMMA)+, SelectField, COMMA => ActionFn(100);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant7(__symbols);
         let __sym0 = __pop_Variant8(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action92::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action100::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant8(__nt), __end));
         (3, 11)
     }
@@ -11944,13 +13052,13 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Term> AND) = Term, AND => ActionFn(68);
+        // (<Term> AND) = Term, AND => ActionFn(76);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant9(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action68::<>(input, __sym0, __sym1);
+        let __nt = super::__action76::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant9(__nt), __end));
         (2, 12)
     }
@@ -11963,10 +13071,10 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Term> AND)* =  => ActionFn(66);
+        // (<Term> AND)* =  => ActionFn(74);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action66::<>(input, &__start, &__end);
+        let __nt = super::__action74::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant10(__nt), __end));
         (0, 13)
     }
@@ -11979,11 +13087,11 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Term> AND)* = (<Term> AND)+ => ActionFn(67);
+        // (<Term> AND)* = (<Term> AND)+ => ActionFn(75);
         let __sym0 = __pop_Variant10(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action67::<>(input, __sym0);
+        let __nt = super::__action75::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant10(__nt), __end));
         (1, 13)
     }
@@ -11996,13 +13104,13 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Term> AND)+ = Term, AND => ActionFn(95);
+        // (<Term> AND)+ = Term, AND => ActionFn(103);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant9(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action95::<>(input, __sym0, __sym1);
+        let __nt = super::__action103::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant10(__nt), __end));
         (2, 14)
     }
@@ -12015,14 +13123,14 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Term> AND)+ = (<Term> AND)+, Term, AND => ActionFn(96);
+        // (<Term> AND)+ = (<Term> AND)+, Term, AND => ActionFn(104);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant9(__symbols);
         let __sym0 = __pop_Variant10(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action96::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action104::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant10(__nt), __end));
         (3, 14)
     }
@@ -12035,14 +13143,14 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AddExpr = AddExpr, PLUS, MulExpr => ActionFn(32);
+        // AddExpr = AddExpr, PLUS, MulExpr => ActionFn(40);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant11(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action32::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action40::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (3, 15)
     }
@@ -12055,14 +13163,14 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AddExpr = AddExpr, MINUS, MulExpr => ActionFn(33);
+        // AddExpr = AddExpr, MINUS, MulExpr => ActionFn(41);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant11(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action33::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action41::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (3, 15)
     }
@@ -12075,11 +13183,11 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AddExpr = MulExpr => ActionFn(34);
+        // AddExpr = MulExpr => ActionFn(42);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action34::<>(input, __sym0);
+        let __nt = super::__action42::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (1, 15)
     }
@@ -12092,13 +13200,17 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // And<Term> = Term => ActionFn(97);
-        let __sym0 = __pop_Variant9(__symbols);
+        // AggregationFn = MAX, LPAREN, IdToken, RPAREN => ActionFn(13);
+        assert!(__symbols.len() >= 4);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action97::<>(input, __sym0);
+        let __end = __sym3.2;
+        let __nt = super::__action13::<>(input, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant12(__nt), __end));
-        (1, 16)
+        (4, 16)
     }
     fn __reduce29<
         'input,
@@ -12109,15 +13221,17 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // And<Term> = (<Term> AND)+, Term => ActionFn(98);
-        assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant9(__symbols);
-        let __sym0 = __pop_Variant10(__symbols);
+        // AggregationFn = MIN, LPAREN, IdToken, RPAREN => ActionFn(14);
+        assert!(__symbols.len() >= 4);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym1.2;
-        let __nt = super::__action98::<>(input, __sym0, __sym1);
+        let __end = __sym3.2;
+        let __nt = super::__action14::<>(input, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant12(__nt), __end));
-        (2, 16)
+        (4, 16)
     }
     fn __reduce30<
         'input,
@@ -12128,13 +13242,17 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<Constant> = Constant => ActionFn(81);
-        let __sym0 = __pop_Variant1(__symbols);
+        // AggregationFn = SUM, LPAREN, IdToken, RPAREN => ActionFn(15);
+        assert!(__symbols.len() >= 4);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action81::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant13(__nt), __end));
-        (1, 17)
+        let __end = __sym3.2;
+        let __nt = super::__action15::<>(input, __sym0, __sym1, __sym2, __sym3);
+        __symbols.push((__start, __Symbol::Variant12(__nt), __end));
+        (4, 16)
     }
     fn __reduce31<
         'input,
@@ -12145,15 +13263,17 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<Constant> = (<Constant> COMMA)+, Constant => ActionFn(82);
-        assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant1(__symbols);
-        let __sym0 = __pop_Variant2(__symbols);
+        // AggregationFn = COUNT, LPAREN, IdToken, RPAREN => ActionFn(16);
+        assert!(__symbols.len() >= 4);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym1.2;
-        let __nt = super::__action82::<>(input, __sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant13(__nt), __end));
-        (2, 17)
+        let __end = __sym3.2;
+        let __nt = super::__action16::<>(input, __sym0, __sym1, __sym2, __sym3);
+        __symbols.push((__start, __Symbol::Variant12(__nt), __end));
+        (4, 16)
     }
     fn __reduce32<
         'input,
@@ -12164,13 +13284,17 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<FieldDefinition> = FieldDefinition => ActionFn(85);
-        let __sym0 = __pop_Variant3(__symbols);
+        // AggregationFn = AVG, LPAREN, IdToken, RPAREN => ActionFn(17);
+        assert!(__symbols.len() >= 4);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action85::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant14(__nt), __end));
-        (1, 18)
+        let __end = __sym3.2;
+        let __nt = super::__action17::<>(input, __sym0, __sym1, __sym2, __sym3);
+        __symbols.push((__start, __Symbol::Variant12(__nt), __end));
+        (4, 16)
     }
     fn __reduce33<
         'input,
@@ -12181,15 +13305,13 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<FieldDefinition> = (<FieldDefinition> COMMA)+, FieldDefinition => ActionFn(86);
-        assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant3(__symbols);
-        let __sym0 = __pop_Variant4(__symbols);
+        // And<Term> = Term => ActionFn(105);
+        let __sym0 = __pop_Variant9(__symbols);
         let __start = __sym0.0;
-        let __end = __sym1.2;
-        let __nt = super::__action86::<>(input, __sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant14(__nt), __end));
-        (2, 18)
+        let __end = __sym0.2;
+        let __nt = super::__action105::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant13(__nt), __end));
+        (1, 17)
     }
     fn __reduce34<
         'input,
@@ -12200,13 +13322,15 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<IdToken> = IdToken => ActionFn(89);
-        let __sym0 = __pop_Variant5(__symbols);
+        // And<Term> = (<Term> AND)+, Term => ActionFn(106);
+        assert!(__symbols.len() >= 2);
+        let __sym1 = __pop_Variant9(__symbols);
+        let __sym0 = __pop_Variant10(__symbols);
         let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action89::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant15(__nt), __end));
-        (1, 19)
+        let __end = __sym1.2;
+        let __nt = super::__action106::<>(input, __sym0, __sym1);
+        __symbols.push((__start, __Symbol::Variant13(__nt), __end));
+        (2, 17)
     }
     fn __reduce35<
         'input,
@@ -12217,15 +13341,13 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<IdToken> = (<IdToken> COMMA)+, IdToken => ActionFn(90);
-        assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant5(__symbols);
-        let __sym0 = __pop_Variant6(__symbols);
+        // Comma<Constant> = Constant => ActionFn(89);
+        let __sym0 = __pop_Variant1(__symbols);
         let __start = __sym0.0;
-        let __end = __sym1.2;
-        let __nt = super::__action90::<>(input, __sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant15(__nt), __end));
-        (2, 19)
+        let __end = __sym0.2;
+        let __nt = super::__action89::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant14(__nt), __end));
+        (1, 18)
     }
     fn __reduce36<
         'input,
@@ -12236,13 +13358,15 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<SelectField> = SelectField => ActionFn(93);
-        let __sym0 = __pop_Variant7(__symbols);
+        // Comma<Constant> = (<Constant> COMMA)+, Constant => ActionFn(90);
+        assert!(__symbols.len() >= 2);
+        let __sym1 = __pop_Variant1(__symbols);
+        let __sym0 = __pop_Variant2(__symbols);
         let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action93::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant16(__nt), __end));
-        (1, 20)
+        let __end = __sym1.2;
+        let __nt = super::__action90::<>(input, __sym0, __sym1);
+        __symbols.push((__start, __Symbol::Variant14(__nt), __end));
+        (2, 18)
     }
     fn __reduce37<
         'input,
@@ -12253,15 +13377,13 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<SelectField> = (<SelectField> COMMA)+, SelectField => ActionFn(94);
-        assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant7(__symbols);
-        let __sym0 = __pop_Variant8(__symbols);
+        // Comma<FieldDefinition> = FieldDefinition => ActionFn(93);
+        let __sym0 = __pop_Variant3(__symbols);
         let __start = __sym0.0;
-        let __end = __sym1.2;
-        let __nt = super::__action94::<>(input, __sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant16(__nt), __end));
-        (2, 20)
+        let __end = __sym0.2;
+        let __nt = super::__action93::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant15(__nt), __end));
+        (1, 19)
     }
     fn __reduce38<
         'input,
@@ -12272,13 +13394,15 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Constant = NULL => ActionFn(43);
-        let __sym0 = __pop_Variant0(__symbols);
+        // Comma<FieldDefinition> = (<FieldDefinition> COMMA)+, FieldDefinition => ActionFn(94);
+        assert!(__symbols.len() >= 2);
+        let __sym1 = __pop_Variant3(__symbols);
+        let __sym0 = __pop_Variant4(__symbols);
         let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action43::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant1(__nt), __end));
-        (1, 21)
+        let __end = __sym1.2;
+        let __nt = super::__action94::<>(input, __sym0, __sym1);
+        __symbols.push((__start, __Symbol::Variant15(__nt), __end));
+        (2, 19)
     }
     fn __reduce39<
         'input,
@@ -12289,13 +13413,13 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Constant = I32Constant => ActionFn(44);
-        let __sym0 = __pop_Variant20(__symbols);
+        // Comma<IdToken> = IdToken => ActionFn(97);
+        let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action44::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant1(__nt), __end));
-        (1, 21)
+        let __nt = super::__action97::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant16(__nt), __end));
+        (1, 20)
     }
     fn __reduce40<
         'input,
@@ -12306,13 +13430,15 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Constant = StringConstant => ActionFn(45);
-        let __sym0 = __pop_Variant5(__symbols);
+        // Comma<IdToken> = (<IdToken> COMMA)+, IdToken => ActionFn(98);
+        assert!(__symbols.len() >= 2);
+        let __sym1 = __pop_Variant5(__symbols);
+        let __sym0 = __pop_Variant6(__symbols);
         let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action45::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant1(__nt), __end));
-        (1, 21)
+        let __end = __sym1.2;
+        let __nt = super::__action98::<>(input, __sym0, __sym1);
+        __symbols.push((__start, __Symbol::Variant16(__nt), __end));
+        (2, 20)
     }
     fn __reduce41<
         'input,
@@ -12323,19 +13449,13 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // CreateCommand = CREATE, TABLE, IdToken, LPAREN, Comma<FieldDefinition>, RPAREN => ActionFn(22);
-        assert!(__symbols.len() >= 6);
-        let __sym5 = __pop_Variant0(__symbols);
-        let __sym4 = __pop_Variant14(__symbols);
-        let __sym3 = __pop_Variant0(__symbols);
-        let __sym2 = __pop_Variant5(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
+        // Comma<SelectField> = SelectField => ActionFn(101);
+        let __sym0 = __pop_Variant7(__symbols);
         let __start = __sym0.0;
-        let __end = __sym5.2;
-        let __nt = super::__action22::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
+        let __end = __sym0.2;
+        let __nt = super::__action101::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant17(__nt), __end));
-        (6, 22)
+        (1, 21)
     }
     fn __reduce42<
         'input,
@@ -12346,18 +13466,15 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // CreateCommand = CREATE, VIEW, IdToken, AS, Query => ActionFn(23);
-        assert!(__symbols.len() >= 5);
-        let __sym4 = __pop_Variant24(__symbols);
-        let __sym3 = __pop_Variant0(__symbols);
-        let __sym2 = __pop_Variant5(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
+        // Comma<SelectField> = (<SelectField> COMMA)+, SelectField => ActionFn(102);
+        assert!(__symbols.len() >= 2);
+        let __sym1 = __pop_Variant7(__symbols);
+        let __sym0 = __pop_Variant8(__symbols);
         let __start = __sym0.0;
-        let __end = __sym4.2;
-        let __nt = super::__action23::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4);
+        let __end = __sym1.2;
+        let __nt = super::__action102::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant17(__nt), __end));
-        (5, 22)
+        (2, 21)
     }
     fn __reduce43<
         'input,
@@ -12368,7 +13485,103 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // CreateCommand = CREATE, INDEX, IdToken, ON, IdToken, LPAREN, IdToken, RPAREN => ActionFn(24);
+        // Constant = NULL => ActionFn(51);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action51::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant1(__nt), __end));
+        (1, 22)
+    }
+    fn __reduce44<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // Constant = I32Constant => ActionFn(52);
+        let __sym0 = __pop_Variant21(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action52::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant1(__nt), __end));
+        (1, 22)
+    }
+    fn __reduce45<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // Constant = StringConstant => ActionFn(53);
+        let __sym0 = __pop_Variant5(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action53::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant1(__nt), __end));
+        (1, 22)
+    }
+    fn __reduce46<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // CreateCommand = CREATE, TABLE, IdToken, LPAREN, Comma<FieldDefinition>, RPAREN => ActionFn(30);
+        assert!(__symbols.len() >= 6);
+        let __sym5 = __pop_Variant0(__symbols);
+        let __sym4 = __pop_Variant15(__symbols);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym5.2;
+        let __nt = super::__action30::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
+        __symbols.push((__start, __Symbol::Variant18(__nt), __end));
+        (6, 23)
+    }
+    fn __reduce47<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // CreateCommand = CREATE, VIEW, IdToken, AS, Query => ActionFn(31);
+        assert!(__symbols.len() >= 5);
+        let __sym4 = __pop_Variant25(__symbols);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym4.2;
+        let __nt = super::__action31::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4);
+        __symbols.push((__start, __Symbol::Variant18(__nt), __end));
+        (5, 23)
+    }
+    fn __reduce48<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // CreateCommand = CREATE, INDEX, IdToken, ON, IdToken, LPAREN, IdToken, RPAREN => ActionFn(32);
         assert!(__symbols.len() >= 8);
         let __sym7 = __pop_Variant0(__symbols);
         let __sym6 = __pop_Variant5(__symbols);
@@ -12380,97 +13593,9 @@ mod __parse__Term {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym7.2;
-        let __nt = super::__action24::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
-        __symbols.push((__start, __Symbol::Variant17(__nt), __end));
-        (8, 22)
-    }
-    fn __reduce44<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // Expression = AddExpr => ActionFn(31);
-        let __sym0 = __pop_Variant11(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action31::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
-        (1, 23)
-    }
-    fn __reduce45<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // Factor = LPAREN, Expression, RPAREN => ActionFn(38);
-        assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant11(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym2.2;
-        let __nt = super::__action38::<>(input, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
-        (3, 24)
-    }
-    fn __reduce46<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // Factor = NULL => ActionFn(39);
-        let __sym0 = __pop_Variant0(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action39::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
-        (1, 24)
-    }
-    fn __reduce47<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // Factor = I32Constant => ActionFn(40);
-        let __sym0 = __pop_Variant20(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action40::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
-        (1, 24)
-    }
-    fn __reduce48<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // Factor = StringConstant => ActionFn(41);
-        let __sym0 = __pop_Variant5(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action41::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
-        (1, 24)
+        let __nt = super::__action32::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
+        __symbols.push((__start, __Symbol::Variant18(__nt), __end));
+        (8, 23)
     }
     fn __reduce49<
         'input,
@@ -12481,11 +13606,11 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Factor = IdToken => ActionFn(42);
-        let __sym0 = __pop_Variant5(__symbols);
+        // Expression = AddExpr => ActionFn(39);
+        let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action42::<>(input, __sym0);
+        let __nt = super::__action39::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (1, 24)
     }
@@ -12498,17 +13623,105 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // FieldDefinition = IdToken, FieldType => ActionFn(25);
+        // Factor = LPAREN, Expression, RPAREN => ActionFn(46);
+        assert!(__symbols.len() >= 3);
+        let __sym2 = __pop_Variant0(__symbols);
+        let __sym1 = __pop_Variant11(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym2.2;
+        let __nt = super::__action46::<>(input, __sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
+        (3, 25)
+    }
+    fn __reduce51<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // Factor = NULL => ActionFn(47);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action47::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
+        (1, 25)
+    }
+    fn __reduce52<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // Factor = I32Constant => ActionFn(48);
+        let __sym0 = __pop_Variant21(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action48::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
+        (1, 25)
+    }
+    fn __reduce53<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // Factor = StringConstant => ActionFn(49);
+        let __sym0 = __pop_Variant5(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action49::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
+        (1, 25)
+    }
+    fn __reduce54<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // Factor = IdToken => ActionFn(50);
+        let __sym0 = __pop_Variant5(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action50::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
+        (1, 25)
+    }
+    fn __reduce55<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // FieldDefinition = IdToken, FieldType => ActionFn(33);
         assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant19(__symbols);
+        let __sym1 = __pop_Variant20(__symbols);
         let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action25::<>(input, __sym0, __sym1);
+        let __nt = super::__action33::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant3(__nt), __end));
-        (2, 25)
+        (2, 26)
     }
-    fn __reduce51<
+    fn __reduce56<
         'input,
     >(
         input: &'input str,
@@ -12522,97 +13735,8 @@ mod __parse__Term {
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action8::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant18(__nt), __end));
-        (1, 26)
-    }
-    fn __reduce52<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // FieldList = Comma<SelectField> => ActionFn(9);
-        let __sym0 = __pop_Variant16(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action9::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant18(__nt), __end));
-        (1, 26)
-    }
-    fn __reduce53<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // FieldType = I32 => ActionFn(26);
-        let __sym0 = __pop_Variant0(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action26::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant19(__nt), __end));
         (1, 27)
-    }
-    fn __reduce54<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // FieldType = VARCHAR, LPAREN, I32Constant, RPAREN => ActionFn(27);
-        assert!(__symbols.len() >= 4);
-        let __sym3 = __pop_Variant0(__symbols);
-        let __sym2 = __pop_Variant20(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym3.2;
-        let __nt = super::__action27::<>(input, __sym0, __sym1, __sym2, __sym3);
-        __symbols.push((__start, __Symbol::Variant19(__nt), __end));
-        (4, 27)
-    }
-    fn __reduce55<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // I32Constant = I32_LITERAL => ActionFn(46);
-        let __sym0 = __pop_Variant0(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action46::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant20(__nt), __end));
-        (1, 28)
-    }
-    fn __reduce56<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // IdToken = ID => ActionFn(48);
-        let __sym0 = __pop_Variant0(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action48::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant5(__nt), __end));
-        (1, 29)
     }
     fn __reduce57<
         'input,
@@ -12623,16 +13747,13 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // MulExpr = MulExpr, STAR, Factor => ActionFn(35);
-        assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant11(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant11(__symbols);
+        // FieldList = Comma<SelectField> => ActionFn(9);
+        let __sym0 = __pop_Variant17(__symbols);
         let __start = __sym0.0;
-        let __end = __sym2.2;
-        let __nt = super::__action35::<>(input, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
-        (3, 30)
+        let __end = __sym0.2;
+        let __nt = super::__action9::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant19(__nt), __end));
+        (1, 27)
     }
     fn __reduce58<
         'input,
@@ -12643,16 +13764,13 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // MulExpr = MulExpr, SLASH, Factor => ActionFn(36);
-        assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant11(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant11(__symbols);
+        // FieldType = I32 => ActionFn(34);
+        let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym2.2;
-        let __nt = super::__action36::<>(input, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
-        (3, 30)
+        let __end = __sym0.2;
+        let __nt = super::__action34::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant20(__nt), __end));
+        (1, 28)
     }
     fn __reduce59<
         'input,
@@ -12663,13 +13781,17 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // MulExpr = Factor => ActionFn(37);
-        let __sym0 = __pop_Variant11(__symbols);
+        // FieldType = VARCHAR, LPAREN, I32Constant, RPAREN => ActionFn(35);
+        assert!(__symbols.len() >= 4);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant21(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action37::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
-        (1, 30)
+        let __end = __sym3.2;
+        let __nt = super::__action35::<>(input, __sym0, __sym1, __sym2, __sym3);
+        __symbols.push((__start, __Symbol::Variant20(__nt), __end));
+        (4, 28)
     }
     fn __reduce60<
         'input,
@@ -12680,16 +13802,13 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // OptOrderBy = ORDER, BY, Comma<IdToken> => ActionFn(14);
-        assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant15(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
+        // I32Constant = I32_LITERAL => ActionFn(54);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym2.2;
-        let __nt = super::__action14::<>(input, __sym0, __sym1, __sym2);
+        let __end = __sym0.2;
+        let __nt = super::__action54::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant21(__nt), __end));
-        (3, 31)
+        (1, 29)
     }
     fn __reduce61<
         'input,
@@ -12700,12 +13819,13 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // OptOrderBy =  => ActionFn(15);
-        let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
-        let __end = __start;
-        let __nt = super::__action15::<>(input, &__start, &__end);
-        __symbols.push((__start, __Symbol::Variant21(__nt), __end));
-        (0, 31)
+        // IdToken = ID => ActionFn(56);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action56::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant5(__nt), __end));
+        (1, 30)
     }
     fn __reduce62<
         'input,
@@ -12716,15 +13836,16 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // OptPredicate = WHERE, Predicate => ActionFn(12);
-        assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant23(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
+        // MulExpr = MulExpr, STAR, Factor => ActionFn(43);
+        assert!(__symbols.len() >= 3);
+        let __sym2 = __pop_Variant11(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
-        let __end = __sym1.2;
-        let __nt = super::__action12::<>(input, __sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant22(__nt), __end));
-        (2, 32)
+        let __end = __sym2.2;
+        let __nt = super::__action43::<>(input, __sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
+        (3, 31)
     }
     fn __reduce63<
         'input,
@@ -12735,12 +13856,16 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // OptPredicate =  => ActionFn(13);
-        let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
-        let __end = __start;
-        let __nt = super::__action13::<>(input, &__start, &__end);
-        __symbols.push((__start, __Symbol::Variant22(__nt), __end));
-        (0, 32)
+        // MulExpr = MulExpr, SLASH, Factor => ActionFn(44);
+        assert!(__symbols.len() >= 3);
+        let __sym2 = __pop_Variant11(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant11(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym2.2;
+        let __nt = super::__action44::<>(input, __sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
+        (3, 31)
     }
     fn __reduce64<
         'input,
@@ -12751,13 +13876,13 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Predicate = And<Term> => ActionFn(28);
-        let __sym0 = __pop_Variant12(__symbols);
+        // MulExpr = Factor => ActionFn(45);
+        let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action28::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant23(__nt), __end));
-        (1, 33)
+        let __nt = super::__action45::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
+        (1, 31)
     }
     fn __reduce65<
         'input,
@@ -12768,21 +13893,146 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Query = SELECT, FieldList, FROM, Comma<IdToken>, OptPredicate, OptOrderBy => ActionFn(7);
-        assert!(__symbols.len() >= 6);
-        let __sym5 = __pop_Variant21(__symbols);
-        let __sym4 = __pop_Variant22(__symbols);
-        let __sym3 = __pop_Variant15(__symbols);
-        let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant18(__symbols);
+        // OptGroupBy = GROUP, BY, Comma<IdToken> => ActionFn(20);
+        assert!(__symbols.len() >= 3);
+        let __sym2 = __pop_Variant16(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym5.2;
-        let __nt = super::__action7::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
-        __symbols.push((__start, __Symbol::Variant24(__nt), __end));
-        (6, 34)
+        let __end = __sym2.2;
+        let __nt = super::__action20::<>(input, __sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant22(__nt), __end));
+        (3, 32)
     }
     fn __reduce66<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // OptGroupBy =  => ActionFn(21);
+        let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
+        let __end = __start;
+        let __nt = super::__action21::<>(input, &__start, &__end);
+        __symbols.push((__start, __Symbol::Variant22(__nt), __end));
+        (0, 32)
+    }
+    fn __reduce67<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // OptOrderBy = ORDER, BY, Comma<IdToken> => ActionFn(22);
+        assert!(__symbols.len() >= 3);
+        let __sym2 = __pop_Variant16(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym2.2;
+        let __nt = super::__action22::<>(input, __sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant22(__nt), __end));
+        (3, 33)
+    }
+    fn __reduce68<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // OptOrderBy =  => ActionFn(23);
+        let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
+        let __end = __start;
+        let __nt = super::__action23::<>(input, &__start, &__end);
+        __symbols.push((__start, __Symbol::Variant22(__nt), __end));
+        (0, 33)
+    }
+    fn __reduce69<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // OptPredicate = WHERE, Predicate => ActionFn(18);
+        assert!(__symbols.len() >= 2);
+        let __sym1 = __pop_Variant24(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym1.2;
+        let __nt = super::__action18::<>(input, __sym0, __sym1);
+        __symbols.push((__start, __Symbol::Variant23(__nt), __end));
+        (2, 34)
+    }
+    fn __reduce70<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // OptPredicate =  => ActionFn(19);
+        let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
+        let __end = __start;
+        let __nt = super::__action19::<>(input, &__start, &__end);
+        __symbols.push((__start, __Symbol::Variant23(__nt), __end));
+        (0, 34)
+    }
+    fn __reduce71<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // Predicate = And<Term> => ActionFn(36);
+        let __sym0 = __pop_Variant13(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action36::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant24(__nt), __end));
+        (1, 35)
+    }
+    fn __reduce72<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // Query = SELECT, FieldList, FROM, Comma<IdToken>, OptPredicate, OptGroupBy, OptOrderBy => ActionFn(7);
+        assert!(__symbols.len() >= 7);
+        let __sym6 = __pop_Variant22(__symbols);
+        let __sym5 = __pop_Variant22(__symbols);
+        let __sym4 = __pop_Variant23(__symbols);
+        let __sym3 = __pop_Variant16(__symbols);
+        let __sym2 = __pop_Variant0(__symbols);
+        let __sym1 = __pop_Variant19(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym6.2;
+        let __nt = super::__action7::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6);
+        __symbols.push((__start, __Symbol::Variant25(__nt), __end));
+        (7, 36)
+    }
+    fn __reduce73<
         'input,
     >(
         input: &'input str,
@@ -12800,142 +14050,7 @@ mod __parse__Term {
         let __end = __sym2.2;
         let __nt = super::__action10::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant7(__nt), __end));
-        (3, 35)
-    }
-    fn __reduce67<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // SelectField = IdToken => ActionFn(11);
-        let __sym0 = __pop_Variant5(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action11::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant7(__nt), __end));
-        (1, 35)
-    }
-    fn __reduce68<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // Statement = Query => ActionFn(5);
-        let __sym0 = __pop_Variant24(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action5::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant25(__nt), __end));
-        (1, 36)
-    }
-    fn __reduce69<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // Statement = UpdateCommand => ActionFn(6);
-        let __sym0 = __pop_Variant26(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action6::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant25(__nt), __end));
-        (1, 36)
-    }
-    fn __reduce70<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // StringConstant = STRING_LITERAL => ActionFn(47);
-        let __sym0 = __pop_Variant0(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action47::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant5(__nt), __end));
-        (1, 37)
-    }
-    fn __reduce71<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // Term = Expression, IS, NULL => ActionFn(29);
-        assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant11(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym2.2;
-        let __nt = super::__action29::<>(input, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant9(__nt), __end));
-        (3, 38)
-    }
-    fn __reduce72<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // Term = Expression, EQ, Expression => ActionFn(30);
-        assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant11(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant11(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym2.2;
-        let __nt = super::__action30::<>(input, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant9(__nt), __end));
-        (3, 38)
-    }
-    fn __reduce73<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // UpdateCommand = INSERT, INTO, IdToken, LPAREN, Comma<IdToken>, RPAREN, VALUES, LPAREN, Comma<Constant>, RPAREN => ActionFn(16);
-        assert!(__symbols.len() >= 10);
-        let __sym9 = __pop_Variant0(__symbols);
-        let __sym8 = __pop_Variant13(__symbols);
-        let __sym7 = __pop_Variant0(__symbols);
-        let __sym6 = __pop_Variant0(__symbols);
-        let __sym5 = __pop_Variant0(__symbols);
-        let __sym4 = __pop_Variant15(__symbols);
-        let __sym3 = __pop_Variant0(__symbols);
-        let __sym2 = __pop_Variant5(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym9.2;
-        let __nt = super::__action16::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9);
-        __symbols.push((__start, __Symbol::Variant26(__nt), __end));
-        (10, 39)
+        (3, 37)
     }
     fn __reduce74<
         'input,
@@ -12946,16 +14061,13 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // UpdateCommand = DELETE, FROM, IdToken => ActionFn(17);
-        assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant5(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
+        // SelectField = Expression => ActionFn(11);
+        let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
-        let __end = __sym2.2;
-        let __nt = super::__action17::<>(input, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant26(__nt), __end));
-        (3, 39)
+        let __end = __sym0.2;
+        let __nt = super::__action11::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant7(__nt), __end));
+        (1, 37)
     }
     fn __reduce75<
         'input,
@@ -12966,18 +14078,13 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // UpdateCommand = DELETE, FROM, IdToken, WHERE, Predicate => ActionFn(18);
-        assert!(__symbols.len() >= 5);
-        let __sym4 = __pop_Variant23(__symbols);
-        let __sym3 = __pop_Variant0(__symbols);
-        let __sym2 = __pop_Variant5(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
+        // SelectField = AggregationFn => ActionFn(12);
+        let __sym0 = __pop_Variant12(__symbols);
         let __start = __sym0.0;
-        let __end = __sym4.2;
-        let __nt = super::__action18::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4);
-        __symbols.push((__start, __Symbol::Variant26(__nt), __end));
-        (5, 39)
+        let __end = __sym0.2;
+        let __nt = super::__action12::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant7(__nt), __end));
+        (1, 37)
     }
     fn __reduce76<
         'input,
@@ -12988,19 +14095,13 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // UpdateCommand = MODIFY, IdToken, SET, IdToken, EQ, Expression => ActionFn(19);
-        assert!(__symbols.len() >= 6);
-        let __sym5 = __pop_Variant11(__symbols);
-        let __sym4 = __pop_Variant0(__symbols);
-        let __sym3 = __pop_Variant5(__symbols);
-        let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant5(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
+        // Statement = Query => ActionFn(5);
+        let __sym0 = __pop_Variant25(__symbols);
         let __start = __sym0.0;
-        let __end = __sym5.2;
-        let __nt = super::__action19::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
+        let __end = __sym0.2;
+        let __nt = super::__action5::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant26(__nt), __end));
-        (6, 39)
+        (1, 38)
     }
     fn __reduce77<
         'input,
@@ -13011,21 +14112,13 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // UpdateCommand = MODIFY, IdToken, SET, IdToken, EQ, Expression, WHERE, Predicate => ActionFn(20);
-        assert!(__symbols.len() >= 8);
-        let __sym7 = __pop_Variant23(__symbols);
-        let __sym6 = __pop_Variant0(__symbols);
-        let __sym5 = __pop_Variant11(__symbols);
-        let __sym4 = __pop_Variant0(__symbols);
-        let __sym3 = __pop_Variant5(__symbols);
-        let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant5(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
+        // Statement = UpdateCommand => ActionFn(6);
+        let __sym0 = __pop_Variant27(__symbols);
         let __start = __sym0.0;
-        let __end = __sym7.2;
-        let __nt = super::__action20::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
+        let __end = __sym0.2;
+        let __nt = super::__action6::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant26(__nt), __end));
-        (8, 39)
+        (1, 38)
     }
     fn __reduce78<
         'input,
@@ -13036,12 +14129,12 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // UpdateCommand = CreateCommand => ActionFn(21);
-        let __sym0 = __pop_Variant17(__symbols);
+        // StringConstant = STRING_LITERAL => ActionFn(55);
+        let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action21::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant26(__nt), __end));
+        let __nt = super::__action55::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant5(__nt), __end));
         (1, 39)
     }
     fn __reduce79<
@@ -13053,13 +14146,16 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // __Predicate = Predicate => ActionFn(3);
-        let __sym0 = __pop_Variant23(__symbols);
+        // Term = Expression, IS, NULL => ActionFn(37);
+        assert!(__symbols.len() >= 3);
+        let __sym2 = __pop_Variant0(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action3::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant23(__nt), __end));
-        (1, 40)
+        let __end = __sym2.2;
+        let __nt = super::__action37::<>(input, __sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant9(__nt), __end));
+        (3, 40)
     }
     fn __reduce80<
         'input,
@@ -13070,13 +14166,16 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // __Query = Query => ActionFn(1);
-        let __sym0 = __pop_Variant24(__symbols);
+        // Term = Expression, EQ, Expression => ActionFn(38);
+        assert!(__symbols.len() >= 3);
+        let __sym2 = __pop_Variant11(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action1::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant24(__nt), __end));
-        (1, 41)
+        let __end = __sym2.2;
+        let __nt = super::__action38::<>(input, __sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant9(__nt), __end));
+        (3, 40)
     }
     fn __reduce81<
         'input,
@@ -13087,13 +14186,43 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // __Statement = Statement => ActionFn(0);
-        let __sym0 = __pop_Variant25(__symbols);
+        // UpdateCommand = INSERT, INTO, IdToken, LPAREN, Comma<IdToken>, RPAREN, VALUES, LPAREN, Comma<Constant>, RPAREN => ActionFn(24);
+        assert!(__symbols.len() >= 10);
+        let __sym9 = __pop_Variant0(__symbols);
+        let __sym8 = __pop_Variant14(__symbols);
+        let __sym7 = __pop_Variant0(__symbols);
+        let __sym6 = __pop_Variant0(__symbols);
+        let __sym5 = __pop_Variant0(__symbols);
+        let __sym4 = __pop_Variant16(__symbols);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action0::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant25(__nt), __end));
-        (1, 42)
+        let __end = __sym9.2;
+        let __nt = super::__action24::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9);
+        __symbols.push((__start, __Symbol::Variant27(__nt), __end));
+        (10, 41)
+    }
+    fn __reduce82<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // UpdateCommand = DELETE, FROM, IdToken => ActionFn(25);
+        assert!(__symbols.len() >= 3);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym2.2;
+        let __nt = super::__action25::<>(input, __sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant27(__nt), __end));
+        (3, 41)
     }
     fn __reduce83<
         'input,
@@ -13104,13 +14233,151 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // __UpdateCommand = UpdateCommand => ActionFn(2);
+        // UpdateCommand = DELETE, FROM, IdToken, WHERE, Predicate => ActionFn(26);
+        assert!(__symbols.len() >= 5);
+        let __sym4 = __pop_Variant24(__symbols);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym4.2;
+        let __nt = super::__action26::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4);
+        __symbols.push((__start, __Symbol::Variant27(__nt), __end));
+        (5, 41)
+    }
+    fn __reduce84<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // UpdateCommand = MODIFY, IdToken, SET, IdToken, EQ, Expression => ActionFn(27);
+        assert!(__symbols.len() >= 6);
+        let __sym5 = __pop_Variant11(__symbols);
+        let __sym4 = __pop_Variant0(__symbols);
+        let __sym3 = __pop_Variant5(__symbols);
+        let __sym2 = __pop_Variant0(__symbols);
+        let __sym1 = __pop_Variant5(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym5.2;
+        let __nt = super::__action27::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
+        __symbols.push((__start, __Symbol::Variant27(__nt), __end));
+        (6, 41)
+    }
+    fn __reduce85<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // UpdateCommand = MODIFY, IdToken, SET, IdToken, EQ, Expression, WHERE, Predicate => ActionFn(28);
+        assert!(__symbols.len() >= 8);
+        let __sym7 = __pop_Variant24(__symbols);
+        let __sym6 = __pop_Variant0(__symbols);
+        let __sym5 = __pop_Variant11(__symbols);
+        let __sym4 = __pop_Variant0(__symbols);
+        let __sym3 = __pop_Variant5(__symbols);
+        let __sym2 = __pop_Variant0(__symbols);
+        let __sym1 = __pop_Variant5(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym7.2;
+        let __nt = super::__action28::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
+        __symbols.push((__start, __Symbol::Variant27(__nt), __end));
+        (8, 41)
+    }
+    fn __reduce86<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // UpdateCommand = CreateCommand => ActionFn(29);
+        let __sym0 = __pop_Variant18(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action29::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant27(__nt), __end));
+        (1, 41)
+    }
+    fn __reduce87<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // __Predicate = Predicate => ActionFn(3);
+        let __sym0 = __pop_Variant24(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action3::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant24(__nt), __end));
+        (1, 42)
+    }
+    fn __reduce88<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // __Query = Query => ActionFn(1);
+        let __sym0 = __pop_Variant25(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action1::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant25(__nt), __end));
+        (1, 43)
+    }
+    fn __reduce89<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // __Statement = Statement => ActionFn(0);
         let __sym0 = __pop_Variant26(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action2::<>(input, __sym0);
+        let __nt = super::__action0::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant26(__nt), __end));
         (1, 44)
+    }
+    fn __reduce91<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // __UpdateCommand = UpdateCommand => ActionFn(2);
+        let __sym0 = __pop_Variant27(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action2::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant27(__nt), __end));
+        (1, 46)
     }
 }
 #[allow(unused_imports)]
@@ -13125,6 +14392,15 @@ mod __parse__UpdateCommand {
     use super::super::predicate;
     use super::super::expression;
     use crate::record::field::{Spec, Value};
+    use crate::materialization::{
+    aggregation_function::AggregationFn,
+    aggregation_function::AggregationFnControl,
+    avg_function::AvgFn,
+    count_function::CountFn,
+    max_function::MaxFn,
+    min_function::MinFn,
+    sum_function::SumFn,
+};
     #[allow(unused_extern_crates)]
     extern crate lalrpop_util as __lalrpop_util;
     #[allow(unused_imports)]
@@ -13142,277 +14418,326 @@ mod __parse__UpdateCommand {
         Variant4(alloc::vec::Vec<statement::FieldDefinition>),
         Variant5(String),
         Variant6(alloc::vec::Vec<String>),
-        Variant7((expression::Expression, Option<String>)),
-        Variant8(alloc::vec::Vec<(expression::Expression, Option<String>)>),
+        Variant7(statement::SelectField),
+        Variant8(alloc::vec::Vec<statement::SelectField>),
         Variant9(predicate::Term),
         Variant10(alloc::vec::Vec<predicate::Term>),
         Variant11(expression::Expression),
-        Variant12(Vec<predicate::Term>),
-        Variant13(Vec<Value>),
-        Variant14(Vec<statement::FieldDefinition>),
-        Variant15(Vec<String>),
-        Variant16(Vec<(expression::Expression, Option<String>)>),
-        Variant17(statement::CreateCommand),
-        Variant18(Option<Vec<(expression::Expression, Option<String>)>>),
-        Variant19(Spec),
-        Variant20(i32),
-        Variant21(Option<Vec<String>>),
-        Variant22(Option<predicate::Predicate>),
-        Variant23(predicate::Predicate),
-        Variant24(statement::QueryData),
-        Variant25(statement::Statement),
-        Variant26(statement::UpdateCommand),
+        Variant12(AggregationFn),
+        Variant13(Vec<predicate::Term>),
+        Variant14(Vec<Value>),
+        Variant15(Vec<statement::FieldDefinition>),
+        Variant16(Vec<String>),
+        Variant17(Vec<statement::SelectField>),
+        Variant18(statement::CreateCommand),
+        Variant19(Option<Vec<statement::SelectField>>),
+        Variant20(Spec),
+        Variant21(i32),
+        Variant22(Option<Vec<String>>),
+        Variant23(Option<predicate::Predicate>),
+        Variant24(predicate::Predicate),
+        Variant25(statement::QueryData),
+        Variant26(statement::Statement),
+        Variant27(statement::UpdateCommand),
     }
-    const __ACTION: &[i8] = &[
+    const __ACTION: &[i16] = &[
         // State 0
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 40, 41, 0, 0, 0, 42, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 47, 48, 0, 0, 0, 0, 49, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 1
-        0, 44, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 2
-        0, 44, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 3
-        0, 44, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 4
-        0, 44, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 5
-        0, 44, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 6
-        0, 44, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 7
-        0, 44, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 8
-        0, 44, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 9
-        0, 44, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 10
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 16, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 16, 0, 0, 0, 0, 0, 0, 0,
         // State 11
-        0, 44, 67, 65, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 66, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 51, 74, 72, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 73, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 12
-        0, 44, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 13
-        0, 44, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 14
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 74, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 75, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 81, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 82, 0, 0,
         // State 15
-        0, 44, 67, 65, 0, 18, 0, 81, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 66, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 51, 74, 72, 0, 18, 0, 92, 0, 0, 0, 0, 0, 0, 88, 0, 89, 0, 0, 0, 0, 0, 0, 0, 0, 0, 90, 91, 0, 73, 0, 0, 0, 0, 93, 0, 0, 0, 0, 0,
         // State 16
-        0, 44, 67, 65, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 66, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 51, 74, 72, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 73, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 17
-        0, 44, 67, 65, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 66, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 51, 74, 72, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 73, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 18
-        0, 44, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 19
-        0, 44, 67, 65, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 66, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 51, 74, 72, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 73, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 20
-        0, 44, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 21
-        0, 44, 67, 65, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 66, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 51, 74, 72, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 88, 0, 89, 0, 0, 0, 0, 0, 0, 0, 0, 0, 90, 91, 0, 73, 0, 0, 0, 0, 93, 0, 0, 0, 0, 0,
         // State 22
-        0, 44, 67, 65, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 66, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 51, 74, 72, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 73, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 23
-        0, 44, 67, 65, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 66, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 51, 74, 72, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 73, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 24
-        0, 44, 67, 65, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 66, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 51, 74, 72, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 73, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 25
-        0, 44, 67, 65, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 66, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 51, 74, 72, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 73, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 26
-        0, 44, 67, 65, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 66, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 51, 74, 72, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 73, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 27
-        0, 0, 0, 65, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 72, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 28
-        0, 44, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 29
-        0, 44, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 30
-        0, 44, 67, 65, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 66, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 31
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -64, 0, 0, 0, 0, 0, 0, 35,
+        0, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 32
-        0, 0, 67, 65, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 114, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 33
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 116, 0, 0, 0, 0, 0, 0, 0,
+        0, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 34
-        0, 44, 67, 65, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 66, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 35
-        0, 0, 67, 65, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 114, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 51, 74, 72, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 73, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 36
-        0, 44, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -71, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -71, 0, 0, 0, 0, 0, 0, 0, 40,
         // State 37
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 74, 72, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 136, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 38
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 137, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -67, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 39
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 5, 0,
+        0, 51, 74, 72, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 73, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 40
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 74, 72, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 136, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 41
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 143, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 42
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0,
+        0, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 43
-        0, 0, 0, 0, -57, -57, -57, -57, -57, -57, -57, -57, -57, -57, 0, 0, 0, -57, -57, 0, 0, 0, -57, 0, 0, -57, -57, 0, -57, 0, 0, -57, 0, -57,
+        0, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 44
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 9, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 45
-        0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 46
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 5, 0,
         // State 47
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 12,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 48
-        0, 0, 0, 0, 0, 13, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 49
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 20, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0,
         // State 50
-        0, 0, 0, 0, 0, 21, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -62, -62, -62, -62, -62, -62, -62, -62, -62, -62, 0, 0, 0, 0, 0, -62, -62, -62, 0, 0, 0, -62, 0, 0, 0, 0, -62, -62, 0, -62, 0, 0, 0, -62, 0, -62,
         // State 51
-        0, 0, 0, 0, 0, 0, 71, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 52
-        0, 0, 0, 0, 0, 0, -33, 0, 0, 72, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 53
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 54
-        0, 0, 0, 0, 23, 0, -45, 0, 24, 0, 0, -45, -45, -45, 0, 0, 0, 0, 0, 0, 0, 0, -45, 0, 0, 0, -45, 0, 0, 0, 0, 0, 0, -45,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 12,
         // State 55
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -65, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 13, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 56
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 83, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 20, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 57
-        0, 0, 0, 0, -60, 0, -60, -60, -60, 0, -60, -60, -60, -60, 0, 0, 0, 0, 0, 0, 0, 0, -60, 0, 0, 0, -60, 0, 0, 0, 0, 0, 0, -60,
+        0, 0, 0, 0, 0, 21, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 58
-        0, 0, 0, 0, -48, 0, -48, -48, -48, 0, -48, -48, -48, -48, 0, 0, 0, 0, 0, 0, 0, 0, -48, 0, 0, 0, -48, 0, 0, 0, 0, 0, 0, -48,
+        0, 0, 0, 0, 0, 0, 78, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 59
-        0, 0, 0, 0, -50, 0, -50, -50, -50, 0, -50, -50, -50, -50, 0, 0, 0, 0, 0, 0, 0, 0, -50, 0, 0, 0, -50, 0, 0, 0, 0, 0, 0, -50,
+        0, 0, 0, 0, 0, 0, -38, 0, 0, 79, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 60
-        0, 0, 0, 0, -28, 0, -28, 27, -28, 0, 26, -28, -28, -28, 0, 0, 0, 0, 0, 0, 0, 0, -28, 0, 0, 0, -28, 0, 0, 0, 0, 0, 0, -28,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 61
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 23, 0, -50, 0, 24, -50, 0, -50, -50, -50, 0, 0, 0, 0, 0, -50, -50, 0, 0, 0, 0, -50, 0, 0, 0, 0, 0, -50, 0, 0, 0, 0, 0, 0, 0, -50,
         // State 62
-        0, 0, 0, 0, -49, 0, -49, -49, -49, 0, -49, -49, -49, -49, 0, 0, 0, 0, 0, 0, 0, 0, -49, 0, 0, 0, -49, 0, 0, 0, 0, 0, 0, -49,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -72, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -72, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 63
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 84, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -29, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 95, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 64
-        0, 0, 0, 0, -56, 0, -56, -56, -56, -56, -56, -56, -56, -56, 0, 0, 0, 0, 0, 0, 0, 0, -56, 0, 0, 0, -56, 0, 0, 0, 0, 0, 0, -56,
+        0, 0, 0, 0, -65, 0, -65, -65, -65, -65, -65, -65, -65, -65, 0, 0, 0, 0, 0, -65, -65, 0, 0, 0, 0, -65, 0, 0, 0, 0, 0, -65, 0, 0, 0, 0, 0, 0, 0, -65,
         // State 65
-        0, 0, 0, 0, -47, 0, -47, -47, -47, 0, -47, -47, -47, -47, 0, 0, 0, 0, 0, 0, 0, 0, -47, 0, 0, 0, -47, 0, 0, 0, 0, 0, 0, -47,
+        0, 0, 0, 0, -53, 0, -53, -53, -53, -53, -53, -53, -53, -53, 0, 0, 0, 0, 0, -53, -53, 0, 0, 0, 0, -53, 0, 0, 0, 0, 0, -53, 0, 0, 0, 0, 0, 0, 0, -53,
         // State 66
-        0, 0, 0, 0, -71, 0, -71, -71, -71, -71, -71, -71, -71, -71, 0, 0, 0, 0, 0, 0, 0, 0, -71, 0, 0, 0, -71, 0, 0, 0, 0, 0, 0, -71,
+        0, 0, 0, 0, -55, 0, -55, -55, -55, -55, -55, -55, -55, -55, 0, 0, 0, 0, 0, -55, -55, 0, 0, 0, 0, -55, 0, 0, 0, 0, 0, -55, 0, 0, 0, 0, 0, 0, 0, -55,
         // State 67
-        0, 0, 0, 0, 0, 0, 87, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -28, 0, -28, 27, -28, -28, 26, -28, -28, -28, 0, 0, 0, 0, 0, -28, -28, 0, 0, 0, 0, -28, 0, 0, 0, 0, 0, -28, 0, 0, 0, 0, 0, 0, 0, -28,
         // State 68
-        0, 0, 0, 0, 0, 0, -35, 0, 0, 88, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -35, 0, 0, 0, 0, 0, 0, -35,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 69
-        0, 0, 0, 0, 0, 0, -34, 0, 0, 91, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -54, 0, -54, -54, -54, -54, -54, -54, -54, -54, 0, 0, 0, 0, 0, -54, -54, 0, 0, 0, 0, -54, 0, 0, 0, 0, 0, -54, 0, 0, 0, 0, 0, 0, 0, -54,
         // State 70
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 96, 0, 0, 0, 0, 0, 0, 0, -34, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -34, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 71
-        0, -9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -61, 0, -61, -61, -61, -61, -61, -61, -61, -61, 0, 0, 0, 0, 0, -61, -61, 0, 0, 0, 0, -61, 0, 0, 0, 0, 0, -61, 0, 0, 0, 0, 0, 0, 0, -61,
         // State 72
-        0, 0, 0, 0, 0, 0, -51, 0, 0, -51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -52, 0, -52, -52, -52, -52, -52, -52, -52, -52, 0, 0, 0, 0, 0, -52, -52, 0, 0, 0, 0, -52, 0, 0, 0, 0, 0, -52, 0, 0, 0, 0, 0, 0, 0, -52,
         // State 73
-        0, 0, 0, 0, 0, 0, -54, 0, 0, -54, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -79, 0, -79, -79, -79, -79, -79, -79, -79, -79, 0, 0, 0, 0, 0, -79, -79, 0, 0, 0, 0, -79, 0, 0, 0, 0, 0, -79, 0, 0, 0, 0, 0, 0, 0, -79,
         // State 74
-        0, 0, 0, 0, 0, 28, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 99, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 75
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, -40, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -40, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -40, 0, 0, 0, 0, 0, 0, 0, -40,
         // State 76
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 29, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, -39, 0, 0, 103, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 77
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 30, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 78
-        0, 0, 0, 0, -50, 0, 0, -50, -50, -68, -50, 0, 0, -50, 0, 0, 0, -68, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, -9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 79
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 93, 0, 0, 0, 0, 0, 0, 0, -37, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, -56, 0, 0, -56, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 80
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -52, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, -59, 0, 0, -59, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 81
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 94, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -30, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 28, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 82
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 98, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, -76, 0, 0, 0, 0, 0, 0, 0, 0, 0, -76, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 83
-        0, -24, -24, -24, 0, -24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -24, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -58, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 84
-        0, 0, 0, 0, 0, 0, 101, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, -75, 0, 0, 0, 29, 0, 0, 0, 0, 0, -75, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 85
-        0, 0, 0, 0, 0, 0, -36, 0, 0, 102, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -36, 0, 0, 0, 0, 0, 0, -36,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 30, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 86
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 103, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 105, 0, 0, 0, 0, 0, 0, 0, 0, 0, -42, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 87
-        0, -14, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 31, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 88
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 31,
+        0, 0, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 89
-        0, 0, 0, 0, 0, 0, 104, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 33, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 90
-        0, -10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 34, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 91
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 106, 0, 0, 0, 0, 0, 0, 0, -38, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -57, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 92
-        0, -19, -19, -19, 0, -19, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -19, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 35, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 93
-        0, -25, -25, -25, 0, -25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -25, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 106, 0, 0, 0, 0, 0, 0, 0, -35, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -35, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 94
-        0, 0, 0, 0, -27, 0, -27, 27, -27, 0, 26, -27, -27, -27, 0, 0, 0, 0, 0, 0, 0, 0, -27, 0, 0, 0, -27, 0, 0, 0, 0, 0, 0, -27,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 110, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 95
-        0, 0, 0, 0, -26, 0, -26, 27, -26, 0, 26, -26, -26, -26, 0, 0, 0, 0, 0, 0, 0, 0, -26, 0, 0, 0, -26, 0, 0, 0, 0, 0, 0, -26,
+        0, -24, -24, -24, 0, -24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 96
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -73, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -73, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 113, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 97
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -72, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -72, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, -41, 0, 0, 114, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -41, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -41, 0, 0, 0, 0, 0, 0, 0, -41,
         // State 98
-        0, 0, 0, 0, -59, 0, -59, -59, -59, 0, -59, -59, -59, -59, 0, 0, 0, 0, 0, 0, 0, 0, -59, 0, 0, 0, -59, 0, 0, 0, 0, 0, 0, -59,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 115, 0, 0, 0,
         // State 99
-        0, 0, 0, 0, -58, 0, -58, -58, -58, 0, -58, -58, -58, -58, 0, 0, 0, 0, 0, 0, 0, 0, -58, 0, 0, 0, -58, 0, 0, 0, 0, 0, 0, -58,
+        0, -14, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 100
-        0, 0, 0, 0, -46, 0, -46, -46, -46, 0, -46, -46, -46, -46, 0, 0, 0, 0, 0, 0, 0, 0, -46, 0, 0, 0, -46, 0, 0, 0, 0, 0, 0, -46,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 36,
         // State 101
-        0, -15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 116, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 102
-        0, 0, 0, 0, 0, 33, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, -10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 103
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 118, 0, 0, 0, 0, 0, 0, 0, 0, 0, -43, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 104
-        0, 0, 0, 0, 0, 0, 109, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, -19, -19, -19, 0, -19, 0, 0, 0, 0, 0, 0, 0, 0, -19, 0, -19, 0, 0, 0, 0, 0, 0, 0, 0, 0, -19, -19, 0, -19, 0, 0, 0, 0, -19, 0, 0, 0, 0, 0,
         // State 105
-        0, -20, -20, -20, 0, -20, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -20, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, -25, -25, -25, 0, -25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 106
-        0, 0, 0, 0, 0, 0, 0, 0, 0, -67, 0, 0, 0, 0, 0, 0, 0, -67, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -27, 0, -27, 27, -27, -27, 26, -27, -27, -27, 0, 0, 0, 0, 0, -27, -27, 0, 0, 0, 0, -27, 0, 0, 0, 0, 0, -27, 0, 0, 0, 0, 0, 0, 0, -27,
         // State 107
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -26, 0, -26, 27, -26, -26, 26, -26, -26, -26, 0, 0, 0, 0, 0, -26, -26, 0, 0, 0, 0, -26, 0, 0, 0, 0, 0, -26, 0, 0, 0, 0, 0, 0, 0, -26,
         // State 108
-        0, 0, 0, 0, 0, 0, -55, 0, 0, -55, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -81, 0, 0, 0, 0, 0, 0, 0, -81, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -81, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 109
-        0, 0, 0, 0, 0, 0, 119, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -80, 0, 0, 0, 0, 0, 0, 0, -80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -80, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 110
-        0, 0, 0, 0, 0, 0, -31, 0, 0, 120, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -64, 0, -64, -64, -64, -64, -64, -64, -64, -64, 0, 0, 0, 0, 0, -64, -64, 0, 0, 0, 0, -64, 0, 0, 0, 0, 0, -64, 0, 0, 0, 0, 0, 0, 0, -64,
         // State 111
-        0, 0, 0, 0, 0, 0, -40, 0, 0, -40, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -63, 0, -63, -63, -63, -63, -63, -63, -63, -63, 0, 0, 0, 0, 0, -63, -63, 0, 0, 0, 0, -63, 0, 0, 0, 0, 0, -63, 0, 0, 0, 0, 0, 0, 0, -63,
         // State 112
-        0, 0, 0, 0, 0, 0, -41, 0, 0, -41, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -51, 0, -51, -51, -51, -51, -51, -51, -51, -51, 0, 0, 0, 0, 0, -51, -51, 0, 0, 0, 0, -51, 0, 0, 0, 0, 0, -51, 0, 0, 0, 0, 0, 0, 0, -51,
         // State 113
-        0, 0, 0, 0, 0, 0, -39, 0, 0, -39, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, -15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 114
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 38, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 115
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 37, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 116
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -63, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 126, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 117
-        0, 0, 0, 0, 0, 0, -32, 0, 0, 121, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, -20, -20, -20, 0, -20, 0, 0, 0, 0, 0, 0, 0, 0, -20, 0, -20, 0, 0, 0, 0, 0, 0, 0, 0, 0, -20, -20, 0, -20, 0, 0, 0, 0, -20, 0, 0, 0, 0, 0,
         // State 118
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, -74, 0, 0, 0, 0, 0, 0, 0, 0, 0, -74, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 119
-        0, 0, -4, -4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -4, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 127, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 120
-        0, 0, -5, -5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -5, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 121
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 129, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 122
+        0, 0, 0, 0, 0, 0, 130, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 123
+        0, 0, 0, 0, 0, 0, 131, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 124
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 125
+        0, 0, 0, 0, 0, 0, -60, 0, 0, -60, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 126
+        0, 0, 0, 0, 0, 0, 0, 0, 0, -33, 0, 0, 0, 0, 0, 0, 0, 0, 0, -33, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 127
+        0, 0, 0, 0, 0, 0, 0, 0, 0, -32, 0, 0, 0, 0, 0, 0, 0, 0, 0, -32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 128
+        0, 0, 0, 0, 0, 0, 0, 0, 0, -29, 0, 0, 0, 0, 0, 0, 0, 0, 0, -29, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 129
+        0, 0, 0, 0, 0, 0, 0, 0, 0, -30, 0, 0, 0, 0, 0, 0, 0, 0, 0, -30, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 130
+        0, 0, 0, 0, 0, 0, 0, 0, 0, -31, 0, 0, 0, 0, 0, 0, 0, 0, 0, -31, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 131
+        0, 0, 0, 0, 0, 0, 140, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 132
+        0, 0, 0, 0, 0, 0, -36, 0, 0, 141, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 133
+        0, 0, 0, 0, 0, 0, -45, 0, 0, -45, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 134
+        0, 0, 0, 0, 0, 0, -46, 0, 0, -46, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 135
+        0, 0, 0, 0, 0, 0, -44, 0, 0, -44, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 136
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 43, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 137
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -70, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -70, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 138
+        0, 0, 0, 0, 0, 0, -37, 0, 0, 144, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 139
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 140
+        0, 0, -4, -4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 141
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 142
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 44, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 143
+        0, 0, -5, -5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 144
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -66, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 145
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     ];
-    fn __action(state: i8, integer: usize) -> i8 {
-        __ACTION[(state as usize) * 34 + integer]
+    fn __action(state: i16, integer: usize) -> i16 {
+        __ACTION[(state as usize) * 40 + integer]
     }
-    const __EOF_ACTION: &[i8] = &[
+    const __EOF_ACTION: &[i16] = &[
         // State 0
         0,
         // State 1
@@ -13476,99 +14801,99 @@ mod __parse__UpdateCommand {
         // State 30
         0,
         // State 31
-        -64,
+        0,
         // State 32
         0,
         // State 33
-        -62,
+        0,
         // State 34
         0,
         // State 35
         0,
         // State 36
-        0,
-        // State 37
-        -79,
-        // State 38
-        -84,
-        // State 39
-        0,
-        // State 40
-        0,
-        // State 41
-        0,
-        // State 42
-        0,
-        // State 43
-        -57,
-        // State 44
-        0,
-        // State 45
-        0,
-        // State 46
-        0,
-        // State 47
-        -75,
-        // State 48
-        0,
-        // State 49
-        0,
-        // State 50
-        0,
-        // State 51
-        0,
-        // State 52
-        0,
-        // State 53
-        -43,
-        // State 54
-        -45,
-        // State 55
-        -65,
-        // State 56
-        0,
-        // State 57
-        -60,
-        // State 58
-        -48,
-        // State 59
-        -50,
-        // State 60
-        -28,
-        // State 61
-        -76,
-        // State 62
-        -49,
-        // State 63
-        -29,
-        // State 64
-        -56,
-        // State 65
-        -47,
-        // State 66
         -71,
+        // State 37
+        0,
+        // State 38
+        -67,
+        // State 39
+        0,
+        // State 40
+        0,
+        // State 41
+        -69,
+        // State 42
+        0,
+        // State 43
+        0,
+        // State 44
+        -87,
+        // State 45
+        -92,
+        // State 46
+        0,
+        // State 47
+        0,
+        // State 48
+        0,
+        // State 49
+        0,
+        // State 50
+        -62,
+        // State 51
+        0,
+        // State 52
+        0,
+        // State 53
+        0,
+        // State 54
+        -83,
+        // State 55
+        0,
+        // State 56
+        0,
+        // State 57
+        0,
+        // State 58
+        0,
+        // State 59
+        0,
+        // State 60
+        -48,
+        // State 61
+        -50,
+        // State 62
+        -72,
+        // State 63
+        0,
+        // State 64
+        -65,
+        // State 65
+        -53,
+        // State 66
+        -55,
         // State 67
-        0,
+        -28,
         // State 68
-        -35,
+        -84,
         // State 69
-        0,
+        -54,
         // State 70
-        -42,
+        -34,
         // State 71
-        0,
+        -61,
         // State 72
-        0,
+        -52,
         // State 73
-        0,
+        -79,
         // State 74
         0,
         // State 75
-        0,
+        -40,
         // State 76
         0,
         // State 77
-        0,
+        -47,
         // State 78
         0,
         // State 79
@@ -13576,7 +14901,7 @@ mod __parse__UpdateCommand {
         // State 80
         0,
         // State 81
-        -30,
+        0,
         // State 82
         0,
         // State 83
@@ -13584,13 +14909,13 @@ mod __parse__UpdateCommand {
         // State 84
         0,
         // State 85
-        -36,
+        0,
         // State 86
         0,
         // State 87
         0,
         // State 88
-        -77,
+        0,
         // State 89
         0,
         // State 90
@@ -13600,152 +14925,207 @@ mod __parse__UpdateCommand {
         // State 92
         0,
         // State 93
-        0,
+        -35,
         // State 94
-        -27,
+        0,
         // State 95
-        -26,
+        0,
         // State 96
-        -73,
+        0,
         // State 97
-        -72,
+        -41,
         // State 98
-        -59,
+        0,
         // State 99
-        -58,
+        0,
         // State 100
-        -46,
+        -85,
         // State 101
         0,
         // State 102
         0,
         // State 103
-        -44,
+        0,
         // State 104
         0,
         // State 105
         0,
         // State 106
-        0,
+        -27,
         // State 107
-        -78,
+        -26,
         // State 108
-        0,
+        -81,
         // State 109
-        0,
+        -80,
         // State 110
-        0,
+        -64,
         // State 111
-        0,
+        -63,
         // State 112
-        0,
+        -51,
         // State 113
         0,
         // State 114
-        -66,
-        // State 115
         0,
+        // State 115
+        -49,
         // State 116
-        -63,
+        0,
         // State 117
         0,
         // State 118
-        -74,
+        0,
         // State 119
         0,
         // State 120
         0,
         // State 121
-        -61,
+        0,
+        // State 122
+        0,
+        // State 123
+        0,
+        // State 124
+        -86,
+        // State 125
+        0,
+        // State 126
+        0,
+        // State 127
+        0,
+        // State 128
+        0,
+        // State 129
+        0,
+        // State 130
+        0,
+        // State 131
+        0,
+        // State 132
+        0,
+        // State 133
+        0,
+        // State 134
+        0,
+        // State 135
+        0,
+        // State 136
+        0,
+        // State 137
+        -70,
+        // State 138
+        0,
+        // State 139
+        -82,
+        // State 140
+        0,
+        // State 141
+        -73,
+        // State 142
+        0,
+        // State 143
+        0,
+        // State 144
+        -66,
+        // State 145
+        -68,
     ];
-    fn __goto(state: i8, nt: usize) -> i8 {
+    fn __goto(state: i16, nt: usize) -> i16 {
         match nt {
-            2 => 35,
+            2 => 40,
             5 => 13,
             8 => 18,
             11 => 21,
             14 => 16,
-            15 => 54,
-            16 => 55,
-            17 => 109,
-            18 => 51,
-            19 => match state {
-                12 => 67,
-                36 => 121,
-                _ => 31,
+            15 => 61,
+            16 => 82,
+            17 => 62,
+            18 => 131,
+            19 => 58,
+            20 => match state {
+                12 => 74,
+                42 => 144,
+                43 => 145,
+                _ => 36,
             },
-            20 => 75,
-            21 => match state {
-                35 => 117,
-                _ => 110,
+            21 => 83,
+            22 => match state {
+                40 => 138,
+                _ => 132,
             },
-            22 => 37,
-            23 => match state {
-                15 | 21 => 76,
-                17 => 84,
-                19 => 88,
-                24 => 96,
-                _ => 56,
-            },
+            23 => 44,
             24 => match state {
-                25 => 98,
-                26 => 99,
-                _ => 57,
-            },
-            25 => match state {
-                13 => 69,
-                _ => 52,
-            },
-            26 => 77,
-            27 => 72,
-            28 => match state {
-                27 => 104,
-                32 | 35 => 111,
-                _ => 58,
-            },
-            29 => match state {
-                9 | 13 => 14,
-                1 => 42,
-                2 => 44,
-                3 => 45,
-                4 => 46,
-                5 => 47,
-                6 => 48,
-                7 => 49,
-                8 => 50,
-                12 | 29 | 36 => 68,
-                15 | 21 => 78,
-                18 => 85,
-                20 => 89,
-                28 => 106,
-                _ => 59,
-            },
-            30 => match state {
-                22 => 94,
-                23 => 95,
-                _ => 60,
-            },
-            31 => 114,
-            32 => 33,
-            33 => match state {
-                30 => 107,
-                34 => 116,
-                _ => 61,
-            },
-            34 => 53,
-            35 => match state {
-                21 => 91,
-                _ => 79,
-            },
-            37 => match state {
-                32 | 35 => 112,
-                _ => 62,
-            },
-            38 => match state {
-                16 => 81,
+                15 | 21 => 84,
+                17 => 96,
+                19 => 100,
+                24 => 108,
                 _ => 63,
             },
-            39 => 38,
+            25 => match state {
+                25 => 110,
+                26 => 111,
+                _ => 64,
+            },
+            26 => match state {
+                13 => 76,
+                _ => 59,
+            },
+            27 => 85,
+            28 => 79,
+            29 => match state {
+                27 => 116,
+                37 | 40 => 133,
+                _ => 65,
+            },
+            30 => match state {
+                9 | 13 => 14,
+                1 => 49,
+                2 => 51,
+                3 => 52,
+                4 => 53,
+                5 => 54,
+                6 => 55,
+                7 => 56,
+                8 => 57,
+                12 | 29 | 42..=43 => 75,
+                18 => 97,
+                20 => 101,
+                28 => 118,
+                30 => 119,
+                31 => 120,
+                32 => 121,
+                33 => 122,
+                34 => 123,
+                _ => 66,
+            },
+            31 => match state {
+                22 => 106,
+                23 => 107,
+                _ => 67,
+            },
+            32 => 41,
+            33 => 141,
+            34 => 38,
+            35 => match state {
+                35 => 124,
+                39 => 137,
+                _ => 68,
+            },
+            36 => 60,
+            37 => match state {
+                21 => 103,
+                _ => 86,
+            },
+            39 => match state {
+                37 | 40 => 134,
+                _ => 69,
+            },
+            40 => match state {
+                16 => 93,
+                _ => 70,
+            },
+            41 => 45,
             _ => 0,
         }
     }
@@ -13764,28 +15144,34 @@ mod __parse__UpdateCommand {
         r###"EQ"###,
         r###"AND"###,
         r###"AS"###,
+        r###"AVG"###,
         r###"BY"###,
+        r###"COUNT"###,
         r###"CREATE"###,
         r###"DELETE"###,
         r###"FROM"###,
+        r###"GROUP"###,
         r###"I32"###,
         r###"INDEX"###,
         r###"INSERT"###,
         r###"INTO"###,
         r###"IS"###,
+        r###"MAX"###,
+        r###"MIN"###,
         r###"MODIFY"###,
         r###"NULL"###,
         r###"ON"###,
         r###"ORDER"###,
         r###"SELECT"###,
         r###"SET"###,
+        r###"SUM"###,
         r###"TABLE"###,
         r###"VALUES"###,
         r###"VARCHAR"###,
         r###"VIEW"###,
         r###"WHERE"###,
     ];
-    fn __expected_tokens(__state: i8) -> alloc::vec::Vec<alloc::string::String> {
+    fn __expected_tokens(__state: i16) -> alloc::vec::Vec<alloc::string::String> {
         __TERMINAL.iter().enumerate().filter_map(|(index, terminal)| {
             let next_state = __action(__state, index);
             if next_state == 0 {
@@ -13798,7 +15184,7 @@ mod __parse__UpdateCommand {
     fn __expected_tokens_from_states<
         'input,
     >(
-        __states: &[i8],
+        __states: &[i16],
         _: core::marker::PhantomData<(&'input ())>,
     ) -> alloc::vec::Vec<alloc::string::String>
     {
@@ -13825,9 +15211,9 @@ mod __parse__UpdateCommand {
         type TokenIndex = usize;
         type Symbol = __Symbol<'input>;
         type Success = statement::UpdateCommand;
-        type StateIndex = i8;
-        type Action = i8;
-        type ReduceIndex = i8;
+        type StateIndex = i16;
+        type Action = i16;
+        type ReduceIndex = i16;
         type NonterminalIndex = usize;
 
         #[inline]
@@ -13846,22 +15232,22 @@ mod __parse__UpdateCommand {
         }
 
         #[inline]
-        fn action(&self, state: i8, integer: usize) -> i8 {
+        fn action(&self, state: i16, integer: usize) -> i16 {
             __action(state, integer)
         }
 
         #[inline]
-        fn error_action(&self, state: i8) -> i8 {
-            __action(state, 34 - 1)
+        fn error_action(&self, state: i16) -> i16 {
+            __action(state, 40 - 1)
         }
 
         #[inline]
-        fn eof_action(&self, state: i8) -> i8 {
+        fn eof_action(&self, state: i16) -> i16 {
             __EOF_ACTION[state as usize]
         }
 
         #[inline]
-        fn goto(&self, state: i8, nt: usize) -> i8 {
+        fn goto(&self, state: i16, nt: usize) -> i16 {
             __goto(state, nt)
         }
 
@@ -13869,11 +15255,11 @@ mod __parse__UpdateCommand {
             __token_to_symbol(token_index, token, core::marker::PhantomData::<(&())>)
         }
 
-        fn expected_tokens(&self, state: i8) -> alloc::vec::Vec<alloc::string::String> {
+        fn expected_tokens(&self, state: i16) -> alloc::vec::Vec<alloc::string::String> {
             __expected_tokens(state)
         }
 
-        fn expected_tokens_from_states(&self, states: &[i8]) -> alloc::vec::Vec<alloc::string::String> {
+        fn expected_tokens_from_states(&self, states: &[i16]) -> alloc::vec::Vec<alloc::string::String> {
             __expected_tokens_from_states(states, core::marker::PhantomData::<(&())>)
         }
 
@@ -13892,9 +15278,9 @@ mod __parse__UpdateCommand {
 
         fn reduce(
             &mut self,
-            action: i8,
+            action: i16,
             start_location: Option<&Self::Location>,
-            states: &mut alloc::vec::Vec<i8>,
+            states: &mut alloc::vec::Vec<i16>,
             symbols: &mut alloc::vec::Vec<__state_machine::SymbolTriple<Self>>,
         ) -> Option<__state_machine::ParseResult<Self>> {
             __reduce(
@@ -13907,7 +15293,7 @@ mod __parse__UpdateCommand {
             )
         }
 
-        fn simulate_reduce(&self, action: i8) -> __state_machine::SimulatedReduce<Self> {
+        fn simulate_reduce(&self, action: i16) -> __state_machine::SimulatedReduce<Self> {
             __simulate_reduce(action, core::marker::PhantomData::<(&())>)
         }
     }
@@ -13954,6 +15340,12 @@ mod __parse__UpdateCommand {
             Token(31, _) if true => Some(31),
             Token(32, _) if true => Some(32),
             Token(33, _) if true => Some(33),
+            Token(34, _) if true => Some(34),
+            Token(35, _) if true => Some(35),
+            Token(36, _) if true => Some(36),
+            Token(37, _) if true => Some(37),
+            Token(38, _) if true => Some(38),
+            Token(39, _) if true => Some(39),
             _ => None,
         }
     }
@@ -13966,8 +15358,8 @@ mod __parse__UpdateCommand {
     ) -> __Symbol<'input>
     {
         #[allow(clippy::manual_range_patterns)]match __token_index {
-            0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20 | 21 | 22 | 23 | 24 | 25 | 26 | 27 | 28 | 29 | 30 | 31 | 32 | 33 => match __token {
-                Token(0, __tok0) | Token(1, __tok0) | Token(2, __tok0) | Token(3, __tok0) | Token(4, __tok0) | Token(5, __tok0) | Token(6, __tok0) | Token(7, __tok0) | Token(8, __tok0) | Token(9, __tok0) | Token(10, __tok0) | Token(11, __tok0) | Token(12, __tok0) | Token(13, __tok0) | Token(14, __tok0) | Token(15, __tok0) | Token(16, __tok0) | Token(17, __tok0) | Token(18, __tok0) | Token(19, __tok0) | Token(20, __tok0) | Token(21, __tok0) | Token(22, __tok0) | Token(23, __tok0) | Token(24, __tok0) | Token(25, __tok0) | Token(26, __tok0) | Token(27, __tok0) | Token(28, __tok0) | Token(29, __tok0) | Token(30, __tok0) | Token(31, __tok0) | Token(32, __tok0) | Token(33, __tok0) if true => __Symbol::Variant0(__tok0),
+            0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20 | 21 | 22 | 23 | 24 | 25 | 26 | 27 | 28 | 29 | 30 | 31 | 32 | 33 | 34 | 35 | 36 | 37 | 38 | 39 => match __token {
+                Token(0, __tok0) | Token(1, __tok0) | Token(2, __tok0) | Token(3, __tok0) | Token(4, __tok0) | Token(5, __tok0) | Token(6, __tok0) | Token(7, __tok0) | Token(8, __tok0) | Token(9, __tok0) | Token(10, __tok0) | Token(11, __tok0) | Token(12, __tok0) | Token(13, __tok0) | Token(14, __tok0) | Token(15, __tok0) | Token(16, __tok0) | Token(17, __tok0) | Token(18, __tok0) | Token(19, __tok0) | Token(20, __tok0) | Token(21, __tok0) | Token(22, __tok0) | Token(23, __tok0) | Token(24, __tok0) | Token(25, __tok0) | Token(26, __tok0) | Token(27, __tok0) | Token(28, __tok0) | Token(29, __tok0) | Token(30, __tok0) | Token(31, __tok0) | Token(32, __tok0) | Token(33, __tok0) | Token(34, __tok0) | Token(35, __tok0) | Token(36, __tok0) | Token(37, __tok0) | Token(38, __tok0) | Token(39, __tok0) if true => __Symbol::Variant0(__tok0),
                 _ => unreachable!(),
             },
             _ => unreachable!(),
@@ -13976,7 +15368,7 @@ mod __parse__UpdateCommand {
     fn __simulate_reduce<
         'input,
     >(
-        __reduce_index: i8,
+        __reduce_index: i16,
         _: core::marker::PhantomData<(&'input ())>,
     ) -> __state_machine::SimulatedReduce<__StateMachine<'input>>
     {
@@ -14151,128 +15543,128 @@ mod __parse__UpdateCommand {
             }
             28 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
+                    states_to_pop: 4,
                     nonterminal_produced: 16,
                 }
             }
             29 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 2,
+                    states_to_pop: 4,
                     nonterminal_produced: 16,
                 }
             }
             30 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 17,
+                    states_to_pop: 4,
+                    nonterminal_produced: 16,
                 }
             }
             31 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 2,
-                    nonterminal_produced: 17,
+                    states_to_pop: 4,
+                    nonterminal_produced: 16,
                 }
             }
             32 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 18,
+                    states_to_pop: 4,
+                    nonterminal_produced: 16,
                 }
             }
             33 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 2,
-                    nonterminal_produced: 18,
+                    states_to_pop: 1,
+                    nonterminal_produced: 17,
                 }
             }
             34 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 19,
+                    states_to_pop: 2,
+                    nonterminal_produced: 17,
                 }
             }
             35 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 2,
-                    nonterminal_produced: 19,
+                    states_to_pop: 1,
+                    nonterminal_produced: 18,
                 }
             }
             36 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 20,
+                    states_to_pop: 2,
+                    nonterminal_produced: 18,
                 }
             }
             37 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 2,
-                    nonterminal_produced: 20,
+                    states_to_pop: 1,
+                    nonterminal_produced: 19,
                 }
             }
             38 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 21,
+                    states_to_pop: 2,
+                    nonterminal_produced: 19,
                 }
             }
             39 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
-                    nonterminal_produced: 21,
+                    nonterminal_produced: 20,
                 }
             }
             40 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 2,
+                    nonterminal_produced: 20,
+                }
+            }
+            41 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
                     nonterminal_produced: 21,
                 }
             }
-            41 => {
-                __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 6,
-                    nonterminal_produced: 22,
-                }
-            }
             42 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 5,
-                    nonterminal_produced: 22,
+                    states_to_pop: 2,
+                    nonterminal_produced: 21,
                 }
             }
             43 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 8,
+                    states_to_pop: 1,
                     nonterminal_produced: 22,
                 }
             }
             44 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
-                    nonterminal_produced: 23,
+                    nonterminal_produced: 22,
                 }
             }
             45 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 3,
-                    nonterminal_produced: 24,
+                    states_to_pop: 1,
+                    nonterminal_produced: 22,
                 }
             }
             46 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 24,
+                    states_to_pop: 6,
+                    nonterminal_produced: 23,
                 }
             }
             47 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 24,
+                    states_to_pop: 5,
+                    nonterminal_produced: 23,
                 }
             }
             48 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 24,
+                    states_to_pop: 8,
+                    nonterminal_produced: 23,
                 }
             }
             49 => {
@@ -14283,170 +15675,170 @@ mod __parse__UpdateCommand {
             }
             50 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 2,
+                    states_to_pop: 3,
                     nonterminal_produced: 25,
                 }
             }
             51 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
-                    nonterminal_produced: 26,
+                    nonterminal_produced: 25,
                 }
             }
             52 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
-                    nonterminal_produced: 26,
+                    nonterminal_produced: 25,
                 }
             }
             53 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
-                    nonterminal_produced: 27,
+                    nonterminal_produced: 25,
                 }
             }
             54 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 4,
-                    nonterminal_produced: 27,
+                    states_to_pop: 1,
+                    nonterminal_produced: 25,
                 }
             }
             55 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 28,
+                    states_to_pop: 2,
+                    nonterminal_produced: 26,
                 }
             }
             56 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
-                    nonterminal_produced: 29,
+                    nonterminal_produced: 27,
                 }
             }
             57 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 3,
-                    nonterminal_produced: 30,
+                    states_to_pop: 1,
+                    nonterminal_produced: 27,
                 }
             }
             58 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 3,
-                    nonterminal_produced: 30,
+                    states_to_pop: 1,
+                    nonterminal_produced: 28,
                 }
             }
             59 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 4,
+                    nonterminal_produced: 28,
+                }
+            }
+            60 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 1,
+                    nonterminal_produced: 29,
+                }
+            }
+            61 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
                     nonterminal_produced: 30,
                 }
             }
-            60 => {
+            62 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 3,
                     nonterminal_produced: 31,
                 }
             }
-            61 => {
-                __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 0,
-                    nonterminal_produced: 31,
-                }
-            }
-            62 => {
-                __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 2,
-                    nonterminal_produced: 32,
-                }
-            }
             63 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 0,
-                    nonterminal_produced: 32,
+                    states_to_pop: 3,
+                    nonterminal_produced: 31,
                 }
             }
             64 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
-                    nonterminal_produced: 33,
+                    nonterminal_produced: 31,
                 }
             }
             65 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 6,
-                    nonterminal_produced: 34,
+                    states_to_pop: 3,
+                    nonterminal_produced: 32,
                 }
             }
             66 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 3,
-                    nonterminal_produced: 35,
+                    states_to_pop: 0,
+                    nonterminal_produced: 32,
                 }
             }
             67 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 35,
+                    states_to_pop: 3,
+                    nonterminal_produced: 33,
                 }
             }
             68 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 36,
+                    states_to_pop: 0,
+                    nonterminal_produced: 33,
                 }
             }
             69 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
-                    nonterminal_produced: 36,
+                    states_to_pop: 2,
+                    nonterminal_produced: 34,
                 }
             }
             70 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 0,
+                    nonterminal_produced: 34,
+                }
+            }
+            71 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 1,
+                    nonterminal_produced: 35,
+                }
+            }
+            72 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 7,
+                    nonterminal_produced: 36,
+                }
+            }
+            73 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 3,
+                    nonterminal_produced: 37,
+                }
+            }
+            74 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
                     nonterminal_produced: 37,
                 }
             }
-            71 => {
-                __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 3,
-                    nonterminal_produced: 38,
-                }
-            }
-            72 => {
-                __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 3,
-                    nonterminal_produced: 38,
-                }
-            }
-            73 => {
-                __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 10,
-                    nonterminal_produced: 39,
-                }
-            }
-            74 => {
-                __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 3,
-                    nonterminal_produced: 39,
-                }
-            }
             75 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 5,
-                    nonterminal_produced: 39,
+                    states_to_pop: 1,
+                    nonterminal_produced: 37,
                 }
             }
             76 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 6,
-                    nonterminal_produced: 39,
+                    states_to_pop: 1,
+                    nonterminal_produced: 38,
                 }
             }
             77 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 8,
-                    nonterminal_produced: 39,
+                    states_to_pop: 1,
+                    nonterminal_produced: 38,
                 }
             }
             78 => {
@@ -14457,29 +15849,77 @@ mod __parse__UpdateCommand {
             }
             79 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
+                    states_to_pop: 3,
                     nonterminal_produced: 40,
                 }
             }
             80 => {
                 __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 3,
+                    nonterminal_produced: 40,
+                }
+            }
+            81 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 10,
+                    nonterminal_produced: 41,
+                }
+            }
+            82 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 3,
+                    nonterminal_produced: 41,
+                }
+            }
+            83 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 5,
+                    nonterminal_produced: 41,
+                }
+            }
+            84 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 6,
+                    nonterminal_produced: 41,
+                }
+            }
+            85 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 8,
+                    nonterminal_produced: 41,
+                }
+            }
+            86 => {
+                __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
                     nonterminal_produced: 41,
                 }
             }
-            81 => {
+            87 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
                     nonterminal_produced: 42,
                 }
             }
-            82 => {
+            88 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
                     nonterminal_produced: 43,
                 }
             }
-            83 => __state_machine::SimulatedReduce::Accept,
+            89 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 1,
+                    nonterminal_produced: 44,
+                }
+            }
+            90 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 1,
+                    nonterminal_produced: 45,
+                }
+            }
+            91 => __state_machine::SimulatedReduce::Accept,
             _ => panic!("invalid reduction index {}", __reduce_index)
         }
     }
@@ -14519,8 +15959,8 @@ mod __parse__UpdateCommand {
     fn __accepts<
         'input,
     >(
-        __error_state: Option<i8>,
-        __states: &[i8],
+        __error_state: Option<i16>,
+        __states: &[i16],
         __opt_integer: Option<usize>,
         _: core::marker::PhantomData<(&'input ())>,
     ) -> bool
@@ -14553,9 +15993,9 @@ mod __parse__UpdateCommand {
         'input,
     >(
         input: &'input str,
-        __action: i8,
+        __action: i16,
         __lookahead_start: Option<&usize>,
-        __states: &mut alloc::vec::Vec<i8>,
+        __states: &mut alloc::vec::Vec<i16>,
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
         _: core::marker::PhantomData<(&'input ())>,
     ) -> Option<Result<statement::UpdateCommand,__lalrpop_util::ParseError<usize, Token<'input>, &'static str>>>
@@ -14811,8 +16251,32 @@ mod __parse__UpdateCommand {
                 __reduce82(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
             }
             83 => {
+                __reduce83(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
+            }
+            84 => {
+                __reduce84(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
+            }
+            85 => {
+                __reduce85(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
+            }
+            86 => {
+                __reduce86(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
+            }
+            87 => {
+                __reduce87(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
+            }
+            88 => {
+                __reduce88(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
+            }
+            89 => {
+                __reduce89(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
+            }
+            90 => {
+                __reduce90(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
+            }
+            91 => {
                 // __UpdateCommand = UpdateCommand => ActionFn(2);
-                let __sym0 = __pop_Variant26(__symbols);
+                let __sym0 = __pop_Variant27(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym0.2;
                 let __nt = super::__action2::<>(input, __sym0);
@@ -14831,36 +16295,14 @@ mod __parse__UpdateCommand {
     fn __symbol_type_mismatch() -> ! {
         panic!("symbol type mismatch")
     }
-    fn __pop_Variant7<
+    fn __pop_Variant12<
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, (expression::Expression, Option<String>), usize)
+    ) -> (usize, AggregationFn, usize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant7(__v), __r)) => (__l, __v, __r),
-            _ => __symbol_type_mismatch()
-        }
-    }
-    fn __pop_Variant18<
-      'input,
-    >(
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, Option<Vec<(expression::Expression, Option<String>)>>, usize)
-     {
-        match __symbols.pop() {
-            Some((__l, __Symbol::Variant18(__v), __r)) => (__l, __v, __r),
-            _ => __symbol_type_mismatch()
-        }
-    }
-    fn __pop_Variant21<
-      'input,
-    >(
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, Option<Vec<String>>, usize)
-     {
-        match __symbols.pop() {
-            Some((__l, __Symbol::Variant21(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant12(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -14868,7 +16310,7 @@ mod __parse__UpdateCommand {
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, Option<predicate::Predicate>, usize)
+    ) -> (usize, Option<Vec<String>>, usize)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant22(__v), __r)) => (__l, __v, __r),
@@ -14879,10 +16321,32 @@ mod __parse__UpdateCommand {
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, Spec, usize)
+    ) -> (usize, Option<Vec<statement::SelectField>>, usize)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant19(__v), __r)) => (__l, __v, __r),
+            _ => __symbol_type_mismatch()
+        }
+    }
+    fn __pop_Variant23<
+      'input,
+    >(
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
+    ) -> (usize, Option<predicate::Predicate>, usize)
+     {
+        match __symbols.pop() {
+            Some((__l, __Symbol::Variant23(__v), __r)) => (__l, __v, __r),
+            _ => __symbol_type_mismatch()
+        }
+    }
+    fn __pop_Variant20<
+      'input,
+    >(
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
+    ) -> (usize, Spec, usize)
+     {
+        match __symbols.pop() {
+            Some((__l, __Symbol::Variant20(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -14912,43 +16376,10 @@ mod __parse__UpdateCommand {
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, Vec<(expression::Expression, Option<String>)>, usize)
-     {
-        match __symbols.pop() {
-            Some((__l, __Symbol::Variant16(__v), __r)) => (__l, __v, __r),
-            _ => __symbol_type_mismatch()
-        }
-    }
-    fn __pop_Variant15<
-      'input,
-    >(
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
     ) -> (usize, Vec<String>, usize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant15(__v), __r)) => (__l, __v, __r),
-            _ => __symbol_type_mismatch()
-        }
-    }
-    fn __pop_Variant13<
-      'input,
-    >(
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, Vec<Value>, usize)
-     {
-        match __symbols.pop() {
-            Some((__l, __Symbol::Variant13(__v), __r)) => (__l, __v, __r),
-            _ => __symbol_type_mismatch()
-        }
-    }
-    fn __pop_Variant12<
-      'input,
-    >(
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, Vec<predicate::Term>, usize)
-     {
-        match __symbols.pop() {
-            Some((__l, __Symbol::Variant12(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant16(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -14956,21 +16387,43 @@ mod __parse__UpdateCommand {
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, Vec<statement::FieldDefinition>, usize)
+    ) -> (usize, Vec<Value>, usize)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant14(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant8<
+    fn __pop_Variant13<
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, alloc::vec::Vec<(expression::Expression, Option<String>)>, usize)
+    ) -> (usize, Vec<predicate::Term>, usize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant8(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant13(__v), __r)) => (__l, __v, __r),
+            _ => __symbol_type_mismatch()
+        }
+    }
+    fn __pop_Variant15<
+      'input,
+    >(
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
+    ) -> (usize, Vec<statement::FieldDefinition>, usize)
+     {
+        match __symbols.pop() {
+            Some((__l, __Symbol::Variant15(__v), __r)) => (__l, __v, __r),
+            _ => __symbol_type_mismatch()
+        }
+    }
+    fn __pop_Variant17<
+      'input,
+    >(
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
+    ) -> (usize, Vec<statement::SelectField>, usize)
+     {
+        match __symbols.pop() {
+            Some((__l, __Symbol::Variant17(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -15018,6 +16471,17 @@ mod __parse__UpdateCommand {
             _ => __symbol_type_mismatch()
         }
     }
+    fn __pop_Variant8<
+      'input,
+    >(
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
+    ) -> (usize, alloc::vec::Vec<statement::SelectField>, usize)
+     {
+        match __symbols.pop() {
+            Some((__l, __Symbol::Variant8(__v), __r)) => (__l, __v, __r),
+            _ => __symbol_type_mismatch()
+        }
+    }
     fn __pop_Variant11<
       'input,
     >(
@@ -15029,25 +16493,25 @@ mod __parse__UpdateCommand {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant20<
+    fn __pop_Variant21<
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
     ) -> (usize, i32, usize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant20(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant21(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant23<
+    fn __pop_Variant24<
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
     ) -> (usize, predicate::Predicate, usize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant23(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant24(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -15062,14 +16526,14 @@ mod __parse__UpdateCommand {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant17<
+    fn __pop_Variant18<
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
     ) -> (usize, statement::CreateCommand, usize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant17(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant18(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -15084,25 +16548,25 @@ mod __parse__UpdateCommand {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant24<
+    fn __pop_Variant25<
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
     ) -> (usize, statement::QueryData, usize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant24(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant25(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant25<
+    fn __pop_Variant7<
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, statement::Statement, usize)
+    ) -> (usize, statement::SelectField, usize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant25(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant7(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -15110,10 +16574,21 @@ mod __parse__UpdateCommand {
       'input,
     >(
         __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
-    ) -> (usize, statement::UpdateCommand, usize)
+    ) -> (usize, statement::Statement, usize)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant26(__v), __r)) => (__l, __v, __r),
+            _ => __symbol_type_mismatch()
+        }
+    }
+    fn __pop_Variant27<
+      'input,
+    >(
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>
+    ) -> (usize, statement::UpdateCommand, usize)
+     {
+        match __symbols.pop() {
+            Some((__l, __Symbol::Variant27(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -15137,13 +16612,13 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Constant> COMMA) = Constant, COMMA => ActionFn(62);
+        // (<Constant> COMMA) = Constant, COMMA => ActionFn(70);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant1(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action62::<>(input, __sym0, __sym1);
+        let __nt = super::__action70::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant1(__nt), __end));
         (2, 0)
     }
@@ -15156,10 +16631,10 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Constant> COMMA)* =  => ActionFn(60);
+        // (<Constant> COMMA)* =  => ActionFn(68);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action60::<>(input, &__start, &__end);
+        let __nt = super::__action68::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant2(__nt), __end));
         (0, 1)
     }
@@ -15172,11 +16647,11 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Constant> COMMA)* = (<Constant> COMMA)+ => ActionFn(61);
+        // (<Constant> COMMA)* = (<Constant> COMMA)+ => ActionFn(69);
         let __sym0 = __pop_Variant2(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action61::<>(input, __sym0);
+        let __nt = super::__action69::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant2(__nt), __end));
         (1, 1)
     }
@@ -15189,13 +16664,13 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Constant> COMMA)+ = Constant, COMMA => ActionFn(79);
+        // (<Constant> COMMA)+ = Constant, COMMA => ActionFn(87);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant1(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action79::<>(input, __sym0, __sym1);
+        let __nt = super::__action87::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant2(__nt), __end));
         (2, 2)
     }
@@ -15208,14 +16683,14 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Constant> COMMA)+ = (<Constant> COMMA)+, Constant, COMMA => ActionFn(80);
+        // (<Constant> COMMA)+ = (<Constant> COMMA)+, Constant, COMMA => ActionFn(88);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant1(__symbols);
         let __sym0 = __pop_Variant2(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action80::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action88::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant2(__nt), __end));
         (3, 2)
     }
@@ -15228,13 +16703,13 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<FieldDefinition> COMMA) = FieldDefinition, COMMA => ActionFn(65);
+        // (<FieldDefinition> COMMA) = FieldDefinition, COMMA => ActionFn(73);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant3(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action65::<>(input, __sym0, __sym1);
+        let __nt = super::__action73::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant3(__nt), __end));
         (2, 3)
     }
@@ -15247,10 +16722,10 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<FieldDefinition> COMMA)* =  => ActionFn(63);
+        // (<FieldDefinition> COMMA)* =  => ActionFn(71);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action63::<>(input, &__start, &__end);
+        let __nt = super::__action71::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant4(__nt), __end));
         (0, 4)
     }
@@ -15263,11 +16738,11 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<FieldDefinition> COMMA)* = (<FieldDefinition> COMMA)+ => ActionFn(64);
+        // (<FieldDefinition> COMMA)* = (<FieldDefinition> COMMA)+ => ActionFn(72);
         let __sym0 = __pop_Variant4(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action64::<>(input, __sym0);
+        let __nt = super::__action72::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant4(__nt), __end));
         (1, 4)
     }
@@ -15280,13 +16755,13 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<FieldDefinition> COMMA)+ = FieldDefinition, COMMA => ActionFn(83);
+        // (<FieldDefinition> COMMA)+ = FieldDefinition, COMMA => ActionFn(91);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant3(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action83::<>(input, __sym0, __sym1);
+        let __nt = super::__action91::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant4(__nt), __end));
         (2, 5)
     }
@@ -15299,14 +16774,14 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<FieldDefinition> COMMA)+ = (<FieldDefinition> COMMA)+, FieldDefinition, COMMA => ActionFn(84);
+        // (<FieldDefinition> COMMA)+ = (<FieldDefinition> COMMA)+, FieldDefinition, COMMA => ActionFn(92);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant3(__symbols);
         let __sym0 = __pop_Variant4(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action84::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action92::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant4(__nt), __end));
         (3, 5)
     }
@@ -15319,13 +16794,13 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<IdToken> COMMA) = IdToken, COMMA => ActionFn(56);
+        // (<IdToken> COMMA) = IdToken, COMMA => ActionFn(64);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action56::<>(input, __sym0, __sym1);
+        let __nt = super::__action64::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant5(__nt), __end));
         (2, 6)
     }
@@ -15338,10 +16813,10 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<IdToken> COMMA)* =  => ActionFn(54);
+        // (<IdToken> COMMA)* =  => ActionFn(62);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action54::<>(input, &__start, &__end);
+        let __nt = super::__action62::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant6(__nt), __end));
         (0, 7)
     }
@@ -15354,11 +16829,11 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<IdToken> COMMA)* = (<IdToken> COMMA)+ => ActionFn(55);
+        // (<IdToken> COMMA)* = (<IdToken> COMMA)+ => ActionFn(63);
         let __sym0 = __pop_Variant6(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action55::<>(input, __sym0);
+        let __nt = super::__action63::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant6(__nt), __end));
         (1, 7)
     }
@@ -15371,13 +16846,13 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<IdToken> COMMA)+ = IdToken, COMMA => ActionFn(87);
+        // (<IdToken> COMMA)+ = IdToken, COMMA => ActionFn(95);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action87::<>(input, __sym0, __sym1);
+        let __nt = super::__action95::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant6(__nt), __end));
         (2, 8)
     }
@@ -15390,14 +16865,14 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<IdToken> COMMA)+ = (<IdToken> COMMA)+, IdToken, COMMA => ActionFn(88);
+        // (<IdToken> COMMA)+ = (<IdToken> COMMA)+, IdToken, COMMA => ActionFn(96);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant5(__symbols);
         let __sym0 = __pop_Variant6(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action88::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action96::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant6(__nt), __end));
         (3, 8)
     }
@@ -15410,13 +16885,13 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<SelectField> COMMA) = SelectField, COMMA => ActionFn(59);
+        // (<SelectField> COMMA) = SelectField, COMMA => ActionFn(67);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant7(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action59::<>(input, __sym0, __sym1);
+        let __nt = super::__action67::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant7(__nt), __end));
         (2, 9)
     }
@@ -15429,10 +16904,10 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<SelectField> COMMA)* =  => ActionFn(57);
+        // (<SelectField> COMMA)* =  => ActionFn(65);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action57::<>(input, &__start, &__end);
+        let __nt = super::__action65::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant8(__nt), __end));
         (0, 10)
     }
@@ -15445,11 +16920,11 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<SelectField> COMMA)* = (<SelectField> COMMA)+ => ActionFn(58);
+        // (<SelectField> COMMA)* = (<SelectField> COMMA)+ => ActionFn(66);
         let __sym0 = __pop_Variant8(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action58::<>(input, __sym0);
+        let __nt = super::__action66::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant8(__nt), __end));
         (1, 10)
     }
@@ -15462,13 +16937,13 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<SelectField> COMMA)+ = SelectField, COMMA => ActionFn(91);
+        // (<SelectField> COMMA)+ = SelectField, COMMA => ActionFn(99);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant7(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action91::<>(input, __sym0, __sym1);
+        let __nt = super::__action99::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant8(__nt), __end));
         (2, 11)
     }
@@ -15481,14 +16956,14 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<SelectField> COMMA)+ = (<SelectField> COMMA)+, SelectField, COMMA => ActionFn(92);
+        // (<SelectField> COMMA)+ = (<SelectField> COMMA)+, SelectField, COMMA => ActionFn(100);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant7(__symbols);
         let __sym0 = __pop_Variant8(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action92::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action100::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant8(__nt), __end));
         (3, 11)
     }
@@ -15501,13 +16976,13 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Term> AND) = Term, AND => ActionFn(68);
+        // (<Term> AND) = Term, AND => ActionFn(76);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant9(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action68::<>(input, __sym0, __sym1);
+        let __nt = super::__action76::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant9(__nt), __end));
         (2, 12)
     }
@@ -15520,10 +16995,10 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Term> AND)* =  => ActionFn(66);
+        // (<Term> AND)* =  => ActionFn(74);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action66::<>(input, &__start, &__end);
+        let __nt = super::__action74::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant10(__nt), __end));
         (0, 13)
     }
@@ -15536,11 +17011,11 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Term> AND)* = (<Term> AND)+ => ActionFn(67);
+        // (<Term> AND)* = (<Term> AND)+ => ActionFn(75);
         let __sym0 = __pop_Variant10(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action67::<>(input, __sym0);
+        let __nt = super::__action75::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant10(__nt), __end));
         (1, 13)
     }
@@ -15553,13 +17028,13 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Term> AND)+ = Term, AND => ActionFn(95);
+        // (<Term> AND)+ = Term, AND => ActionFn(103);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant9(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action95::<>(input, __sym0, __sym1);
+        let __nt = super::__action103::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant10(__nt), __end));
         (2, 14)
     }
@@ -15572,14 +17047,14 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Term> AND)+ = (<Term> AND)+, Term, AND => ActionFn(96);
+        // (<Term> AND)+ = (<Term> AND)+, Term, AND => ActionFn(104);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant9(__symbols);
         let __sym0 = __pop_Variant10(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action96::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action104::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant10(__nt), __end));
         (3, 14)
     }
@@ -15592,14 +17067,14 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AddExpr = AddExpr, PLUS, MulExpr => ActionFn(32);
+        // AddExpr = AddExpr, PLUS, MulExpr => ActionFn(40);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant11(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action32::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action40::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (3, 15)
     }
@@ -15612,14 +17087,14 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AddExpr = AddExpr, MINUS, MulExpr => ActionFn(33);
+        // AddExpr = AddExpr, MINUS, MulExpr => ActionFn(41);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant11(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action33::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action41::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (3, 15)
     }
@@ -15632,11 +17107,11 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AddExpr = MulExpr => ActionFn(34);
+        // AddExpr = MulExpr => ActionFn(42);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action34::<>(input, __sym0);
+        let __nt = super::__action42::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (1, 15)
     }
@@ -15649,13 +17124,17 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // And<Term> = Term => ActionFn(97);
-        let __sym0 = __pop_Variant9(__symbols);
+        // AggregationFn = MAX, LPAREN, IdToken, RPAREN => ActionFn(13);
+        assert!(__symbols.len() >= 4);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action97::<>(input, __sym0);
+        let __end = __sym3.2;
+        let __nt = super::__action13::<>(input, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant12(__nt), __end));
-        (1, 16)
+        (4, 16)
     }
     fn __reduce29<
         'input,
@@ -15666,15 +17145,17 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // And<Term> = (<Term> AND)+, Term => ActionFn(98);
-        assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant9(__symbols);
-        let __sym0 = __pop_Variant10(__symbols);
+        // AggregationFn = MIN, LPAREN, IdToken, RPAREN => ActionFn(14);
+        assert!(__symbols.len() >= 4);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym1.2;
-        let __nt = super::__action98::<>(input, __sym0, __sym1);
+        let __end = __sym3.2;
+        let __nt = super::__action14::<>(input, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant12(__nt), __end));
-        (2, 16)
+        (4, 16)
     }
     fn __reduce30<
         'input,
@@ -15685,13 +17166,17 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<Constant> = Constant => ActionFn(81);
-        let __sym0 = __pop_Variant1(__symbols);
+        // AggregationFn = SUM, LPAREN, IdToken, RPAREN => ActionFn(15);
+        assert!(__symbols.len() >= 4);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action81::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant13(__nt), __end));
-        (1, 17)
+        let __end = __sym3.2;
+        let __nt = super::__action15::<>(input, __sym0, __sym1, __sym2, __sym3);
+        __symbols.push((__start, __Symbol::Variant12(__nt), __end));
+        (4, 16)
     }
     fn __reduce31<
         'input,
@@ -15702,15 +17187,17 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<Constant> = (<Constant> COMMA)+, Constant => ActionFn(82);
-        assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant1(__symbols);
-        let __sym0 = __pop_Variant2(__symbols);
+        // AggregationFn = COUNT, LPAREN, IdToken, RPAREN => ActionFn(16);
+        assert!(__symbols.len() >= 4);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym1.2;
-        let __nt = super::__action82::<>(input, __sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant13(__nt), __end));
-        (2, 17)
+        let __end = __sym3.2;
+        let __nt = super::__action16::<>(input, __sym0, __sym1, __sym2, __sym3);
+        __symbols.push((__start, __Symbol::Variant12(__nt), __end));
+        (4, 16)
     }
     fn __reduce32<
         'input,
@@ -15721,13 +17208,17 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<FieldDefinition> = FieldDefinition => ActionFn(85);
-        let __sym0 = __pop_Variant3(__symbols);
+        // AggregationFn = AVG, LPAREN, IdToken, RPAREN => ActionFn(17);
+        assert!(__symbols.len() >= 4);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action85::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant14(__nt), __end));
-        (1, 18)
+        let __end = __sym3.2;
+        let __nt = super::__action17::<>(input, __sym0, __sym1, __sym2, __sym3);
+        __symbols.push((__start, __Symbol::Variant12(__nt), __end));
+        (4, 16)
     }
     fn __reduce33<
         'input,
@@ -15738,15 +17229,13 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<FieldDefinition> = (<FieldDefinition> COMMA)+, FieldDefinition => ActionFn(86);
-        assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant3(__symbols);
-        let __sym0 = __pop_Variant4(__symbols);
+        // And<Term> = Term => ActionFn(105);
+        let __sym0 = __pop_Variant9(__symbols);
         let __start = __sym0.0;
-        let __end = __sym1.2;
-        let __nt = super::__action86::<>(input, __sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant14(__nt), __end));
-        (2, 18)
+        let __end = __sym0.2;
+        let __nt = super::__action105::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant13(__nt), __end));
+        (1, 17)
     }
     fn __reduce34<
         'input,
@@ -15757,13 +17246,15 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<IdToken> = IdToken => ActionFn(89);
-        let __sym0 = __pop_Variant5(__symbols);
+        // And<Term> = (<Term> AND)+, Term => ActionFn(106);
+        assert!(__symbols.len() >= 2);
+        let __sym1 = __pop_Variant9(__symbols);
+        let __sym0 = __pop_Variant10(__symbols);
         let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action89::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant15(__nt), __end));
-        (1, 19)
+        let __end = __sym1.2;
+        let __nt = super::__action106::<>(input, __sym0, __sym1);
+        __symbols.push((__start, __Symbol::Variant13(__nt), __end));
+        (2, 17)
     }
     fn __reduce35<
         'input,
@@ -15774,15 +17265,13 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<IdToken> = (<IdToken> COMMA)+, IdToken => ActionFn(90);
-        assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant5(__symbols);
-        let __sym0 = __pop_Variant6(__symbols);
+        // Comma<Constant> = Constant => ActionFn(89);
+        let __sym0 = __pop_Variant1(__symbols);
         let __start = __sym0.0;
-        let __end = __sym1.2;
-        let __nt = super::__action90::<>(input, __sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant15(__nt), __end));
-        (2, 19)
+        let __end = __sym0.2;
+        let __nt = super::__action89::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant14(__nt), __end));
+        (1, 18)
     }
     fn __reduce36<
         'input,
@@ -15793,13 +17282,15 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<SelectField> = SelectField => ActionFn(93);
-        let __sym0 = __pop_Variant7(__symbols);
+        // Comma<Constant> = (<Constant> COMMA)+, Constant => ActionFn(90);
+        assert!(__symbols.len() >= 2);
+        let __sym1 = __pop_Variant1(__symbols);
+        let __sym0 = __pop_Variant2(__symbols);
         let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action93::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant16(__nt), __end));
-        (1, 20)
+        let __end = __sym1.2;
+        let __nt = super::__action90::<>(input, __sym0, __sym1);
+        __symbols.push((__start, __Symbol::Variant14(__nt), __end));
+        (2, 18)
     }
     fn __reduce37<
         'input,
@@ -15810,15 +17301,13 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<SelectField> = (<SelectField> COMMA)+, SelectField => ActionFn(94);
-        assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant7(__symbols);
-        let __sym0 = __pop_Variant8(__symbols);
+        // Comma<FieldDefinition> = FieldDefinition => ActionFn(93);
+        let __sym0 = __pop_Variant3(__symbols);
         let __start = __sym0.0;
-        let __end = __sym1.2;
-        let __nt = super::__action94::<>(input, __sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant16(__nt), __end));
-        (2, 20)
+        let __end = __sym0.2;
+        let __nt = super::__action93::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant15(__nt), __end));
+        (1, 19)
     }
     fn __reduce38<
         'input,
@@ -15829,13 +17318,15 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Constant = NULL => ActionFn(43);
-        let __sym0 = __pop_Variant0(__symbols);
+        // Comma<FieldDefinition> = (<FieldDefinition> COMMA)+, FieldDefinition => ActionFn(94);
+        assert!(__symbols.len() >= 2);
+        let __sym1 = __pop_Variant3(__symbols);
+        let __sym0 = __pop_Variant4(__symbols);
         let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action43::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant1(__nt), __end));
-        (1, 21)
+        let __end = __sym1.2;
+        let __nt = super::__action94::<>(input, __sym0, __sym1);
+        __symbols.push((__start, __Symbol::Variant15(__nt), __end));
+        (2, 19)
     }
     fn __reduce39<
         'input,
@@ -15846,13 +17337,13 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Constant = I32Constant => ActionFn(44);
-        let __sym0 = __pop_Variant20(__symbols);
+        // Comma<IdToken> = IdToken => ActionFn(97);
+        let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action44::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant1(__nt), __end));
-        (1, 21)
+        let __nt = super::__action97::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant16(__nt), __end));
+        (1, 20)
     }
     fn __reduce40<
         'input,
@@ -15863,13 +17354,15 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Constant = StringConstant => ActionFn(45);
-        let __sym0 = __pop_Variant5(__symbols);
+        // Comma<IdToken> = (<IdToken> COMMA)+, IdToken => ActionFn(98);
+        assert!(__symbols.len() >= 2);
+        let __sym1 = __pop_Variant5(__symbols);
+        let __sym0 = __pop_Variant6(__symbols);
         let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action45::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant1(__nt), __end));
-        (1, 21)
+        let __end = __sym1.2;
+        let __nt = super::__action98::<>(input, __sym0, __sym1);
+        __symbols.push((__start, __Symbol::Variant16(__nt), __end));
+        (2, 20)
     }
     fn __reduce41<
         'input,
@@ -15880,19 +17373,13 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // CreateCommand = CREATE, TABLE, IdToken, LPAREN, Comma<FieldDefinition>, RPAREN => ActionFn(22);
-        assert!(__symbols.len() >= 6);
-        let __sym5 = __pop_Variant0(__symbols);
-        let __sym4 = __pop_Variant14(__symbols);
-        let __sym3 = __pop_Variant0(__symbols);
-        let __sym2 = __pop_Variant5(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
+        // Comma<SelectField> = SelectField => ActionFn(101);
+        let __sym0 = __pop_Variant7(__symbols);
         let __start = __sym0.0;
-        let __end = __sym5.2;
-        let __nt = super::__action22::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
+        let __end = __sym0.2;
+        let __nt = super::__action101::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant17(__nt), __end));
-        (6, 22)
+        (1, 21)
     }
     fn __reduce42<
         'input,
@@ -15903,18 +17390,15 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // CreateCommand = CREATE, VIEW, IdToken, AS, Query => ActionFn(23);
-        assert!(__symbols.len() >= 5);
-        let __sym4 = __pop_Variant24(__symbols);
-        let __sym3 = __pop_Variant0(__symbols);
-        let __sym2 = __pop_Variant5(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
+        // Comma<SelectField> = (<SelectField> COMMA)+, SelectField => ActionFn(102);
+        assert!(__symbols.len() >= 2);
+        let __sym1 = __pop_Variant7(__symbols);
+        let __sym0 = __pop_Variant8(__symbols);
         let __start = __sym0.0;
-        let __end = __sym4.2;
-        let __nt = super::__action23::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4);
+        let __end = __sym1.2;
+        let __nt = super::__action102::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant17(__nt), __end));
-        (5, 22)
+        (2, 21)
     }
     fn __reduce43<
         'input,
@@ -15925,7 +17409,103 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // CreateCommand = CREATE, INDEX, IdToken, ON, IdToken, LPAREN, IdToken, RPAREN => ActionFn(24);
+        // Constant = NULL => ActionFn(51);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action51::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant1(__nt), __end));
+        (1, 22)
+    }
+    fn __reduce44<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // Constant = I32Constant => ActionFn(52);
+        let __sym0 = __pop_Variant21(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action52::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant1(__nt), __end));
+        (1, 22)
+    }
+    fn __reduce45<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // Constant = StringConstant => ActionFn(53);
+        let __sym0 = __pop_Variant5(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action53::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant1(__nt), __end));
+        (1, 22)
+    }
+    fn __reduce46<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // CreateCommand = CREATE, TABLE, IdToken, LPAREN, Comma<FieldDefinition>, RPAREN => ActionFn(30);
+        assert!(__symbols.len() >= 6);
+        let __sym5 = __pop_Variant0(__symbols);
+        let __sym4 = __pop_Variant15(__symbols);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym5.2;
+        let __nt = super::__action30::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
+        __symbols.push((__start, __Symbol::Variant18(__nt), __end));
+        (6, 23)
+    }
+    fn __reduce47<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // CreateCommand = CREATE, VIEW, IdToken, AS, Query => ActionFn(31);
+        assert!(__symbols.len() >= 5);
+        let __sym4 = __pop_Variant25(__symbols);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym4.2;
+        let __nt = super::__action31::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4);
+        __symbols.push((__start, __Symbol::Variant18(__nt), __end));
+        (5, 23)
+    }
+    fn __reduce48<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // CreateCommand = CREATE, INDEX, IdToken, ON, IdToken, LPAREN, IdToken, RPAREN => ActionFn(32);
         assert!(__symbols.len() >= 8);
         let __sym7 = __pop_Variant0(__symbols);
         let __sym6 = __pop_Variant5(__symbols);
@@ -15937,97 +17517,9 @@ mod __parse__UpdateCommand {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym7.2;
-        let __nt = super::__action24::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
-        __symbols.push((__start, __Symbol::Variant17(__nt), __end));
-        (8, 22)
-    }
-    fn __reduce44<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // Expression = AddExpr => ActionFn(31);
-        let __sym0 = __pop_Variant11(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action31::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
-        (1, 23)
-    }
-    fn __reduce45<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // Factor = LPAREN, Expression, RPAREN => ActionFn(38);
-        assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant11(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym2.2;
-        let __nt = super::__action38::<>(input, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
-        (3, 24)
-    }
-    fn __reduce46<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // Factor = NULL => ActionFn(39);
-        let __sym0 = __pop_Variant0(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action39::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
-        (1, 24)
-    }
-    fn __reduce47<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // Factor = I32Constant => ActionFn(40);
-        let __sym0 = __pop_Variant20(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action40::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
-        (1, 24)
-    }
-    fn __reduce48<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // Factor = StringConstant => ActionFn(41);
-        let __sym0 = __pop_Variant5(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action41::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
-        (1, 24)
+        let __nt = super::__action32::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
+        __symbols.push((__start, __Symbol::Variant18(__nt), __end));
+        (8, 23)
     }
     fn __reduce49<
         'input,
@@ -16038,11 +17530,11 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Factor = IdToken => ActionFn(42);
-        let __sym0 = __pop_Variant5(__symbols);
+        // Expression = AddExpr => ActionFn(39);
+        let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action42::<>(input, __sym0);
+        let __nt = super::__action39::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (1, 24)
     }
@@ -16055,17 +17547,105 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // FieldDefinition = IdToken, FieldType => ActionFn(25);
+        // Factor = LPAREN, Expression, RPAREN => ActionFn(46);
+        assert!(__symbols.len() >= 3);
+        let __sym2 = __pop_Variant0(__symbols);
+        let __sym1 = __pop_Variant11(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym2.2;
+        let __nt = super::__action46::<>(input, __sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
+        (3, 25)
+    }
+    fn __reduce51<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // Factor = NULL => ActionFn(47);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action47::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
+        (1, 25)
+    }
+    fn __reduce52<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // Factor = I32Constant => ActionFn(48);
+        let __sym0 = __pop_Variant21(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action48::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
+        (1, 25)
+    }
+    fn __reduce53<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // Factor = StringConstant => ActionFn(49);
+        let __sym0 = __pop_Variant5(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action49::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
+        (1, 25)
+    }
+    fn __reduce54<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // Factor = IdToken => ActionFn(50);
+        let __sym0 = __pop_Variant5(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action50::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
+        (1, 25)
+    }
+    fn __reduce55<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // FieldDefinition = IdToken, FieldType => ActionFn(33);
         assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant19(__symbols);
+        let __sym1 = __pop_Variant20(__symbols);
         let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action25::<>(input, __sym0, __sym1);
+        let __nt = super::__action33::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant3(__nt), __end));
-        (2, 25)
+        (2, 26)
     }
-    fn __reduce51<
+    fn __reduce56<
         'input,
     >(
         input: &'input str,
@@ -16079,97 +17659,8 @@ mod __parse__UpdateCommand {
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action8::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant18(__nt), __end));
-        (1, 26)
-    }
-    fn __reduce52<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // FieldList = Comma<SelectField> => ActionFn(9);
-        let __sym0 = __pop_Variant16(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action9::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant18(__nt), __end));
-        (1, 26)
-    }
-    fn __reduce53<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // FieldType = I32 => ActionFn(26);
-        let __sym0 = __pop_Variant0(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action26::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant19(__nt), __end));
         (1, 27)
-    }
-    fn __reduce54<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // FieldType = VARCHAR, LPAREN, I32Constant, RPAREN => ActionFn(27);
-        assert!(__symbols.len() >= 4);
-        let __sym3 = __pop_Variant0(__symbols);
-        let __sym2 = __pop_Variant20(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym3.2;
-        let __nt = super::__action27::<>(input, __sym0, __sym1, __sym2, __sym3);
-        __symbols.push((__start, __Symbol::Variant19(__nt), __end));
-        (4, 27)
-    }
-    fn __reduce55<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // I32Constant = I32_LITERAL => ActionFn(46);
-        let __sym0 = __pop_Variant0(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action46::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant20(__nt), __end));
-        (1, 28)
-    }
-    fn __reduce56<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // IdToken = ID => ActionFn(48);
-        let __sym0 = __pop_Variant0(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action48::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant5(__nt), __end));
-        (1, 29)
     }
     fn __reduce57<
         'input,
@@ -16180,16 +17671,13 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // MulExpr = MulExpr, STAR, Factor => ActionFn(35);
-        assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant11(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant11(__symbols);
+        // FieldList = Comma<SelectField> => ActionFn(9);
+        let __sym0 = __pop_Variant17(__symbols);
         let __start = __sym0.0;
-        let __end = __sym2.2;
-        let __nt = super::__action35::<>(input, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
-        (3, 30)
+        let __end = __sym0.2;
+        let __nt = super::__action9::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant19(__nt), __end));
+        (1, 27)
     }
     fn __reduce58<
         'input,
@@ -16200,16 +17688,13 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // MulExpr = MulExpr, SLASH, Factor => ActionFn(36);
-        assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant11(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant11(__symbols);
+        // FieldType = I32 => ActionFn(34);
+        let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym2.2;
-        let __nt = super::__action36::<>(input, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
-        (3, 30)
+        let __end = __sym0.2;
+        let __nt = super::__action34::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant20(__nt), __end));
+        (1, 28)
     }
     fn __reduce59<
         'input,
@@ -16220,13 +17705,17 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // MulExpr = Factor => ActionFn(37);
-        let __sym0 = __pop_Variant11(__symbols);
+        // FieldType = VARCHAR, LPAREN, I32Constant, RPAREN => ActionFn(35);
+        assert!(__symbols.len() >= 4);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant21(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action37::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
-        (1, 30)
+        let __end = __sym3.2;
+        let __nt = super::__action35::<>(input, __sym0, __sym1, __sym2, __sym3);
+        __symbols.push((__start, __Symbol::Variant20(__nt), __end));
+        (4, 28)
     }
     fn __reduce60<
         'input,
@@ -16237,16 +17726,13 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // OptOrderBy = ORDER, BY, Comma<IdToken> => ActionFn(14);
-        assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant15(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
+        // I32Constant = I32_LITERAL => ActionFn(54);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym2.2;
-        let __nt = super::__action14::<>(input, __sym0, __sym1, __sym2);
+        let __end = __sym0.2;
+        let __nt = super::__action54::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant21(__nt), __end));
-        (3, 31)
+        (1, 29)
     }
     fn __reduce61<
         'input,
@@ -16257,12 +17743,13 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // OptOrderBy =  => ActionFn(15);
-        let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
-        let __end = __start;
-        let __nt = super::__action15::<>(input, &__start, &__end);
-        __symbols.push((__start, __Symbol::Variant21(__nt), __end));
-        (0, 31)
+        // IdToken = ID => ActionFn(56);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action56::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant5(__nt), __end));
+        (1, 30)
     }
     fn __reduce62<
         'input,
@@ -16273,15 +17760,16 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // OptPredicate = WHERE, Predicate => ActionFn(12);
-        assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant23(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
+        // MulExpr = MulExpr, STAR, Factor => ActionFn(43);
+        assert!(__symbols.len() >= 3);
+        let __sym2 = __pop_Variant11(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
-        let __end = __sym1.2;
-        let __nt = super::__action12::<>(input, __sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant22(__nt), __end));
-        (2, 32)
+        let __end = __sym2.2;
+        let __nt = super::__action43::<>(input, __sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
+        (3, 31)
     }
     fn __reduce63<
         'input,
@@ -16292,12 +17780,16 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // OptPredicate =  => ActionFn(13);
-        let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
-        let __end = __start;
-        let __nt = super::__action13::<>(input, &__start, &__end);
-        __symbols.push((__start, __Symbol::Variant22(__nt), __end));
-        (0, 32)
+        // MulExpr = MulExpr, SLASH, Factor => ActionFn(44);
+        assert!(__symbols.len() >= 3);
+        let __sym2 = __pop_Variant11(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant11(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym2.2;
+        let __nt = super::__action44::<>(input, __sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
+        (3, 31)
     }
     fn __reduce64<
         'input,
@@ -16308,13 +17800,13 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Predicate = And<Term> => ActionFn(28);
-        let __sym0 = __pop_Variant12(__symbols);
+        // MulExpr = Factor => ActionFn(45);
+        let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action28::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant23(__nt), __end));
-        (1, 33)
+        let __nt = super::__action45::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant11(__nt), __end));
+        (1, 31)
     }
     fn __reduce65<
         'input,
@@ -16325,21 +17817,146 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Query = SELECT, FieldList, FROM, Comma<IdToken>, OptPredicate, OptOrderBy => ActionFn(7);
-        assert!(__symbols.len() >= 6);
-        let __sym5 = __pop_Variant21(__symbols);
-        let __sym4 = __pop_Variant22(__symbols);
-        let __sym3 = __pop_Variant15(__symbols);
-        let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant18(__symbols);
+        // OptGroupBy = GROUP, BY, Comma<IdToken> => ActionFn(20);
+        assert!(__symbols.len() >= 3);
+        let __sym2 = __pop_Variant16(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym5.2;
-        let __nt = super::__action7::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
-        __symbols.push((__start, __Symbol::Variant24(__nt), __end));
-        (6, 34)
+        let __end = __sym2.2;
+        let __nt = super::__action20::<>(input, __sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant22(__nt), __end));
+        (3, 32)
     }
     fn __reduce66<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // OptGroupBy =  => ActionFn(21);
+        let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
+        let __end = __start;
+        let __nt = super::__action21::<>(input, &__start, &__end);
+        __symbols.push((__start, __Symbol::Variant22(__nt), __end));
+        (0, 32)
+    }
+    fn __reduce67<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // OptOrderBy = ORDER, BY, Comma<IdToken> => ActionFn(22);
+        assert!(__symbols.len() >= 3);
+        let __sym2 = __pop_Variant16(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym2.2;
+        let __nt = super::__action22::<>(input, __sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant22(__nt), __end));
+        (3, 33)
+    }
+    fn __reduce68<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // OptOrderBy =  => ActionFn(23);
+        let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
+        let __end = __start;
+        let __nt = super::__action23::<>(input, &__start, &__end);
+        __symbols.push((__start, __Symbol::Variant22(__nt), __end));
+        (0, 33)
+    }
+    fn __reduce69<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // OptPredicate = WHERE, Predicate => ActionFn(18);
+        assert!(__symbols.len() >= 2);
+        let __sym1 = __pop_Variant24(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym1.2;
+        let __nt = super::__action18::<>(input, __sym0, __sym1);
+        __symbols.push((__start, __Symbol::Variant23(__nt), __end));
+        (2, 34)
+    }
+    fn __reduce70<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // OptPredicate =  => ActionFn(19);
+        let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
+        let __end = __start;
+        let __nt = super::__action19::<>(input, &__start, &__end);
+        __symbols.push((__start, __Symbol::Variant23(__nt), __end));
+        (0, 34)
+    }
+    fn __reduce71<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // Predicate = And<Term> => ActionFn(36);
+        let __sym0 = __pop_Variant13(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action36::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant24(__nt), __end));
+        (1, 35)
+    }
+    fn __reduce72<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // Query = SELECT, FieldList, FROM, Comma<IdToken>, OptPredicate, OptGroupBy, OptOrderBy => ActionFn(7);
+        assert!(__symbols.len() >= 7);
+        let __sym6 = __pop_Variant22(__symbols);
+        let __sym5 = __pop_Variant22(__symbols);
+        let __sym4 = __pop_Variant23(__symbols);
+        let __sym3 = __pop_Variant16(__symbols);
+        let __sym2 = __pop_Variant0(__symbols);
+        let __sym1 = __pop_Variant19(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym6.2;
+        let __nt = super::__action7::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6);
+        __symbols.push((__start, __Symbol::Variant25(__nt), __end));
+        (7, 36)
+    }
+    fn __reduce73<
         'input,
     >(
         input: &'input str,
@@ -16357,142 +17974,7 @@ mod __parse__UpdateCommand {
         let __end = __sym2.2;
         let __nt = super::__action10::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant7(__nt), __end));
-        (3, 35)
-    }
-    fn __reduce67<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // SelectField = IdToken => ActionFn(11);
-        let __sym0 = __pop_Variant5(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action11::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant7(__nt), __end));
-        (1, 35)
-    }
-    fn __reduce68<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // Statement = Query => ActionFn(5);
-        let __sym0 = __pop_Variant24(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action5::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant25(__nt), __end));
-        (1, 36)
-    }
-    fn __reduce69<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // Statement = UpdateCommand => ActionFn(6);
-        let __sym0 = __pop_Variant26(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action6::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant25(__nt), __end));
-        (1, 36)
-    }
-    fn __reduce70<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // StringConstant = STRING_LITERAL => ActionFn(47);
-        let __sym0 = __pop_Variant0(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action47::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant5(__nt), __end));
-        (1, 37)
-    }
-    fn __reduce71<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // Term = Expression, IS, NULL => ActionFn(29);
-        assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant11(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym2.2;
-        let __nt = super::__action29::<>(input, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant9(__nt), __end));
-        (3, 38)
-    }
-    fn __reduce72<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // Term = Expression, EQ, Expression => ActionFn(30);
-        assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant11(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant11(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym2.2;
-        let __nt = super::__action30::<>(input, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant9(__nt), __end));
-        (3, 38)
-    }
-    fn __reduce73<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // UpdateCommand = INSERT, INTO, IdToken, LPAREN, Comma<IdToken>, RPAREN, VALUES, LPAREN, Comma<Constant>, RPAREN => ActionFn(16);
-        assert!(__symbols.len() >= 10);
-        let __sym9 = __pop_Variant0(__symbols);
-        let __sym8 = __pop_Variant13(__symbols);
-        let __sym7 = __pop_Variant0(__symbols);
-        let __sym6 = __pop_Variant0(__symbols);
-        let __sym5 = __pop_Variant0(__symbols);
-        let __sym4 = __pop_Variant15(__symbols);
-        let __sym3 = __pop_Variant0(__symbols);
-        let __sym2 = __pop_Variant5(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym9.2;
-        let __nt = super::__action16::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9);
-        __symbols.push((__start, __Symbol::Variant26(__nt), __end));
-        (10, 39)
+        (3, 37)
     }
     fn __reduce74<
         'input,
@@ -16503,16 +17985,13 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // UpdateCommand = DELETE, FROM, IdToken => ActionFn(17);
-        assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant5(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
+        // SelectField = Expression => ActionFn(11);
+        let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
-        let __end = __sym2.2;
-        let __nt = super::__action17::<>(input, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant26(__nt), __end));
-        (3, 39)
+        let __end = __sym0.2;
+        let __nt = super::__action11::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant7(__nt), __end));
+        (1, 37)
     }
     fn __reduce75<
         'input,
@@ -16523,18 +18002,13 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // UpdateCommand = DELETE, FROM, IdToken, WHERE, Predicate => ActionFn(18);
-        assert!(__symbols.len() >= 5);
-        let __sym4 = __pop_Variant23(__symbols);
-        let __sym3 = __pop_Variant0(__symbols);
-        let __sym2 = __pop_Variant5(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
+        // SelectField = AggregationFn => ActionFn(12);
+        let __sym0 = __pop_Variant12(__symbols);
         let __start = __sym0.0;
-        let __end = __sym4.2;
-        let __nt = super::__action18::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4);
-        __symbols.push((__start, __Symbol::Variant26(__nt), __end));
-        (5, 39)
+        let __end = __sym0.2;
+        let __nt = super::__action12::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant7(__nt), __end));
+        (1, 37)
     }
     fn __reduce76<
         'input,
@@ -16545,19 +18019,13 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // UpdateCommand = MODIFY, IdToken, SET, IdToken, EQ, Expression => ActionFn(19);
-        assert!(__symbols.len() >= 6);
-        let __sym5 = __pop_Variant11(__symbols);
-        let __sym4 = __pop_Variant0(__symbols);
-        let __sym3 = __pop_Variant5(__symbols);
-        let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant5(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
+        // Statement = Query => ActionFn(5);
+        let __sym0 = __pop_Variant25(__symbols);
         let __start = __sym0.0;
-        let __end = __sym5.2;
-        let __nt = super::__action19::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
+        let __end = __sym0.2;
+        let __nt = super::__action5::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant26(__nt), __end));
-        (6, 39)
+        (1, 38)
     }
     fn __reduce77<
         'input,
@@ -16568,21 +18036,13 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // UpdateCommand = MODIFY, IdToken, SET, IdToken, EQ, Expression, WHERE, Predicate => ActionFn(20);
-        assert!(__symbols.len() >= 8);
-        let __sym7 = __pop_Variant23(__symbols);
-        let __sym6 = __pop_Variant0(__symbols);
-        let __sym5 = __pop_Variant11(__symbols);
-        let __sym4 = __pop_Variant0(__symbols);
-        let __sym3 = __pop_Variant5(__symbols);
-        let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant5(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
+        // Statement = UpdateCommand => ActionFn(6);
+        let __sym0 = __pop_Variant27(__symbols);
         let __start = __sym0.0;
-        let __end = __sym7.2;
-        let __nt = super::__action20::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
+        let __end = __sym0.2;
+        let __nt = super::__action6::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant26(__nt), __end));
-        (8, 39)
+        (1, 38)
     }
     fn __reduce78<
         'input,
@@ -16593,12 +18053,12 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // UpdateCommand = CreateCommand => ActionFn(21);
-        let __sym0 = __pop_Variant17(__symbols);
+        // StringConstant = STRING_LITERAL => ActionFn(55);
+        let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action21::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant26(__nt), __end));
+        let __nt = super::__action55::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant5(__nt), __end));
         (1, 39)
     }
     fn __reduce79<
@@ -16610,13 +18070,16 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // __Predicate = Predicate => ActionFn(3);
-        let __sym0 = __pop_Variant23(__symbols);
+        // Term = Expression, IS, NULL => ActionFn(37);
+        assert!(__symbols.len() >= 3);
+        let __sym2 = __pop_Variant0(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action3::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant23(__nt), __end));
-        (1, 40)
+        let __end = __sym2.2;
+        let __nt = super::__action37::<>(input, __sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant9(__nt), __end));
+        (3, 40)
     }
     fn __reduce80<
         'input,
@@ -16627,13 +18090,16 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // __Query = Query => ActionFn(1);
-        let __sym0 = __pop_Variant24(__symbols);
+        // Term = Expression, EQ, Expression => ActionFn(38);
+        assert!(__symbols.len() >= 3);
+        let __sym2 = __pop_Variant11(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action1::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant24(__nt), __end));
-        (1, 41)
+        let __end = __sym2.2;
+        let __nt = super::__action38::<>(input, __sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant9(__nt), __end));
+        (3, 40)
     }
     fn __reduce81<
         'input,
@@ -16644,15 +18110,183 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // __Statement = Statement => ActionFn(0);
+        // UpdateCommand = INSERT, INTO, IdToken, LPAREN, Comma<IdToken>, RPAREN, VALUES, LPAREN, Comma<Constant>, RPAREN => ActionFn(24);
+        assert!(__symbols.len() >= 10);
+        let __sym9 = __pop_Variant0(__symbols);
+        let __sym8 = __pop_Variant14(__symbols);
+        let __sym7 = __pop_Variant0(__symbols);
+        let __sym6 = __pop_Variant0(__symbols);
+        let __sym5 = __pop_Variant0(__symbols);
+        let __sym4 = __pop_Variant16(__symbols);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym9.2;
+        let __nt = super::__action24::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9);
+        __symbols.push((__start, __Symbol::Variant27(__nt), __end));
+        (10, 41)
+    }
+    fn __reduce82<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // UpdateCommand = DELETE, FROM, IdToken => ActionFn(25);
+        assert!(__symbols.len() >= 3);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym2.2;
+        let __nt = super::__action25::<>(input, __sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant27(__nt), __end));
+        (3, 41)
+    }
+    fn __reduce83<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // UpdateCommand = DELETE, FROM, IdToken, WHERE, Predicate => ActionFn(26);
+        assert!(__symbols.len() >= 5);
+        let __sym4 = __pop_Variant24(__symbols);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym4.2;
+        let __nt = super::__action26::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4);
+        __symbols.push((__start, __Symbol::Variant27(__nt), __end));
+        (5, 41)
+    }
+    fn __reduce84<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // UpdateCommand = MODIFY, IdToken, SET, IdToken, EQ, Expression => ActionFn(27);
+        assert!(__symbols.len() >= 6);
+        let __sym5 = __pop_Variant11(__symbols);
+        let __sym4 = __pop_Variant0(__symbols);
+        let __sym3 = __pop_Variant5(__symbols);
+        let __sym2 = __pop_Variant0(__symbols);
+        let __sym1 = __pop_Variant5(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym5.2;
+        let __nt = super::__action27::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
+        __symbols.push((__start, __Symbol::Variant27(__nt), __end));
+        (6, 41)
+    }
+    fn __reduce85<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // UpdateCommand = MODIFY, IdToken, SET, IdToken, EQ, Expression, WHERE, Predicate => ActionFn(28);
+        assert!(__symbols.len() >= 8);
+        let __sym7 = __pop_Variant24(__symbols);
+        let __sym6 = __pop_Variant0(__symbols);
+        let __sym5 = __pop_Variant11(__symbols);
+        let __sym4 = __pop_Variant0(__symbols);
+        let __sym3 = __pop_Variant5(__symbols);
+        let __sym2 = __pop_Variant0(__symbols);
+        let __sym1 = __pop_Variant5(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym7.2;
+        let __nt = super::__action28::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
+        __symbols.push((__start, __Symbol::Variant27(__nt), __end));
+        (8, 41)
+    }
+    fn __reduce86<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // UpdateCommand = CreateCommand => ActionFn(29);
+        let __sym0 = __pop_Variant18(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action29::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant27(__nt), __end));
+        (1, 41)
+    }
+    fn __reduce87<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // __Predicate = Predicate => ActionFn(3);
+        let __sym0 = __pop_Variant24(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action3::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant24(__nt), __end));
+        (1, 42)
+    }
+    fn __reduce88<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // __Query = Query => ActionFn(1);
         let __sym0 = __pop_Variant25(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action0::<>(input, __sym0);
+        let __nt = super::__action1::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant25(__nt), __end));
-        (1, 42)
+        (1, 43)
     }
-    fn __reduce82<
+    fn __reduce89<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // __Statement = Statement => ActionFn(0);
+        let __sym0 = __pop_Variant26(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym0.2;
+        let __nt = super::__action0::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant26(__nt), __end));
+        (1, 44)
+    }
+    fn __reduce90<
         'input,
     >(
         input: &'input str,
@@ -16667,7 +18301,7 @@ mod __parse__UpdateCommand {
         let __end = __sym0.2;
         let __nt = super::__action4::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant9(__nt), __end));
-        (1, 43)
+        (1, 45)
     }
 }
 #[allow(unused_imports)]
@@ -16680,6 +18314,15 @@ mod __intern_token {
     use super::super::predicate;
     use super::super::expression;
     use crate::record::field::{Spec, Value};
+    use crate::materialization::{
+    aggregation_function::AggregationFn,
+    aggregation_function::AggregationFnControl,
+    avg_function::AvgFn,
+    count_function::CountFn,
+    max_function::MaxFn,
+    min_function::MinFn,
+    sum_function::SumFn,
+};
     #[allow(unused_extern_crates)]
     extern crate lalrpop_util as __lalrpop_util;
     #[allow(unused_imports)]
@@ -16702,21 +18345,27 @@ mod __intern_token {
             ("=", false),
             ("(?:[Aa][Nn][Dd])", false),
             ("(?:[Aa][Ssſ])", false),
+            ("(?:[Aa][Vv][Gg])", false),
             ("(?:[Bb][Yy])", false),
+            ("(?:[Cc][Oo][Uu][Nn][Tt])", false),
             ("(?:[Cc][Rr][Ee][Aa][Tt][Ee])", false),
             ("(?:[Dd][Ee][Ll][Ee][Tt][Ee])", false),
             ("(?:[Ff][Rr][Oo][Mm])", false),
+            ("(?:[Gg][Rr][Oo][Uu][Pp])", false),
             ("(?:[Ii](?:32))", false),
             ("(?:[Ii][Nn][Dd][Ee][Xx])", false),
             ("(?:[Ii][Nn][Ssſ][Ee][Rr][Tt])", false),
             ("(?:[Ii][Nn][Tt][Oo])", false),
             ("(?:[Ii][Ssſ])", false),
+            ("(?:[Mm][Aa][Xx])", false),
+            ("(?:[Mm][Ii][Nn])", false),
             ("(?:[Mm][Oo][Dd][Ii][Ff][Yy])", false),
             ("(?:[Nn][Uu][Ll][Ll])", false),
             ("(?:[Oo][Nn])", false),
             ("(?:[Oo][Rr][Dd][Ee][Rr])", false),
             ("(?:[Ssſ][Ee][Ll][Ee][Cc][Tt])", false),
             ("(?:[Ssſ][Ee][Tt])", false),
+            ("(?:[Ssſ][Uu][Mm])", false),
             ("(?:[Tt][Aa][Bb][Ll][Ee])", false),
             ("(?:[Vv][Aa][Ll][Uu][Ee][Ssſ])", false),
             ("(?:[Vv][Aa][Rr][Cc][Hh][Aa][Rr])", false),
@@ -16829,33 +18478,47 @@ fn __action6<'input>(
 fn __action7<'input>(
     input: &'input str,
     (_, _, _): (usize, &'input str, usize),
-    (_, fs, _): (
-        usize,
-        Option<Vec<(expression::Expression, Option<String>)>>,
-        usize,
-    ),
+    (_, fs, _): (usize, Option<Vec<statement::SelectField>>, usize),
     (_, _, _): (usize, &'input str, usize),
     (_, ts, _): (usize, Vec<String>, usize),
     (_, p, _): (usize, Option<predicate::Predicate>, usize),
+    (_, g, _): (usize, Option<Vec<String>>, usize),
     (_, o, _): (usize, Option<Vec<String>>, usize),
 ) -> statement::QueryData {
     match fs {
         Some(fields) => {
-            let output_fields = fields
-                .iter()
-                .map(|(expr, alias)| match (expr, alias) {
-                    (_, Some(a)) => a.clone(),
-                    (expression::Expression::Field(f), None) => f.clone(),
-                    _ => panic!("expression without alias"),
-                })
-                .collect();
-            let extend_fields = fields
-                .into_iter()
-                .filter_map(|(expr, alias)| alias.map(|a| (expr, a)))
-                .collect();
-            statement::QueryData::new_with_order_and_extend(output_fields, ts, p, o, extend_fields)
+            let mut output_fields = Vec::new();
+            let mut extend_fields = Vec::new();
+            let mut aggregation_functions = Vec::new();
+            for field in fields.into_iter() {
+                match field {
+                    statement::SelectField::Expression(expr, alias) => match alias {
+                        Some(a) => {
+                            output_fields.push(a.clone());
+                            extend_fields.push((expr, a));
+                        }
+                        None => match expr.try_get_field() {
+                            Some(f) => output_fields.push(f.to_string()),
+                            None => panic!("expression without alias"),
+                        },
+                    },
+                    statement::SelectField::Aggregation(af) => {
+                        output_fields.push(af.get_field_name().to_string());
+                        aggregation_functions.push(af);
+                    }
+                }
+            }
+            statement::QueryData::new_full(
+                Some(output_fields),
+                ts,
+                p,
+                g,
+                o,
+                extend_fields,
+                aggregation_functions,
+            )
         }
-        None => statement::QueryData::new_all_with_order(ts, p, o),
+        None => statement::QueryData::new_full(None, ts, p, g, o, Vec::new(), Vec::new()),
     }
 }
 
@@ -16868,7 +18531,7 @@ fn __action7<'input>(
 fn __action8<'input>(
     input: &'input str,
     (_, __0, _): (usize, &'input str, usize),
-) -> Option<Vec<(expression::Expression, Option<String>)>> {
+) -> Option<Vec<statement::SelectField>> {
     None
 }
 
@@ -16880,8 +18543,8 @@ fn __action8<'input>(
 )]
 fn __action9<'input>(
     input: &'input str,
-    (_, fs, _): (usize, Vec<(expression::Expression, Option<String>)>, usize),
-) -> Option<Vec<(expression::Expression, Option<String>)>> {
+    (_, fs, _): (usize, Vec<statement::SelectField>, usize),
+) -> Option<Vec<statement::SelectField>> {
     Some(fs)
 }
 
@@ -16896,8 +18559,8 @@ fn __action10<'input>(
     (_, e, _): (usize, expression::Expression, usize),
     (_, _, _): (usize, &'input str, usize),
     (_, alias, _): (usize, String, usize),
-) -> (expression::Expression, Option<String>) {
-    (e, Some(alias))
+) -> statement::SelectField {
+    statement::SelectField::Expression(e, Some(alias))
 }
 
 #[allow(unused_variables)]
@@ -16908,9 +18571,9 @@ fn __action10<'input>(
 )]
 fn __action11<'input>(
     input: &'input str,
-    (_, f, _): (usize, String, usize),
-) -> (expression::Expression, Option<String>) {
-    (expression::Expression::Field(f.clone()), None)
+    (_, e, _): (usize, expression::Expression, usize),
+) -> statement::SelectField {
+    statement::SelectField::Expression(e, None)
 }
 
 #[allow(unused_variables)]
@@ -16920,6 +18583,99 @@ fn __action11<'input>(
     clippy::just_underscores_and_digits
 )]
 fn __action12<'input>(
+    input: &'input str,
+    (_, a, _): (usize, AggregationFn, usize),
+) -> statement::SelectField {
+    statement::SelectField::Aggregation(a)
+}
+
+#[allow(unused_variables)]
+#[allow(
+    clippy::too_many_arguments,
+    clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits
+)]
+fn __action13<'input>(
+    input: &'input str,
+    (_, _, _): (usize, &'input str, usize),
+    (_, _, _): (usize, &'input str, usize),
+    (_, f, _): (usize, String, usize),
+    (_, _, _): (usize, &'input str, usize),
+) -> AggregationFn {
+    AggregationFn::from(MaxFn::new(&f))
+}
+
+#[allow(unused_variables)]
+#[allow(
+    clippy::too_many_arguments,
+    clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits
+)]
+fn __action14<'input>(
+    input: &'input str,
+    (_, _, _): (usize, &'input str, usize),
+    (_, _, _): (usize, &'input str, usize),
+    (_, f, _): (usize, String, usize),
+    (_, _, _): (usize, &'input str, usize),
+) -> AggregationFn {
+    AggregationFn::from(MinFn::new(&f))
+}
+
+#[allow(unused_variables)]
+#[allow(
+    clippy::too_many_arguments,
+    clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits
+)]
+fn __action15<'input>(
+    input: &'input str,
+    (_, _, _): (usize, &'input str, usize),
+    (_, _, _): (usize, &'input str, usize),
+    (_, f, _): (usize, String, usize),
+    (_, _, _): (usize, &'input str, usize),
+) -> AggregationFn {
+    AggregationFn::from(SumFn::new(&f))
+}
+
+#[allow(unused_variables)]
+#[allow(
+    clippy::too_many_arguments,
+    clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits
+)]
+fn __action16<'input>(
+    input: &'input str,
+    (_, _, _): (usize, &'input str, usize),
+    (_, _, _): (usize, &'input str, usize),
+    (_, f, _): (usize, String, usize),
+    (_, _, _): (usize, &'input str, usize),
+) -> AggregationFn {
+    AggregationFn::from(CountFn::new(&f))
+}
+
+#[allow(unused_variables)]
+#[allow(
+    clippy::too_many_arguments,
+    clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits
+)]
+fn __action17<'input>(
+    input: &'input str,
+    (_, _, _): (usize, &'input str, usize),
+    (_, _, _): (usize, &'input str, usize),
+    (_, f, _): (usize, String, usize),
+    (_, _, _): (usize, &'input str, usize),
+) -> AggregationFn {
+    AggregationFn::from(AvgFn::new(&f))
+}
+
+#[allow(unused_variables)]
+#[allow(
+    clippy::too_many_arguments,
+    clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits
+)]
+fn __action18<'input>(
     input: &'input str,
     (_, _, _): (usize, &'input str, usize),
     (_, p, _): (usize, predicate::Predicate, usize),
@@ -16933,7 +18689,7 @@ fn __action12<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action13<'input>(
+fn __action19<'input>(
     input: &'input str,
     __lookbehind: &usize,
     __lookahead: &usize,
@@ -16947,7 +18703,7 @@ fn __action13<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action14<'input>(
+fn __action20<'input>(
     input: &'input str,
     (_, _, _): (usize, &'input str, usize),
     (_, _, _): (usize, &'input str, usize),
@@ -16962,7 +18718,7 @@ fn __action14<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action15<'input>(
+fn __action21<'input>(
     input: &'input str,
     __lookbehind: &usize,
     __lookahead: &usize,
@@ -16976,7 +18732,36 @@ fn __action15<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action16<'input>(
+fn __action22<'input>(
+    input: &'input str,
+    (_, _, _): (usize, &'input str, usize),
+    (_, _, _): (usize, &'input str, usize),
+    (_, os, _): (usize, Vec<String>, usize),
+) -> Option<Vec<String>> {
+    Some(os)
+}
+
+#[allow(unused_variables)]
+#[allow(
+    clippy::too_many_arguments,
+    clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits
+)]
+fn __action23<'input>(
+    input: &'input str,
+    __lookbehind: &usize,
+    __lookahead: &usize,
+) -> Option<Vec<String>> {
+    None
+}
+
+#[allow(unused_variables)]
+#[allow(
+    clippy::too_many_arguments,
+    clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits
+)]
+fn __action24<'input>(
     input: &'input str,
     (_, _, _): (usize, &'input str, usize),
     (_, _, _): (usize, &'input str, usize),
@@ -16998,7 +18783,7 @@ fn __action16<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action17<'input>(
+fn __action25<'input>(
     input: &'input str,
     (_, _, _): (usize, &'input str, usize),
     (_, _, _): (usize, &'input str, usize),
@@ -17013,7 +18798,7 @@ fn __action17<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action18<'input>(
+fn __action26<'input>(
     input: &'input str,
     (_, _, _): (usize, &'input str, usize),
     (_, _, _): (usize, &'input str, usize),
@@ -17030,7 +18815,7 @@ fn __action18<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action19<'input>(
+fn __action27<'input>(
     input: &'input str,
     (_, _, _): (usize, &'input str, usize),
     (_, t, _): (usize, String, usize),
@@ -17048,7 +18833,7 @@ fn __action19<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action20<'input>(
+fn __action28<'input>(
     input: &'input str,
     (_, _, _): (usize, &'input str, usize),
     (_, t, _): (usize, String, usize),
@@ -17068,7 +18853,7 @@ fn __action20<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action21<'input>(
+fn __action29<'input>(
     input: &'input str,
     (_, c, _): (usize, statement::CreateCommand, usize),
 ) -> statement::UpdateCommand {
@@ -17081,7 +18866,7 @@ fn __action21<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action22<'input>(
+fn __action30<'input>(
     input: &'input str,
     (_, _, _): (usize, &'input str, usize),
     (_, _, _): (usize, &'input str, usize),
@@ -17099,7 +18884,7 @@ fn __action22<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action23<'input>(
+fn __action31<'input>(
     input: &'input str,
     (_, _, _): (usize, &'input str, usize),
     (_, _, _): (usize, &'input str, usize),
@@ -17116,7 +18901,7 @@ fn __action23<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action24<'input>(
+fn __action32<'input>(
     input: &'input str,
     (_, _, _): (usize, &'input str, usize),
     (_, _, _): (usize, &'input str, usize),
@@ -17136,7 +18921,7 @@ fn __action24<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action25<'input>(
+fn __action33<'input>(
     input: &'input str,
     (_, n, _): (usize, String, usize),
     (_, t, _): (usize, Spec, usize),
@@ -17150,7 +18935,7 @@ fn __action25<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action26<'input>(input: &'input str, (_, __0, _): (usize, &'input str, usize)) -> Spec {
+fn __action34<'input>(input: &'input str, (_, __0, _): (usize, &'input str, usize)) -> Spec {
     Spec::I32
 }
 
@@ -17160,7 +18945,7 @@ fn __action26<'input>(input: &'input str, (_, __0, _): (usize, &'input str, usiz
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action27<'input>(
+fn __action35<'input>(
     input: &'input str,
     (_, _, _): (usize, &'input str, usize),
     (_, _, _): (usize, &'input str, usize),
@@ -17176,7 +18961,7 @@ fn __action27<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action28<'input>(
+fn __action36<'input>(
     input: &'input str,
     (_, ts, _): (usize, Vec<predicate::Term>, usize),
 ) -> predicate::Predicate {
@@ -17189,7 +18974,7 @@ fn __action28<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action29<'input>(
+fn __action37<'input>(
     input: &'input str,
     (_, e, _): (usize, expression::Expression, usize),
     (_, _, _): (usize, &'input str, usize),
@@ -17204,7 +18989,7 @@ fn __action29<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action30<'input>(
+fn __action38<'input>(
     input: &'input str,
     (_, l, _): (usize, expression::Expression, usize),
     (_, _, _): (usize, &'input str, usize),
@@ -17219,7 +19004,7 @@ fn __action30<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action31<'input>(
+fn __action39<'input>(
     input: &'input str,
     (_, e, _): (usize, expression::Expression, usize),
 ) -> expression::Expression {
@@ -17232,7 +19017,7 @@ fn __action31<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action32<'input>(
+fn __action40<'input>(
     input: &'input str,
     (_, l, _): (usize, expression::Expression, usize),
     (_, _, _): (usize, &'input str, usize),
@@ -17247,7 +19032,7 @@ fn __action32<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action33<'input>(
+fn __action41<'input>(
     input: &'input str,
     (_, l, _): (usize, expression::Expression, usize),
     (_, _, _): (usize, &'input str, usize),
@@ -17262,7 +19047,7 @@ fn __action33<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action34<'input>(
+fn __action42<'input>(
     input: &'input str,
     (_, e, _): (usize, expression::Expression, usize),
 ) -> expression::Expression {
@@ -17275,7 +19060,7 @@ fn __action34<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action35<'input>(
+fn __action43<'input>(
     input: &'input str,
     (_, l, _): (usize, expression::Expression, usize),
     (_, _, _): (usize, &'input str, usize),
@@ -17290,7 +19075,7 @@ fn __action35<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action36<'input>(
+fn __action44<'input>(
     input: &'input str,
     (_, l, _): (usize, expression::Expression, usize),
     (_, _, _): (usize, &'input str, usize),
@@ -17305,7 +19090,7 @@ fn __action36<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action37<'input>(
+fn __action45<'input>(
     input: &'input str,
     (_, e, _): (usize, expression::Expression, usize),
 ) -> expression::Expression {
@@ -17318,7 +19103,7 @@ fn __action37<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action38<'input>(
+fn __action46<'input>(
     input: &'input str,
     (_, _, _): (usize, &'input str, usize),
     (_, e, _): (usize, expression::Expression, usize),
@@ -17333,7 +19118,7 @@ fn __action38<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action39<'input>(
+fn __action47<'input>(
     input: &'input str,
     (_, __0, _): (usize, &'input str, usize),
 ) -> expression::Expression {
@@ -17346,7 +19131,7 @@ fn __action39<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action40<'input>(
+fn __action48<'input>(
     input: &'input str,
     (_, i, _): (usize, i32, usize),
 ) -> expression::Expression {
@@ -17359,7 +19144,7 @@ fn __action40<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action41<'input>(
+fn __action49<'input>(
     input: &'input str,
     (_, s, _): (usize, String, usize),
 ) -> expression::Expression {
@@ -17372,7 +19157,7 @@ fn __action41<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action42<'input>(
+fn __action50<'input>(
     input: &'input str,
     (_, t, _): (usize, String, usize),
 ) -> expression::Expression {
@@ -17385,7 +19170,7 @@ fn __action42<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action43<'input>(input: &'input str, (_, __0, _): (usize, &'input str, usize)) -> Value {
+fn __action51<'input>(input: &'input str, (_, __0, _): (usize, &'input str, usize)) -> Value {
     Value::Null
 }
 
@@ -17395,7 +19180,7 @@ fn __action43<'input>(input: &'input str, (_, __0, _): (usize, &'input str, usiz
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action44<'input>(input: &'input str, (_, i, _): (usize, i32, usize)) -> Value {
+fn __action52<'input>(input: &'input str, (_, i, _): (usize, i32, usize)) -> Value {
     Value::I32(i)
 }
 
@@ -17405,7 +19190,7 @@ fn __action44<'input>(input: &'input str, (_, i, _): (usize, i32, usize)) -> Val
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action45<'input>(input: &'input str, (_, s, _): (usize, String, usize)) -> Value {
+fn __action53<'input>(input: &'input str, (_, s, _): (usize, String, usize)) -> Value {
     Value::String(s)
 }
 
@@ -17415,7 +19200,7 @@ fn __action45<'input>(input: &'input str, (_, s, _): (usize, String, usize)) -> 
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action46<'input>(input: &'input str, (_, __0, _): (usize, &'input str, usize)) -> i32 {
+fn __action54<'input>(input: &'input str, (_, __0, _): (usize, &'input str, usize)) -> i32 {
     i32::from_str(__0).unwrap()
 }
 
@@ -17425,7 +19210,7 @@ fn __action46<'input>(input: &'input str, (_, __0, _): (usize, &'input str, usiz
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action47<'input>(input: &'input str, (_, __0, _): (usize, &'input str, usize)) -> String {
+fn __action55<'input>(input: &'input str, (_, __0, _): (usize, &'input str, usize)) -> String {
     String::from(&__0[1..__0.len() - 1].to_string())
 }
 
@@ -17435,7 +19220,7 @@ fn __action47<'input>(input: &'input str, (_, __0, _): (usize, &'input str, usiz
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action48<'input>(input: &'input str, (_, __0, _): (usize, &'input str, usize)) -> String {
+fn __action56<'input>(input: &'input str, (_, __0, _): (usize, &'input str, usize)) -> String {
     String::from(__0)
 }
 
@@ -17445,7 +19230,7 @@ fn __action48<'input>(input: &'input str, (_, __0, _): (usize, &'input str, usiz
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action49<'input>(
+fn __action57<'input>(
     input: &'input str,
     (_, mut v, _): (usize, alloc::vec::Vec<predicate::Term>, usize),
     (_, e, _): (usize, predicate::Term, usize),
@@ -17462,7 +19247,7 @@ fn __action49<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action50<'input>(
+fn __action58<'input>(
     input: &'input str,
     (_, mut v, _): (usize, alloc::vec::Vec<statement::FieldDefinition>, usize),
     (_, e, _): (usize, statement::FieldDefinition, usize),
@@ -17479,7 +19264,7 @@ fn __action50<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action51<'input>(
+fn __action59<'input>(
     input: &'input str,
     (_, mut v, _): (usize, alloc::vec::Vec<Value>, usize),
     (_, e, _): (usize, Value, usize),
@@ -17496,15 +19281,11 @@ fn __action51<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action52<'input>(
+fn __action60<'input>(
     input: &'input str,
-    (_, mut v, _): (
-        usize,
-        alloc::vec::Vec<(expression::Expression, Option<String>)>,
-        usize,
-    ),
-    (_, e, _): (usize, (expression::Expression, Option<String>), usize),
-) -> Vec<(expression::Expression, Option<String>)> {
+    (_, mut v, _): (usize, alloc::vec::Vec<statement::SelectField>, usize),
+    (_, e, _): (usize, statement::SelectField, usize),
+) -> Vec<statement::SelectField> {
     {
         v.push(e);
         v
@@ -17517,7 +19298,7 @@ fn __action52<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action53<'input>(
+fn __action61<'input>(
     input: &'input str,
     (_, mut v, _): (usize, alloc::vec::Vec<String>, usize),
     (_, e, _): (usize, String, usize),
@@ -17534,7 +19315,7 @@ fn __action53<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action54<'input>(
+fn __action62<'input>(
     input: &'input str,
     __lookbehind: &usize,
     __lookahead: &usize,
@@ -17548,7 +19329,7 @@ fn __action54<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action55<'input>(
+fn __action63<'input>(
     input: &'input str,
     (_, v, _): (usize, alloc::vec::Vec<String>, usize),
 ) -> alloc::vec::Vec<String> {
@@ -17561,7 +19342,7 @@ fn __action55<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action56<'input>(
+fn __action64<'input>(
     input: &'input str,
     (_, __0, _): (usize, String, usize),
     (_, _, _): (usize, &'input str, usize),
@@ -17575,11 +19356,11 @@ fn __action56<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action57<'input>(
+fn __action65<'input>(
     input: &'input str,
     __lookbehind: &usize,
     __lookahead: &usize,
-) -> alloc::vec::Vec<(expression::Expression, Option<String>)> {
+) -> alloc::vec::Vec<statement::SelectField> {
     alloc::vec![]
 }
 
@@ -17589,14 +19370,10 @@ fn __action57<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action58<'input>(
+fn __action66<'input>(
     input: &'input str,
-    (_, v, _): (
-        usize,
-        alloc::vec::Vec<(expression::Expression, Option<String>)>,
-        usize,
-    ),
-) -> alloc::vec::Vec<(expression::Expression, Option<String>)> {
+    (_, v, _): (usize, alloc::vec::Vec<statement::SelectField>, usize),
+) -> alloc::vec::Vec<statement::SelectField> {
     v
 }
 
@@ -17606,11 +19383,11 @@ fn __action58<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action59<'input>(
+fn __action67<'input>(
     input: &'input str,
-    (_, __0, _): (usize, (expression::Expression, Option<String>), usize),
+    (_, __0, _): (usize, statement::SelectField, usize),
     (_, _, _): (usize, &'input str, usize),
-) -> (expression::Expression, Option<String>) {
+) -> statement::SelectField {
     __0
 }
 
@@ -17620,7 +19397,7 @@ fn __action59<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action60<'input>(
+fn __action68<'input>(
     input: &'input str,
     __lookbehind: &usize,
     __lookahead: &usize,
@@ -17634,7 +19411,7 @@ fn __action60<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action61<'input>(
+fn __action69<'input>(
     input: &'input str,
     (_, v, _): (usize, alloc::vec::Vec<Value>, usize),
 ) -> alloc::vec::Vec<Value> {
@@ -17647,7 +19424,7 @@ fn __action61<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action62<'input>(
+fn __action70<'input>(
     input: &'input str,
     (_, __0, _): (usize, Value, usize),
     (_, _, _): (usize, &'input str, usize),
@@ -17661,7 +19438,7 @@ fn __action62<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action63<'input>(
+fn __action71<'input>(
     input: &'input str,
     __lookbehind: &usize,
     __lookahead: &usize,
@@ -17675,7 +19452,7 @@ fn __action63<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action64<'input>(
+fn __action72<'input>(
     input: &'input str,
     (_, v, _): (usize, alloc::vec::Vec<statement::FieldDefinition>, usize),
 ) -> alloc::vec::Vec<statement::FieldDefinition> {
@@ -17688,7 +19465,7 @@ fn __action64<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action65<'input>(
+fn __action73<'input>(
     input: &'input str,
     (_, __0, _): (usize, statement::FieldDefinition, usize),
     (_, _, _): (usize, &'input str, usize),
@@ -17702,7 +19479,7 @@ fn __action65<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action66<'input>(
+fn __action74<'input>(
     input: &'input str,
     __lookbehind: &usize,
     __lookahead: &usize,
@@ -17716,7 +19493,7 @@ fn __action66<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action67<'input>(
+fn __action75<'input>(
     input: &'input str,
     (_, v, _): (usize, alloc::vec::Vec<predicate::Term>, usize),
 ) -> alloc::vec::Vec<predicate::Term> {
@@ -17729,7 +19506,7 @@ fn __action67<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action68<'input>(
+fn __action76<'input>(
     input: &'input str,
     (_, __0, _): (usize, predicate::Term, usize),
     (_, _, _): (usize, &'input str, usize),
@@ -17743,7 +19520,7 @@ fn __action68<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action69<'input>(
+fn __action77<'input>(
     input: &'input str,
     (_, __0, _): (usize, predicate::Term, usize),
 ) -> alloc::vec::Vec<predicate::Term> {
@@ -17756,7 +19533,7 @@ fn __action69<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action70<'input>(
+fn __action78<'input>(
     input: &'input str,
     (_, v, _): (usize, alloc::vec::Vec<predicate::Term>, usize),
     (_, e, _): (usize, predicate::Term, usize),
@@ -17774,7 +19551,7 @@ fn __action70<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action71<'input>(
+fn __action79<'input>(
     input: &'input str,
     (_, __0, _): (usize, statement::FieldDefinition, usize),
 ) -> alloc::vec::Vec<statement::FieldDefinition> {
@@ -17787,7 +19564,7 @@ fn __action71<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action72<'input>(
+fn __action80<'input>(
     input: &'input str,
     (_, v, _): (usize, alloc::vec::Vec<statement::FieldDefinition>, usize),
     (_, e, _): (usize, statement::FieldDefinition, usize),
@@ -17805,7 +19582,7 @@ fn __action72<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action73<'input>(
+fn __action81<'input>(
     input: &'input str,
     (_, __0, _): (usize, Value, usize),
 ) -> alloc::vec::Vec<Value> {
@@ -17818,7 +19595,7 @@ fn __action73<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action74<'input>(
+fn __action82<'input>(
     input: &'input str,
     (_, v, _): (usize, alloc::vec::Vec<Value>, usize),
     (_, e, _): (usize, Value, usize),
@@ -17836,10 +19613,10 @@ fn __action74<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action75<'input>(
+fn __action83<'input>(
     input: &'input str,
-    (_, __0, _): (usize, (expression::Expression, Option<String>), usize),
-) -> alloc::vec::Vec<(expression::Expression, Option<String>)> {
+    (_, __0, _): (usize, statement::SelectField, usize),
+) -> alloc::vec::Vec<statement::SelectField> {
     alloc::vec![__0]
 }
 
@@ -17849,15 +19626,11 @@ fn __action75<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action76<'input>(
+fn __action84<'input>(
     input: &'input str,
-    (_, v, _): (
-        usize,
-        alloc::vec::Vec<(expression::Expression, Option<String>)>,
-        usize,
-    ),
-    (_, e, _): (usize, (expression::Expression, Option<String>), usize),
-) -> alloc::vec::Vec<(expression::Expression, Option<String>)> {
+    (_, v, _): (usize, alloc::vec::Vec<statement::SelectField>, usize),
+    (_, e, _): (usize, statement::SelectField, usize),
+) -> alloc::vec::Vec<statement::SelectField> {
     {
         let mut v = v;
         v.push(e);
@@ -17871,7 +19644,7 @@ fn __action76<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action77<'input>(
+fn __action85<'input>(
     input: &'input str,
     (_, __0, _): (usize, String, usize),
 ) -> alloc::vec::Vec<String> {
@@ -17884,7 +19657,7 @@ fn __action77<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action78<'input>(
+fn __action86<'input>(
     input: &'input str,
     (_, v, _): (usize, alloc::vec::Vec<String>, usize),
     (_, e, _): (usize, String, usize),
@@ -17902,157 +19675,16 @@ fn __action78<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action79<'input>(
+fn __action87<'input>(
     input: &'input str,
     __0: (usize, Value, usize),
     __1: (usize, &'input str, usize),
 ) -> alloc::vec::Vec<Value> {
     let __start0 = __0.0;
     let __end0 = __1.2;
-    let __temp0 = __action62(input, __0, __1);
+    let __temp0 = __action70(input, __0, __1);
     let __temp0 = (__start0, __temp0, __end0);
-    __action73(input, __temp0)
-}
-
-#[allow(unused_variables)]
-#[allow(
-    clippy::too_many_arguments,
-    clippy::needless_lifetimes,
-    clippy::just_underscores_and_digits
-)]
-fn __action80<'input>(
-    input: &'input str,
-    __0: (usize, alloc::vec::Vec<Value>, usize),
-    __1: (usize, Value, usize),
-    __2: (usize, &'input str, usize),
-) -> alloc::vec::Vec<Value> {
-    let __start0 = __1.0;
-    let __end0 = __2.2;
-    let __temp0 = __action62(input, __1, __2);
-    let __temp0 = (__start0, __temp0, __end0);
-    __action74(input, __0, __temp0)
-}
-
-#[allow(unused_variables)]
-#[allow(
-    clippy::too_many_arguments,
-    clippy::needless_lifetimes,
-    clippy::just_underscores_and_digits
-)]
-fn __action81<'input>(input: &'input str, __0: (usize, Value, usize)) -> Vec<Value> {
-    let __start0 = __0.0;
-    let __end0 = __0.0;
-    let __temp0 = __action60(input, &__start0, &__end0);
-    let __temp0 = (__start0, __temp0, __end0);
-    __action51(input, __temp0, __0)
-}
-
-#[allow(unused_variables)]
-#[allow(
-    clippy::too_many_arguments,
-    clippy::needless_lifetimes,
-    clippy::just_underscores_and_digits
-)]
-fn __action82<'input>(
-    input: &'input str,
-    __0: (usize, alloc::vec::Vec<Value>, usize),
-    __1: (usize, Value, usize),
-) -> Vec<Value> {
-    let __start0 = __0.0;
-    let __end0 = __0.2;
-    let __temp0 = __action61(input, __0);
-    let __temp0 = (__start0, __temp0, __end0);
-    __action51(input, __temp0, __1)
-}
-
-#[allow(unused_variables)]
-#[allow(
-    clippy::too_many_arguments,
-    clippy::needless_lifetimes,
-    clippy::just_underscores_and_digits
-)]
-fn __action83<'input>(
-    input: &'input str,
-    __0: (usize, statement::FieldDefinition, usize),
-    __1: (usize, &'input str, usize),
-) -> alloc::vec::Vec<statement::FieldDefinition> {
-    let __start0 = __0.0;
-    let __end0 = __1.2;
-    let __temp0 = __action65(input, __0, __1);
-    let __temp0 = (__start0, __temp0, __end0);
-    __action71(input, __temp0)
-}
-
-#[allow(unused_variables)]
-#[allow(
-    clippy::too_many_arguments,
-    clippy::needless_lifetimes,
-    clippy::just_underscores_and_digits
-)]
-fn __action84<'input>(
-    input: &'input str,
-    __0: (usize, alloc::vec::Vec<statement::FieldDefinition>, usize),
-    __1: (usize, statement::FieldDefinition, usize),
-    __2: (usize, &'input str, usize),
-) -> alloc::vec::Vec<statement::FieldDefinition> {
-    let __start0 = __1.0;
-    let __end0 = __2.2;
-    let __temp0 = __action65(input, __1, __2);
-    let __temp0 = (__start0, __temp0, __end0);
-    __action72(input, __0, __temp0)
-}
-
-#[allow(unused_variables)]
-#[allow(
-    clippy::too_many_arguments,
-    clippy::needless_lifetimes,
-    clippy::just_underscores_and_digits
-)]
-fn __action85<'input>(
-    input: &'input str,
-    __0: (usize, statement::FieldDefinition, usize),
-) -> Vec<statement::FieldDefinition> {
-    let __start0 = __0.0;
-    let __end0 = __0.0;
-    let __temp0 = __action63(input, &__start0, &__end0);
-    let __temp0 = (__start0, __temp0, __end0);
-    __action50(input, __temp0, __0)
-}
-
-#[allow(unused_variables)]
-#[allow(
-    clippy::too_many_arguments,
-    clippy::needless_lifetimes,
-    clippy::just_underscores_and_digits
-)]
-fn __action86<'input>(
-    input: &'input str,
-    __0: (usize, alloc::vec::Vec<statement::FieldDefinition>, usize),
-    __1: (usize, statement::FieldDefinition, usize),
-) -> Vec<statement::FieldDefinition> {
-    let __start0 = __0.0;
-    let __end0 = __0.2;
-    let __temp0 = __action64(input, __0);
-    let __temp0 = (__start0, __temp0, __end0);
-    __action50(input, __temp0, __1)
-}
-
-#[allow(unused_variables)]
-#[allow(
-    clippy::too_many_arguments,
-    clippy::needless_lifetimes,
-    clippy::just_underscores_and_digits
-)]
-fn __action87<'input>(
-    input: &'input str,
-    __0: (usize, String, usize),
-    __1: (usize, &'input str, usize),
-) -> alloc::vec::Vec<String> {
-    let __start0 = __0.0;
-    let __end0 = __1.2;
-    let __temp0 = __action56(input, __0, __1);
-    let __temp0 = (__start0, __temp0, __end0);
-    __action77(input, __temp0)
+    __action81(input, __temp0)
 }
 
 #[allow(unused_variables)]
@@ -18063,15 +19695,15 @@ fn __action87<'input>(
 )]
 fn __action88<'input>(
     input: &'input str,
-    __0: (usize, alloc::vec::Vec<String>, usize),
-    __1: (usize, String, usize),
+    __0: (usize, alloc::vec::Vec<Value>, usize),
+    __1: (usize, Value, usize),
     __2: (usize, &'input str, usize),
-) -> alloc::vec::Vec<String> {
+) -> alloc::vec::Vec<Value> {
     let __start0 = __1.0;
     let __end0 = __2.2;
-    let __temp0 = __action56(input, __1, __2);
+    let __temp0 = __action70(input, __1, __2);
     let __temp0 = (__start0, __temp0, __end0);
-    __action78(input, __0, __temp0)
+    __action82(input, __0, __temp0)
 }
 
 #[allow(unused_variables)]
@@ -18080,12 +19712,12 @@ fn __action88<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action89<'input>(input: &'input str, __0: (usize, String, usize)) -> Vec<String> {
+fn __action89<'input>(input: &'input str, __0: (usize, Value, usize)) -> Vec<Value> {
     let __start0 = __0.0;
     let __end0 = __0.0;
-    let __temp0 = __action54(input, &__start0, &__end0);
+    let __temp0 = __action68(input, &__start0, &__end0);
     let __temp0 = (__start0, __temp0, __end0);
-    __action53(input, __temp0, __0)
+    __action59(input, __temp0, __0)
 }
 
 #[allow(unused_variables)]
@@ -18096,14 +19728,14 @@ fn __action89<'input>(input: &'input str, __0: (usize, String, usize)) -> Vec<St
 )]
 fn __action90<'input>(
     input: &'input str,
-    __0: (usize, alloc::vec::Vec<String>, usize),
-    __1: (usize, String, usize),
-) -> Vec<String> {
+    __0: (usize, alloc::vec::Vec<Value>, usize),
+    __1: (usize, Value, usize),
+) -> Vec<Value> {
     let __start0 = __0.0;
     let __end0 = __0.2;
-    let __temp0 = __action55(input, __0);
+    let __temp0 = __action69(input, __0);
     let __temp0 = (__start0, __temp0, __end0);
-    __action53(input, __temp0, __1)
+    __action59(input, __temp0, __1)
 }
 
 #[allow(unused_variables)]
@@ -18114,14 +19746,14 @@ fn __action90<'input>(
 )]
 fn __action91<'input>(
     input: &'input str,
-    __0: (usize, (expression::Expression, Option<String>), usize),
+    __0: (usize, statement::FieldDefinition, usize),
     __1: (usize, &'input str, usize),
-) -> alloc::vec::Vec<(expression::Expression, Option<String>)> {
+) -> alloc::vec::Vec<statement::FieldDefinition> {
     let __start0 = __0.0;
     let __end0 = __1.2;
-    let __temp0 = __action59(input, __0, __1);
+    let __temp0 = __action73(input, __0, __1);
     let __temp0 = (__start0, __temp0, __end0);
-    __action75(input, __temp0)
+    __action79(input, __temp0)
 }
 
 #[allow(unused_variables)]
@@ -18132,19 +19764,15 @@ fn __action91<'input>(
 )]
 fn __action92<'input>(
     input: &'input str,
-    __0: (
-        usize,
-        alloc::vec::Vec<(expression::Expression, Option<String>)>,
-        usize,
-    ),
-    __1: (usize, (expression::Expression, Option<String>), usize),
+    __0: (usize, alloc::vec::Vec<statement::FieldDefinition>, usize),
+    __1: (usize, statement::FieldDefinition, usize),
     __2: (usize, &'input str, usize),
-) -> alloc::vec::Vec<(expression::Expression, Option<String>)> {
+) -> alloc::vec::Vec<statement::FieldDefinition> {
     let __start0 = __1.0;
     let __end0 = __2.2;
-    let __temp0 = __action59(input, __1, __2);
+    let __temp0 = __action73(input, __1, __2);
     let __temp0 = (__start0, __temp0, __end0);
-    __action76(input, __0, __temp0)
+    __action80(input, __0, __temp0)
 }
 
 #[allow(unused_variables)]
@@ -18155,13 +19783,13 @@ fn __action92<'input>(
 )]
 fn __action93<'input>(
     input: &'input str,
-    __0: (usize, (expression::Expression, Option<String>), usize),
-) -> Vec<(expression::Expression, Option<String>)> {
+    __0: (usize, statement::FieldDefinition, usize),
+) -> Vec<statement::FieldDefinition> {
     let __start0 = __0.0;
     let __end0 = __0.0;
-    let __temp0 = __action57(input, &__start0, &__end0);
+    let __temp0 = __action71(input, &__start0, &__end0);
     let __temp0 = (__start0, __temp0, __end0);
-    __action52(input, __temp0, __0)
+    __action58(input, __temp0, __0)
 }
 
 #[allow(unused_variables)]
@@ -18172,18 +19800,14 @@ fn __action93<'input>(
 )]
 fn __action94<'input>(
     input: &'input str,
-    __0: (
-        usize,
-        alloc::vec::Vec<(expression::Expression, Option<String>)>,
-        usize,
-    ),
-    __1: (usize, (expression::Expression, Option<String>), usize),
-) -> Vec<(expression::Expression, Option<String>)> {
+    __0: (usize, alloc::vec::Vec<statement::FieldDefinition>, usize),
+    __1: (usize, statement::FieldDefinition, usize),
+) -> Vec<statement::FieldDefinition> {
     let __start0 = __0.0;
     let __end0 = __0.2;
-    let __temp0 = __action58(input, __0);
+    let __temp0 = __action72(input, __0);
     let __temp0 = (__start0, __temp0, __end0);
-    __action52(input, __temp0, __1)
+    __action58(input, __temp0, __1)
 }
 
 #[allow(unused_variables)]
@@ -18194,14 +19818,14 @@ fn __action94<'input>(
 )]
 fn __action95<'input>(
     input: &'input str,
-    __0: (usize, predicate::Term, usize),
+    __0: (usize, String, usize),
     __1: (usize, &'input str, usize),
-) -> alloc::vec::Vec<predicate::Term> {
+) -> alloc::vec::Vec<String> {
     let __start0 = __0.0;
     let __end0 = __1.2;
-    let __temp0 = __action68(input, __0, __1);
+    let __temp0 = __action64(input, __0, __1);
     let __temp0 = (__start0, __temp0, __end0);
-    __action69(input, __temp0)
+    __action85(input, __temp0)
 }
 
 #[allow(unused_variables)]
@@ -18212,15 +19836,15 @@ fn __action95<'input>(
 )]
 fn __action96<'input>(
     input: &'input str,
-    __0: (usize, alloc::vec::Vec<predicate::Term>, usize),
-    __1: (usize, predicate::Term, usize),
+    __0: (usize, alloc::vec::Vec<String>, usize),
+    __1: (usize, String, usize),
     __2: (usize, &'input str, usize),
-) -> alloc::vec::Vec<predicate::Term> {
+) -> alloc::vec::Vec<String> {
     let __start0 = __1.0;
     let __end0 = __2.2;
-    let __temp0 = __action68(input, __1, __2);
+    let __temp0 = __action64(input, __1, __2);
     let __temp0 = (__start0, __temp0, __end0);
-    __action70(input, __0, __temp0)
+    __action86(input, __0, __temp0)
 }
 
 #[allow(unused_variables)]
@@ -18229,15 +19853,12 @@ fn __action96<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action97<'input>(
-    input: &'input str,
-    __0: (usize, predicate::Term, usize),
-) -> Vec<predicate::Term> {
+fn __action97<'input>(input: &'input str, __0: (usize, String, usize)) -> Vec<String> {
     let __start0 = __0.0;
     let __end0 = __0.0;
-    let __temp0 = __action66(input, &__start0, &__end0);
+    let __temp0 = __action62(input, &__start0, &__end0);
     let __temp0 = (__start0, __temp0, __end0);
-    __action49(input, __temp0, __0)
+    __action61(input, __temp0, __0)
 }
 
 #[allow(unused_variables)]
@@ -18248,14 +19869,158 @@ fn __action97<'input>(
 )]
 fn __action98<'input>(
     input: &'input str,
+    __0: (usize, alloc::vec::Vec<String>, usize),
+    __1: (usize, String, usize),
+) -> Vec<String> {
+    let __start0 = __0.0;
+    let __end0 = __0.2;
+    let __temp0 = __action63(input, __0);
+    let __temp0 = (__start0, __temp0, __end0);
+    __action61(input, __temp0, __1)
+}
+
+#[allow(unused_variables)]
+#[allow(
+    clippy::too_many_arguments,
+    clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits
+)]
+fn __action99<'input>(
+    input: &'input str,
+    __0: (usize, statement::SelectField, usize),
+    __1: (usize, &'input str, usize),
+) -> alloc::vec::Vec<statement::SelectField> {
+    let __start0 = __0.0;
+    let __end0 = __1.2;
+    let __temp0 = __action67(input, __0, __1);
+    let __temp0 = (__start0, __temp0, __end0);
+    __action83(input, __temp0)
+}
+
+#[allow(unused_variables)]
+#[allow(
+    clippy::too_many_arguments,
+    clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits
+)]
+fn __action100<'input>(
+    input: &'input str,
+    __0: (usize, alloc::vec::Vec<statement::SelectField>, usize),
+    __1: (usize, statement::SelectField, usize),
+    __2: (usize, &'input str, usize),
+) -> alloc::vec::Vec<statement::SelectField> {
+    let __start0 = __1.0;
+    let __end0 = __2.2;
+    let __temp0 = __action67(input, __1, __2);
+    let __temp0 = (__start0, __temp0, __end0);
+    __action84(input, __0, __temp0)
+}
+
+#[allow(unused_variables)]
+#[allow(
+    clippy::too_many_arguments,
+    clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits
+)]
+fn __action101<'input>(
+    input: &'input str,
+    __0: (usize, statement::SelectField, usize),
+) -> Vec<statement::SelectField> {
+    let __start0 = __0.0;
+    let __end0 = __0.0;
+    let __temp0 = __action65(input, &__start0, &__end0);
+    let __temp0 = (__start0, __temp0, __end0);
+    __action60(input, __temp0, __0)
+}
+
+#[allow(unused_variables)]
+#[allow(
+    clippy::too_many_arguments,
+    clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits
+)]
+fn __action102<'input>(
+    input: &'input str,
+    __0: (usize, alloc::vec::Vec<statement::SelectField>, usize),
+    __1: (usize, statement::SelectField, usize),
+) -> Vec<statement::SelectField> {
+    let __start0 = __0.0;
+    let __end0 = __0.2;
+    let __temp0 = __action66(input, __0);
+    let __temp0 = (__start0, __temp0, __end0);
+    __action60(input, __temp0, __1)
+}
+
+#[allow(unused_variables)]
+#[allow(
+    clippy::too_many_arguments,
+    clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits
+)]
+fn __action103<'input>(
+    input: &'input str,
+    __0: (usize, predicate::Term, usize),
+    __1: (usize, &'input str, usize),
+) -> alloc::vec::Vec<predicate::Term> {
+    let __start0 = __0.0;
+    let __end0 = __1.2;
+    let __temp0 = __action76(input, __0, __1);
+    let __temp0 = (__start0, __temp0, __end0);
+    __action77(input, __temp0)
+}
+
+#[allow(unused_variables)]
+#[allow(
+    clippy::too_many_arguments,
+    clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits
+)]
+fn __action104<'input>(
+    input: &'input str,
+    __0: (usize, alloc::vec::Vec<predicate::Term>, usize),
+    __1: (usize, predicate::Term, usize),
+    __2: (usize, &'input str, usize),
+) -> alloc::vec::Vec<predicate::Term> {
+    let __start0 = __1.0;
+    let __end0 = __2.2;
+    let __temp0 = __action76(input, __1, __2);
+    let __temp0 = (__start0, __temp0, __end0);
+    __action78(input, __0, __temp0)
+}
+
+#[allow(unused_variables)]
+#[allow(
+    clippy::too_many_arguments,
+    clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits
+)]
+fn __action105<'input>(
+    input: &'input str,
+    __0: (usize, predicate::Term, usize),
+) -> Vec<predicate::Term> {
+    let __start0 = __0.0;
+    let __end0 = __0.0;
+    let __temp0 = __action74(input, &__start0, &__end0);
+    let __temp0 = (__start0, __temp0, __end0);
+    __action57(input, __temp0, __0)
+}
+
+#[allow(unused_variables)]
+#[allow(
+    clippy::too_many_arguments,
+    clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits
+)]
+fn __action106<'input>(
+    input: &'input str,
     __0: (usize, alloc::vec::Vec<predicate::Term>, usize),
     __1: (usize, predicate::Term, usize),
 ) -> Vec<predicate::Term> {
     let __start0 = __0.0;
     let __end0 = __0.2;
-    let __temp0 = __action67(input, __0);
+    let __temp0 = __action75(input, __0);
     let __temp0 = (__start0, __temp0, __end0);
-    __action49(input, __temp0, __1)
+    __action57(input, __temp0, __1)
 }
 
 #[allow(clippy::type_complexity, dead_code)]

--- a/src/parser/grammar.rs
+++ b/src/parser/grammar.rs
@@ -1,5 +1,5 @@
 // auto-generated: "lalrpop 0.22.0"
-// sha3: 0da152653bc476df143bab3d1a852ee1c16078df0606b2c318c99488ed8c7a5b
+// sha3: a1f95ca00eb9c07b7f582ed1db9e9677965a01724a15649f0c3d35ca728c20f4
 use super::expression;
 use super::predicate;
 use super::statement;
@@ -118,7 +118,7 @@ mod __parse__Predicate {
         // State 20
         0, 0, 0, 0, -52, 0, -52, -52, -52, 0, -52, -52, -52, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -52, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 21
-        0, 0, 0, 0, -79, 0, -79, -79, -79, 0, -79, -79, -79, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -79, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -80, 0, -80, -80, -80, 0, -80, -80, -80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 22
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 27, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 23
@@ -134,9 +134,9 @@ mod __parse__Predicate {
         // State 28
         0, 0, 0, 0, -26, 0, -26, 8, -26, 0, 7, -26, -26, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -26, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 29
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -81, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -82, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 30
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -81, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 31
         0, 0, 0, 0, -64, 0, -64, -64, -64, 0, -64, -64, -64, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -64, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 32
@@ -179,7 +179,7 @@ mod __parse__Predicate {
         // State 14
         -28,
         // State 15
-        -88,
+        -89,
         // State 16
         -54,
         // State 17
@@ -191,7 +191,7 @@ mod __parse__Predicate {
         // State 20
         -52,
         // State 21
-        -79,
+        -80,
         // State 22
         -35,
         // State 23
@@ -207,9 +207,9 @@ mod __parse__Predicate {
         // State 28
         -26,
         // State 29
-        -81,
+        -82,
         // State 30
-        -80,
+        -81,
         // State 31
         -64,
         // State 32
@@ -944,14 +944,14 @@ mod __parse__Predicate {
             }
             75 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
+                    states_to_pop: 3,
                     nonterminal_produced: 37,
                 }
             }
             76 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
-                    nonterminal_produced: 38,
+                    nonterminal_produced: 37,
                 }
             }
             77 => {
@@ -963,13 +963,13 @@ mod __parse__Predicate {
             78 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
-                    nonterminal_produced: 39,
+                    nonterminal_produced: 38,
                 }
             }
             79 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 3,
-                    nonterminal_produced: 40,
+                    states_to_pop: 1,
+                    nonterminal_produced: 39,
                 }
             }
             80 => {
@@ -980,60 +980,66 @@ mod __parse__Predicate {
             }
             81 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 10,
-                    nonterminal_produced: 41,
+                    states_to_pop: 3,
+                    nonterminal_produced: 40,
                 }
             }
             82 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 3,
+                    states_to_pop: 10,
                     nonterminal_produced: 41,
                 }
             }
             83 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 5,
+                    states_to_pop: 3,
                     nonterminal_produced: 41,
                 }
             }
             84 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 6,
+                    states_to_pop: 5,
                     nonterminal_produced: 41,
                 }
             }
             85 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 8,
+                    states_to_pop: 6,
                     nonterminal_produced: 41,
                 }
             }
             86 => {
                 __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 8,
+                    nonterminal_produced: 41,
+                }
+            }
+            87 => {
+                __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
                     nonterminal_produced: 41,
                 }
             }
-            87 => __state_machine::SimulatedReduce::Accept,
-            88 => {
+            88 => __state_machine::SimulatedReduce::Accept,
+            89 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
                     nonterminal_produced: 43,
                 }
             }
-            89 => {
+            90 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
                     nonterminal_produced: 44,
                 }
             }
-            90 => {
+            91 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
                     nonterminal_produced: 45,
                 }
             }
-            91 => {
+            92 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
                     nonterminal_produced: 46,
@@ -1382,15 +1388,15 @@ mod __parse__Predicate {
                 __reduce86(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
             }
             87 => {
+                __reduce87(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
+            }
+            88 => {
                 // __Predicate = Predicate => ActionFn(3);
                 let __sym0 = __pop_Variant24(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym0.2;
                 let __nt = super::__action3::<>(input, __sym0);
                 return Some(Ok(__nt));
-            }
-            88 => {
-                __reduce88(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
             }
             89 => {
                 __reduce89(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
@@ -1400,6 +1406,9 @@ mod __parse__Predicate {
             }
             91 => {
                 __reduce91(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
+            }
+            92 => {
+                __reduce92(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
             }
             _ => panic!("invalid action code {}", __action)
         };
@@ -1731,13 +1740,13 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Constant> COMMA) = Constant, COMMA => ActionFn(70);
+        // (<Constant> COMMA) = Constant, COMMA => ActionFn(71);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant1(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action70::<>(input, __sym0, __sym1);
+        let __nt = super::__action71::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant1(__nt), __end));
         (2, 0)
     }
@@ -1750,10 +1759,10 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Constant> COMMA)* =  => ActionFn(68);
+        // (<Constant> COMMA)* =  => ActionFn(69);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action68::<>(input, &__start, &__end);
+        let __nt = super::__action69::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant2(__nt), __end));
         (0, 1)
     }
@@ -1766,11 +1775,11 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Constant> COMMA)* = (<Constant> COMMA)+ => ActionFn(69);
+        // (<Constant> COMMA)* = (<Constant> COMMA)+ => ActionFn(70);
         let __sym0 = __pop_Variant2(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action69::<>(input, __sym0);
+        let __nt = super::__action70::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant2(__nt), __end));
         (1, 1)
     }
@@ -1783,13 +1792,13 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Constant> COMMA)+ = Constant, COMMA => ActionFn(87);
+        // (<Constant> COMMA)+ = Constant, COMMA => ActionFn(88);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant1(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action87::<>(input, __sym0, __sym1);
+        let __nt = super::__action88::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant2(__nt), __end));
         (2, 2)
     }
@@ -1802,14 +1811,14 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Constant> COMMA)+ = (<Constant> COMMA)+, Constant, COMMA => ActionFn(88);
+        // (<Constant> COMMA)+ = (<Constant> COMMA)+, Constant, COMMA => ActionFn(89);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant1(__symbols);
         let __sym0 = __pop_Variant2(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action88::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action89::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant2(__nt), __end));
         (3, 2)
     }
@@ -1822,13 +1831,13 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<FieldDefinition> COMMA) = FieldDefinition, COMMA => ActionFn(73);
+        // (<FieldDefinition> COMMA) = FieldDefinition, COMMA => ActionFn(74);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant3(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action73::<>(input, __sym0, __sym1);
+        let __nt = super::__action74::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant3(__nt), __end));
         (2, 3)
     }
@@ -1841,10 +1850,10 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<FieldDefinition> COMMA)* =  => ActionFn(71);
+        // (<FieldDefinition> COMMA)* =  => ActionFn(72);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action71::<>(input, &__start, &__end);
+        let __nt = super::__action72::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant4(__nt), __end));
         (0, 4)
     }
@@ -1857,11 +1866,11 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<FieldDefinition> COMMA)* = (<FieldDefinition> COMMA)+ => ActionFn(72);
+        // (<FieldDefinition> COMMA)* = (<FieldDefinition> COMMA)+ => ActionFn(73);
         let __sym0 = __pop_Variant4(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action72::<>(input, __sym0);
+        let __nt = super::__action73::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant4(__nt), __end));
         (1, 4)
     }
@@ -1874,13 +1883,13 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<FieldDefinition> COMMA)+ = FieldDefinition, COMMA => ActionFn(91);
+        // (<FieldDefinition> COMMA)+ = FieldDefinition, COMMA => ActionFn(92);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant3(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action91::<>(input, __sym0, __sym1);
+        let __nt = super::__action92::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant4(__nt), __end));
         (2, 5)
     }
@@ -1893,14 +1902,14 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<FieldDefinition> COMMA)+ = (<FieldDefinition> COMMA)+, FieldDefinition, COMMA => ActionFn(92);
+        // (<FieldDefinition> COMMA)+ = (<FieldDefinition> COMMA)+, FieldDefinition, COMMA => ActionFn(93);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant3(__symbols);
         let __sym0 = __pop_Variant4(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action92::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action93::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant4(__nt), __end));
         (3, 5)
     }
@@ -1913,13 +1922,13 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<IdToken> COMMA) = IdToken, COMMA => ActionFn(64);
+        // (<IdToken> COMMA) = IdToken, COMMA => ActionFn(65);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action64::<>(input, __sym0, __sym1);
+        let __nt = super::__action65::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant5(__nt), __end));
         (2, 6)
     }
@@ -1932,10 +1941,10 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<IdToken> COMMA)* =  => ActionFn(62);
+        // (<IdToken> COMMA)* =  => ActionFn(63);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action62::<>(input, &__start, &__end);
+        let __nt = super::__action63::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant6(__nt), __end));
         (0, 7)
     }
@@ -1948,11 +1957,11 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<IdToken> COMMA)* = (<IdToken> COMMA)+ => ActionFn(63);
+        // (<IdToken> COMMA)* = (<IdToken> COMMA)+ => ActionFn(64);
         let __sym0 = __pop_Variant6(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action63::<>(input, __sym0);
+        let __nt = super::__action64::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant6(__nt), __end));
         (1, 7)
     }
@@ -1965,13 +1974,13 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<IdToken> COMMA)+ = IdToken, COMMA => ActionFn(95);
+        // (<IdToken> COMMA)+ = IdToken, COMMA => ActionFn(96);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action95::<>(input, __sym0, __sym1);
+        let __nt = super::__action96::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant6(__nt), __end));
         (2, 8)
     }
@@ -1984,14 +1993,14 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<IdToken> COMMA)+ = (<IdToken> COMMA)+, IdToken, COMMA => ActionFn(96);
+        // (<IdToken> COMMA)+ = (<IdToken> COMMA)+, IdToken, COMMA => ActionFn(97);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant5(__symbols);
         let __sym0 = __pop_Variant6(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action96::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action97::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant6(__nt), __end));
         (3, 8)
     }
@@ -2004,13 +2013,13 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<SelectField> COMMA) = SelectField, COMMA => ActionFn(67);
+        // (<SelectField> COMMA) = SelectField, COMMA => ActionFn(68);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant7(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action67::<>(input, __sym0, __sym1);
+        let __nt = super::__action68::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant7(__nt), __end));
         (2, 9)
     }
@@ -2023,10 +2032,10 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<SelectField> COMMA)* =  => ActionFn(65);
+        // (<SelectField> COMMA)* =  => ActionFn(66);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action65::<>(input, &__start, &__end);
+        let __nt = super::__action66::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant8(__nt), __end));
         (0, 10)
     }
@@ -2039,11 +2048,11 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<SelectField> COMMA)* = (<SelectField> COMMA)+ => ActionFn(66);
+        // (<SelectField> COMMA)* = (<SelectField> COMMA)+ => ActionFn(67);
         let __sym0 = __pop_Variant8(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action66::<>(input, __sym0);
+        let __nt = super::__action67::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant8(__nt), __end));
         (1, 10)
     }
@@ -2056,13 +2065,13 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<SelectField> COMMA)+ = SelectField, COMMA => ActionFn(99);
+        // (<SelectField> COMMA)+ = SelectField, COMMA => ActionFn(100);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant7(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action99::<>(input, __sym0, __sym1);
+        let __nt = super::__action100::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant8(__nt), __end));
         (2, 11)
     }
@@ -2075,14 +2084,14 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<SelectField> COMMA)+ = (<SelectField> COMMA)+, SelectField, COMMA => ActionFn(100);
+        // (<SelectField> COMMA)+ = (<SelectField> COMMA)+, SelectField, COMMA => ActionFn(101);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant7(__symbols);
         let __sym0 = __pop_Variant8(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action100::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action101::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant8(__nt), __end));
         (3, 11)
     }
@@ -2095,13 +2104,13 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Term> AND) = Term, AND => ActionFn(76);
+        // (<Term> AND) = Term, AND => ActionFn(77);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant9(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action76::<>(input, __sym0, __sym1);
+        let __nt = super::__action77::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant9(__nt), __end));
         (2, 12)
     }
@@ -2114,10 +2123,10 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Term> AND)* =  => ActionFn(74);
+        // (<Term> AND)* =  => ActionFn(75);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action74::<>(input, &__start, &__end);
+        let __nt = super::__action75::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant10(__nt), __end));
         (0, 13)
     }
@@ -2130,11 +2139,11 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Term> AND)* = (<Term> AND)+ => ActionFn(75);
+        // (<Term> AND)* = (<Term> AND)+ => ActionFn(76);
         let __sym0 = __pop_Variant10(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action75::<>(input, __sym0);
+        let __nt = super::__action76::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant10(__nt), __end));
         (1, 13)
     }
@@ -2147,13 +2156,13 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Term> AND)+ = Term, AND => ActionFn(103);
+        // (<Term> AND)+ = Term, AND => ActionFn(104);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant9(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action103::<>(input, __sym0, __sym1);
+        let __nt = super::__action104::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant10(__nt), __end));
         (2, 14)
     }
@@ -2166,14 +2175,14 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Term> AND)+ = (<Term> AND)+, Term, AND => ActionFn(104);
+        // (<Term> AND)+ = (<Term> AND)+, Term, AND => ActionFn(105);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant9(__symbols);
         let __sym0 = __pop_Variant10(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action104::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action105::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant10(__nt), __end));
         (3, 14)
     }
@@ -2186,14 +2195,14 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AddExpr = AddExpr, PLUS, MulExpr => ActionFn(40);
+        // AddExpr = AddExpr, PLUS, MulExpr => ActionFn(41);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant11(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action40::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action41::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (3, 15)
     }
@@ -2206,14 +2215,14 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AddExpr = AddExpr, MINUS, MulExpr => ActionFn(41);
+        // AddExpr = AddExpr, MINUS, MulExpr => ActionFn(42);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant11(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action41::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action42::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (3, 15)
     }
@@ -2226,11 +2235,11 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AddExpr = MulExpr => ActionFn(42);
+        // AddExpr = MulExpr => ActionFn(43);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action42::<>(input, __sym0);
+        let __nt = super::__action43::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (1, 15)
     }
@@ -2243,7 +2252,7 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AggregationFn = MAX, LPAREN, IdToken, RPAREN => ActionFn(13);
+        // AggregationFn = MAX, LPAREN, IdToken, RPAREN => ActionFn(14);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant5(__symbols);
@@ -2251,7 +2260,7 @@ mod __parse__Predicate {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action13::<>(input, __sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action14::<>(input, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant12(__nt), __end));
         (4, 16)
     }
@@ -2264,7 +2273,7 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AggregationFn = MIN, LPAREN, IdToken, RPAREN => ActionFn(14);
+        // AggregationFn = MIN, LPAREN, IdToken, RPAREN => ActionFn(15);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant5(__symbols);
@@ -2272,7 +2281,7 @@ mod __parse__Predicate {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action14::<>(input, __sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action15::<>(input, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant12(__nt), __end));
         (4, 16)
     }
@@ -2285,7 +2294,7 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AggregationFn = SUM, LPAREN, IdToken, RPAREN => ActionFn(15);
+        // AggregationFn = SUM, LPAREN, IdToken, RPAREN => ActionFn(16);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant5(__symbols);
@@ -2293,7 +2302,7 @@ mod __parse__Predicate {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action15::<>(input, __sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action16::<>(input, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant12(__nt), __end));
         (4, 16)
     }
@@ -2306,7 +2315,7 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AggregationFn = COUNT, LPAREN, IdToken, RPAREN => ActionFn(16);
+        // AggregationFn = COUNT, LPAREN, IdToken, RPAREN => ActionFn(17);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant5(__symbols);
@@ -2314,7 +2323,7 @@ mod __parse__Predicate {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action16::<>(input, __sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action17::<>(input, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant12(__nt), __end));
         (4, 16)
     }
@@ -2327,7 +2336,7 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AggregationFn = AVG, LPAREN, IdToken, RPAREN => ActionFn(17);
+        // AggregationFn = AVG, LPAREN, IdToken, RPAREN => ActionFn(18);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant5(__symbols);
@@ -2335,7 +2344,7 @@ mod __parse__Predicate {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action17::<>(input, __sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action18::<>(input, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant12(__nt), __end));
         (4, 16)
     }
@@ -2348,11 +2357,11 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // And<Term> = Term => ActionFn(105);
+        // And<Term> = Term => ActionFn(106);
         let __sym0 = __pop_Variant9(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action105::<>(input, __sym0);
+        let __nt = super::__action106::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant13(__nt), __end));
         (1, 17)
     }
@@ -2365,13 +2374,13 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // And<Term> = (<Term> AND)+, Term => ActionFn(106);
+        // And<Term> = (<Term> AND)+, Term => ActionFn(107);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant9(__symbols);
         let __sym0 = __pop_Variant10(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action106::<>(input, __sym0, __sym1);
+        let __nt = super::__action107::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant13(__nt), __end));
         (2, 17)
     }
@@ -2384,11 +2393,11 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<Constant> = Constant => ActionFn(89);
+        // Comma<Constant> = Constant => ActionFn(90);
         let __sym0 = __pop_Variant1(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action89::<>(input, __sym0);
+        let __nt = super::__action90::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant14(__nt), __end));
         (1, 18)
     }
@@ -2401,13 +2410,13 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<Constant> = (<Constant> COMMA)+, Constant => ActionFn(90);
+        // Comma<Constant> = (<Constant> COMMA)+, Constant => ActionFn(91);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant1(__symbols);
         let __sym0 = __pop_Variant2(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action90::<>(input, __sym0, __sym1);
+        let __nt = super::__action91::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant14(__nt), __end));
         (2, 18)
     }
@@ -2420,11 +2429,11 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<FieldDefinition> = FieldDefinition => ActionFn(93);
+        // Comma<FieldDefinition> = FieldDefinition => ActionFn(94);
         let __sym0 = __pop_Variant3(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action93::<>(input, __sym0);
+        let __nt = super::__action94::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (1, 19)
     }
@@ -2437,13 +2446,13 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<FieldDefinition> = (<FieldDefinition> COMMA)+, FieldDefinition => ActionFn(94);
+        // Comma<FieldDefinition> = (<FieldDefinition> COMMA)+, FieldDefinition => ActionFn(95);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant3(__symbols);
         let __sym0 = __pop_Variant4(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action94::<>(input, __sym0, __sym1);
+        let __nt = super::__action95::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (2, 19)
     }
@@ -2456,11 +2465,11 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<IdToken> = IdToken => ActionFn(97);
+        // Comma<IdToken> = IdToken => ActionFn(98);
         let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action97::<>(input, __sym0);
+        let __nt = super::__action98::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant16(__nt), __end));
         (1, 20)
     }
@@ -2473,13 +2482,13 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<IdToken> = (<IdToken> COMMA)+, IdToken => ActionFn(98);
+        // Comma<IdToken> = (<IdToken> COMMA)+, IdToken => ActionFn(99);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant5(__symbols);
         let __sym0 = __pop_Variant6(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action98::<>(input, __sym0, __sym1);
+        let __nt = super::__action99::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant16(__nt), __end));
         (2, 20)
     }
@@ -2492,11 +2501,11 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<SelectField> = SelectField => ActionFn(101);
+        // Comma<SelectField> = SelectField => ActionFn(102);
         let __sym0 = __pop_Variant7(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action101::<>(input, __sym0);
+        let __nt = super::__action102::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant17(__nt), __end));
         (1, 21)
     }
@@ -2509,13 +2518,13 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<SelectField> = (<SelectField> COMMA)+, SelectField => ActionFn(102);
+        // Comma<SelectField> = (<SelectField> COMMA)+, SelectField => ActionFn(103);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant7(__symbols);
         let __sym0 = __pop_Variant8(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action102::<>(input, __sym0, __sym1);
+        let __nt = super::__action103::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant17(__nt), __end));
         (2, 21)
     }
@@ -2528,11 +2537,11 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Constant = NULL => ActionFn(51);
+        // Constant = NULL => ActionFn(52);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action51::<>(input, __sym0);
+        let __nt = super::__action52::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant1(__nt), __end));
         (1, 22)
     }
@@ -2545,11 +2554,11 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Constant = I32Constant => ActionFn(52);
+        // Constant = I32Constant => ActionFn(53);
         let __sym0 = __pop_Variant21(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action52::<>(input, __sym0);
+        let __nt = super::__action53::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant1(__nt), __end));
         (1, 22)
     }
@@ -2562,11 +2571,11 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Constant = StringConstant => ActionFn(53);
+        // Constant = StringConstant => ActionFn(54);
         let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action53::<>(input, __sym0);
+        let __nt = super::__action54::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant1(__nt), __end));
         (1, 22)
     }
@@ -2579,7 +2588,7 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // CreateCommand = CREATE, TABLE, IdToken, LPAREN, Comma<FieldDefinition>, RPAREN => ActionFn(30);
+        // CreateCommand = CREATE, TABLE, IdToken, LPAREN, Comma<FieldDefinition>, RPAREN => ActionFn(31);
         assert!(__symbols.len() >= 6);
         let __sym5 = __pop_Variant0(__symbols);
         let __sym4 = __pop_Variant15(__symbols);
@@ -2589,7 +2598,7 @@ mod __parse__Predicate {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym5.2;
-        let __nt = super::__action30::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
+        let __nt = super::__action31::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
         __symbols.push((__start, __Symbol::Variant18(__nt), __end));
         (6, 23)
     }
@@ -2602,7 +2611,7 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // CreateCommand = CREATE, VIEW, IdToken, AS, Query => ActionFn(31);
+        // CreateCommand = CREATE, VIEW, IdToken, AS, Query => ActionFn(32);
         assert!(__symbols.len() >= 5);
         let __sym4 = __pop_Variant25(__symbols);
         let __sym3 = __pop_Variant0(__symbols);
@@ -2611,7 +2620,7 @@ mod __parse__Predicate {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym4.2;
-        let __nt = super::__action31::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4);
+        let __nt = super::__action32::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4);
         __symbols.push((__start, __Symbol::Variant18(__nt), __end));
         (5, 23)
     }
@@ -2624,7 +2633,7 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // CreateCommand = CREATE, INDEX, IdToken, ON, IdToken, LPAREN, IdToken, RPAREN => ActionFn(32);
+        // CreateCommand = CREATE, INDEX, IdToken, ON, IdToken, LPAREN, IdToken, RPAREN => ActionFn(33);
         assert!(__symbols.len() >= 8);
         let __sym7 = __pop_Variant0(__symbols);
         let __sym6 = __pop_Variant5(__symbols);
@@ -2636,7 +2645,7 @@ mod __parse__Predicate {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym7.2;
-        let __nt = super::__action32::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
+        let __nt = super::__action33::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
         __symbols.push((__start, __Symbol::Variant18(__nt), __end));
         (8, 23)
     }
@@ -2649,11 +2658,11 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Expression = AddExpr => ActionFn(39);
+        // Expression = AddExpr => ActionFn(40);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action39::<>(input, __sym0);
+        let __nt = super::__action40::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (1, 24)
     }
@@ -2666,14 +2675,14 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Factor = LPAREN, Expression, RPAREN => ActionFn(46);
+        // Factor = LPAREN, Expression, RPAREN => ActionFn(47);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant11(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action46::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action47::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (3, 25)
     }
@@ -2686,11 +2695,11 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Factor = NULL => ActionFn(47);
+        // Factor = NULL => ActionFn(48);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action47::<>(input, __sym0);
+        let __nt = super::__action48::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (1, 25)
     }
@@ -2703,11 +2712,11 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Factor = I32Constant => ActionFn(48);
+        // Factor = I32Constant => ActionFn(49);
         let __sym0 = __pop_Variant21(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action48::<>(input, __sym0);
+        let __nt = super::__action49::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (1, 25)
     }
@@ -2720,11 +2729,11 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Factor = StringConstant => ActionFn(49);
+        // Factor = StringConstant => ActionFn(50);
         let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action49::<>(input, __sym0);
+        let __nt = super::__action50::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (1, 25)
     }
@@ -2737,11 +2746,11 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Factor = IdToken => ActionFn(50);
+        // Factor = IdToken => ActionFn(51);
         let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action50::<>(input, __sym0);
+        let __nt = super::__action51::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (1, 25)
     }
@@ -2754,13 +2763,13 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // FieldDefinition = IdToken, FieldType => ActionFn(33);
+        // FieldDefinition = IdToken, FieldType => ActionFn(34);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant20(__symbols);
         let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action33::<>(input, __sym0, __sym1);
+        let __nt = super::__action34::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant3(__nt), __end));
         (2, 26)
     }
@@ -2807,11 +2816,11 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // FieldType = I32 => ActionFn(34);
+        // FieldType = I32 => ActionFn(35);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action34::<>(input, __sym0);
+        let __nt = super::__action35::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant20(__nt), __end));
         (1, 28)
     }
@@ -2824,7 +2833,7 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // FieldType = VARCHAR, LPAREN, I32Constant, RPAREN => ActionFn(35);
+        // FieldType = VARCHAR, LPAREN, I32Constant, RPAREN => ActionFn(36);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant21(__symbols);
@@ -2832,7 +2841,7 @@ mod __parse__Predicate {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action35::<>(input, __sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action36::<>(input, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant20(__nt), __end));
         (4, 28)
     }
@@ -2845,11 +2854,11 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // I32Constant = I32_LITERAL => ActionFn(54);
+        // I32Constant = I32_LITERAL => ActionFn(55);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action54::<>(input, __sym0);
+        let __nt = super::__action55::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant21(__nt), __end));
         (1, 29)
     }
@@ -2862,11 +2871,11 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // IdToken = ID => ActionFn(56);
+        // IdToken = ID => ActionFn(57);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action56::<>(input, __sym0);
+        let __nt = super::__action57::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant5(__nt), __end));
         (1, 30)
     }
@@ -2879,14 +2888,14 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // MulExpr = MulExpr, STAR, Factor => ActionFn(43);
+        // MulExpr = MulExpr, STAR, Factor => ActionFn(44);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant11(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action43::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action44::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (3, 31)
     }
@@ -2899,14 +2908,14 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // MulExpr = MulExpr, SLASH, Factor => ActionFn(44);
+        // MulExpr = MulExpr, SLASH, Factor => ActionFn(45);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant11(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action44::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action45::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (3, 31)
     }
@@ -2919,11 +2928,11 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // MulExpr = Factor => ActionFn(45);
+        // MulExpr = Factor => ActionFn(46);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action45::<>(input, __sym0);
+        let __nt = super::__action46::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (1, 31)
     }
@@ -2936,14 +2945,14 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // OptGroupBy = GROUP, BY, Comma<IdToken> => ActionFn(20);
+        // OptGroupBy = GROUP, BY, Comma<IdToken> => ActionFn(21);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant16(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action20::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action21::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant22(__nt), __end));
         (3, 32)
     }
@@ -2956,10 +2965,10 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // OptGroupBy =  => ActionFn(21);
+        // OptGroupBy =  => ActionFn(22);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action21::<>(input, &__start, &__end);
+        let __nt = super::__action22::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant22(__nt), __end));
         (0, 32)
     }
@@ -2972,14 +2981,14 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // OptOrderBy = ORDER, BY, Comma<IdToken> => ActionFn(22);
+        // OptOrderBy = ORDER, BY, Comma<IdToken> => ActionFn(23);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant16(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action22::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action23::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant22(__nt), __end));
         (3, 33)
     }
@@ -2992,10 +3001,10 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // OptOrderBy =  => ActionFn(23);
+        // OptOrderBy =  => ActionFn(24);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action23::<>(input, &__start, &__end);
+        let __nt = super::__action24::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant22(__nt), __end));
         (0, 33)
     }
@@ -3008,13 +3017,13 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // OptPredicate = WHERE, Predicate => ActionFn(18);
+        // OptPredicate = WHERE, Predicate => ActionFn(19);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant24(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action18::<>(input, __sym0, __sym1);
+        let __nt = super::__action19::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant23(__nt), __end));
         (2, 34)
     }
@@ -3027,10 +3036,10 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // OptPredicate =  => ActionFn(19);
+        // OptPredicate =  => ActionFn(20);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action19::<>(input, &__start, &__end);
+        let __nt = super::__action20::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant23(__nt), __end));
         (0, 34)
     }
@@ -3043,11 +3052,11 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Predicate = And<Term> => ActionFn(36);
+        // Predicate = And<Term> => ActionFn(37);
         let __sym0 = __pop_Variant13(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action36::<>(input, __sym0);
+        let __nt = super::__action37::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant24(__nt), __end));
         (1, 35)
     }
@@ -3121,15 +3130,35 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // SelectField = AggregationFn => ActionFn(12);
+        // SelectField = AggregationFn, AS, IdToken => ActionFn(12);
+        assert!(__symbols.len() >= 3);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant12(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym2.2;
+        let __nt = super::__action12::<>(input, __sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant7(__nt), __end));
+        (3, 37)
+    }
+    fn __reduce76<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // SelectField = AggregationFn => ActionFn(13);
         let __sym0 = __pop_Variant12(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action12::<>(input, __sym0);
+        let __nt = super::__action13::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant7(__nt), __end));
         (1, 37)
     }
-    fn __reduce76<
+    fn __reduce77<
         'input,
     >(
         input: &'input str,
@@ -3146,7 +3175,7 @@ mod __parse__Predicate {
         __symbols.push((__start, __Symbol::Variant26(__nt), __end));
         (1, 38)
     }
-    fn __reduce77<
+    fn __reduce78<
         'input,
     >(
         input: &'input str,
@@ -3163,23 +3192,6 @@ mod __parse__Predicate {
         __symbols.push((__start, __Symbol::Variant26(__nt), __end));
         (1, 38)
     }
-    fn __reduce78<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // StringConstant = STRING_LITERAL => ActionFn(55);
-        let __sym0 = __pop_Variant0(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action55::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant5(__nt), __end));
-        (1, 39)
-    }
     fn __reduce79<
         'input,
     >(
@@ -3189,16 +3201,13 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Term = Expression, IS, NULL => ActionFn(37);
-        assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant11(__symbols);
+        // StringConstant = STRING_LITERAL => ActionFn(56);
+        let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym2.2;
-        let __nt = super::__action37::<>(input, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant9(__nt), __end));
-        (3, 40)
+        let __end = __sym0.2;
+        let __nt = super::__action56::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant5(__nt), __end));
+        (1, 39)
     }
     fn __reduce80<
         'input,
@@ -3209,9 +3218,9 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Term = Expression, EQ, Expression => ActionFn(38);
+        // Term = Expression, IS, NULL => ActionFn(38);
         assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant11(__symbols);
+        let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
@@ -3229,7 +3238,27 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // UpdateCommand = INSERT, INTO, IdToken, LPAREN, Comma<IdToken>, RPAREN, VALUES, LPAREN, Comma<Constant>, RPAREN => ActionFn(24);
+        // Term = Expression, EQ, Expression => ActionFn(39);
+        assert!(__symbols.len() >= 3);
+        let __sym2 = __pop_Variant11(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant11(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym2.2;
+        let __nt = super::__action39::<>(input, __sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant9(__nt), __end));
+        (3, 40)
+    }
+    fn __reduce82<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // UpdateCommand = INSERT, INTO, IdToken, LPAREN, Comma<IdToken>, RPAREN, VALUES, LPAREN, Comma<Constant>, RPAREN => ActionFn(25);
         assert!(__symbols.len() >= 10);
         let __sym9 = __pop_Variant0(__symbols);
         let __sym8 = __pop_Variant14(__symbols);
@@ -3243,29 +3272,9 @@ mod __parse__Predicate {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym9.2;
-        let __nt = super::__action24::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9);
+        let __nt = super::__action25::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9);
         __symbols.push((__start, __Symbol::Variant27(__nt), __end));
         (10, 41)
-    }
-    fn __reduce82<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // UpdateCommand = DELETE, FROM, IdToken => ActionFn(25);
-        assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant5(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym2.2;
-        let __nt = super::__action25::<>(input, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant27(__nt), __end));
-        (3, 41)
     }
     fn __reduce83<
         'input,
@@ -3276,18 +3285,16 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // UpdateCommand = DELETE, FROM, IdToken, WHERE, Predicate => ActionFn(26);
-        assert!(__symbols.len() >= 5);
-        let __sym4 = __pop_Variant24(__symbols);
-        let __sym3 = __pop_Variant0(__symbols);
+        // UpdateCommand = DELETE, FROM, IdToken => ActionFn(26);
+        assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant5(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym4.2;
-        let __nt = super::__action26::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4);
+        let __end = __sym2.2;
+        let __nt = super::__action26::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant27(__nt), __end));
-        (5, 41)
+        (3, 41)
     }
     fn __reduce84<
         'input,
@@ -3298,19 +3305,18 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // UpdateCommand = MODIFY, IdToken, SET, IdToken, EQ, Expression => ActionFn(27);
-        assert!(__symbols.len() >= 6);
-        let __sym5 = __pop_Variant11(__symbols);
-        let __sym4 = __pop_Variant0(__symbols);
-        let __sym3 = __pop_Variant5(__symbols);
-        let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant5(__symbols);
+        // UpdateCommand = DELETE, FROM, IdToken, WHERE, Predicate => ActionFn(27);
+        assert!(__symbols.len() >= 5);
+        let __sym4 = __pop_Variant24(__symbols);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym5.2;
-        let __nt = super::__action27::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
+        let __end = __sym4.2;
+        let __nt = super::__action27::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4);
         __symbols.push((__start, __Symbol::Variant27(__nt), __end));
-        (6, 41)
+        (5, 41)
     }
     fn __reduce85<
         'input,
@@ -3321,7 +3327,30 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // UpdateCommand = MODIFY, IdToken, SET, IdToken, EQ, Expression, WHERE, Predicate => ActionFn(28);
+        // UpdateCommand = MODIFY, IdToken, SET, IdToken, EQ, Expression => ActionFn(28);
+        assert!(__symbols.len() >= 6);
+        let __sym5 = __pop_Variant11(__symbols);
+        let __sym4 = __pop_Variant0(__symbols);
+        let __sym3 = __pop_Variant5(__symbols);
+        let __sym2 = __pop_Variant0(__symbols);
+        let __sym1 = __pop_Variant5(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym5.2;
+        let __nt = super::__action28::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
+        __symbols.push((__start, __Symbol::Variant27(__nt), __end));
+        (6, 41)
+    }
+    fn __reduce86<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // UpdateCommand = MODIFY, IdToken, SET, IdToken, EQ, Expression, WHERE, Predicate => ActionFn(29);
         assert!(__symbols.len() >= 8);
         let __sym7 = __pop_Variant24(__symbols);
         let __sym6 = __pop_Variant0(__symbols);
@@ -3333,11 +3362,11 @@ mod __parse__Predicate {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym7.2;
-        let __nt = super::__action28::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
+        let __nt = super::__action29::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
         __symbols.push((__start, __Symbol::Variant27(__nt), __end));
         (8, 41)
     }
-    fn __reduce86<
+    fn __reduce87<
         'input,
     >(
         input: &'input str,
@@ -3346,15 +3375,15 @@ mod __parse__Predicate {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // UpdateCommand = CreateCommand => ActionFn(29);
+        // UpdateCommand = CreateCommand => ActionFn(30);
         let __sym0 = __pop_Variant18(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action29::<>(input, __sym0);
+        let __nt = super::__action30::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant27(__nt), __end));
         (1, 41)
     }
-    fn __reduce88<
+    fn __reduce89<
         'input,
     >(
         input: &'input str,
@@ -3371,7 +3400,7 @@ mod __parse__Predicate {
         __symbols.push((__start, __Symbol::Variant25(__nt), __end));
         (1, 43)
     }
-    fn __reduce89<
+    fn __reduce90<
         'input,
     >(
         input: &'input str,
@@ -3388,7 +3417,7 @@ mod __parse__Predicate {
         __symbols.push((__start, __Symbol::Variant26(__nt), __end));
         (1, 44)
     }
-    fn __reduce90<
+    fn __reduce91<
         'input,
     >(
         input: &'input str,
@@ -3405,7 +3434,7 @@ mod __parse__Predicate {
         __symbols.push((__start, __Symbol::Variant9(__nt), __end));
         (1, 45)
     }
-    fn __reduce91<
+    fn __reduce92<
         'input,
     >(
         input: &'input str,
@@ -3487,172 +3516,176 @@ mod __parse__Query {
         // State 0
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0,
         // State 1
-        0, 40, 45, 39, 0, 4, 0, 44, 0, 0, 0, 0, 0, 0, 37, 0, 38, 0, 0, 0, 0, 0, 0, 0, 0, 0, 41, 42, 0, 43, 0, 0, 0, 0, 46, 0, 0, 0, 0, 0,
+        0, 41, 46, 40, 0, 4, 0, 45, 0, 0, 0, 0, 0, 0, 38, 0, 39, 0, 0, 0, 0, 0, 0, 0, 0, 0, 42, 43, 0, 44, 0, 0, 0, 0, 47, 0, 0, 0, 0, 0,
         // State 2
-        0, 40, 45, 39, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 37, 0, 38, 0, 0, 0, 0, 0, 0, 0, 0, 0, 41, 42, 0, 43, 0, 0, 0, 0, 46, 0, 0, 0, 0, 0,
+        0, 41, 46, 40, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 38, 0, 39, 0, 0, 0, 0, 0, 0, 0, 0, 0, 42, 43, 0, 44, 0, 0, 0, 0, 47, 0, 0, 0, 0, 0,
         // State 3
-        0, 40, 45, 39, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 43, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 41, 46, 40, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 44, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 4
-        0, 40, 45, 39, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 43, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 41, 46, 40, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 44, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 5
-        0, 40, 45, 39, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 43, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 41, 46, 40, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 44, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 6
-        0, 40, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 41, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 7
-        0, 40, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 41, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 8
-        0, 40, 45, 39, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 43, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 41, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 9
-        0, 40, 45, 39, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 43, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 41, 46, 40, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 44, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 10
-        0, 40, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 41, 46, 40, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 44, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 11
-        0, 40, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 41, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 12
-        0, 40, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 41, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 13
-        0, 40, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 41, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 14
-        0, 40, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 41, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 15
-        0, 40, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 41, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 16
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -71, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -71, 0, 0, 0, 0, 0, 0, 0, 19,
+        0, 41, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 17
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 71, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -67, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -71, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -71, 0, 0, 0, 0, 0, 0, 0, 20,
         // State 18
-        0, 40, 45, 39, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 43, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 73, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -67, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 19
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 77, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 41, 46, 40, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 44, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 20
-        0, 40, 45, 39, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 43, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 79, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 21
-        0, 40, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 41, 46, 40, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 44, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 22
-        0, 40, 45, 39, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 43, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 41, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 23
-        0, 40, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 41, 46, 40, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 44, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 24
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 41, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 25
-        0, 0, 0, 0, 5, 0, -50, 0, 6, -50, 0, -50, -50, -50, 0, 0, 0, 0, 0, -50, -50, 0, 0, 0, 0, -50, 0, 0, 0, 0, 0, -50, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 26
-        0, 0, 0, 0, 0, 0, 0, 0, 0, -76, 0, 0, 0, 0, 0, 0, 0, 0, 0, -76, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 5, 0, -50, 0, 6, -50, 0, -50, -50, -50, 0, 0, 0, 0, 0, -50, -50, 0, 0, 0, 0, -50, 0, 0, 0, 0, 0, -50, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 27
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -58, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, -77, 0, 0, 0, 7, 0, 0, 0, 0, 0, -77, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 28
-        0, 0, 0, 0, 0, 0, 0, 0, 0, -75, 0, 0, 0, 7, 0, 0, 0, 0, 0, -75, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -58, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 29
-        0, 0, 0, 0, -65, 0, -65, -65, -65, -65, -65, -65, -65, -65, 0, 0, 0, 0, 0, -65, -65, 0, 0, 0, 0, -65, 0, 0, 0, 0, 0, -65, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, -75, 0, 0, 0, 8, 0, 0, 0, 0, 0, -75, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 30
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -65, 0, -65, -65, -65, -65, -65, -65, -65, -65, 0, 0, 0, 0, 0, -65, -65, 0, 0, 0, 0, -65, 0, 0, 0, 0, 0, -65, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 31
-        0, 0, 0, 0, -53, 0, -53, -53, -53, -53, -53, -53, -53, -53, 0, 0, 0, 0, 0, -53, -53, 0, 0, 0, 0, -53, 0, 0, 0, 0, 0, -53, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 32
-        0, 0, 0, 0, -55, 0, -55, -55, -55, -55, -55, -55, -55, -55, 0, 0, 0, 0, 0, -55, -55, 0, 0, 0, 0, -55, 0, 0, 0, 0, 0, -55, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -53, 0, -53, -53, -53, -53, -53, -53, -53, -53, 0, 0, 0, 0, 0, -53, -53, 0, 0, 0, 0, -53, 0, 0, 0, 0, 0, -53, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 33
-        0, 0, 0, 0, -28, 0, -28, 10, -28, -28, 9, -28, -28, -28, 0, 0, 0, 0, 0, -28, -28, 0, 0, 0, 0, -28, 0, 0, 0, 0, 0, -28, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -55, 0, -55, -55, -55, -55, -55, -55, -55, -55, 0, 0, 0, 0, 0, -55, -55, 0, 0, 0, 0, -55, 0, 0, 0, 0, 0, -55, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 34
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 48, 0, 0, 0, 0, 0, 0, 0, 0, 0, -42, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -28, 0, -28, 11, -28, -28, 10, -28, -28, -28, 0, 0, 0, 0, 0, -28, -28, 0, 0, 0, 0, -28, 0, 0, 0, 0, 0, -28, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 35
-        0, 0, 0, 0, -54, 0, -54, -54, -54, -54, -54, -54, -54, -54, 0, 0, 0, 0, 0, -54, -54, 0, 0, 0, 0, -54, 0, 0, 0, 0, 0, -54, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 49, 0, 0, 0, 0, 0, 0, 0, 0, 0, -42, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 36
-        0, 0, 0, 0, 0, 11, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -54, 0, -54, -54, -54, -54, -54, -54, -54, -54, 0, 0, 0, 0, 0, -54, -54, 0, 0, 0, 0, -54, 0, 0, 0, 0, 0, -54, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 37
         0, 0, 0, 0, 0, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 38
-        0, 0, 0, 0, -61, 0, -61, -61, -61, -61, -61, -61, -61, -61, 0, 0, 0, 0, 0, -61, -61, 0, 0, 0, 0, -61, 0, 0, 0, 0, 0, -61, 0, 0, 0, 0, 0, 0, 0, 0,
-        // State 39
-        0, 0, 0, 0, -62, 0, -62, -62, -62, -62, -62, -62, -62, -62, 0, 0, 0, 0, 0, -62, -62, 0, 0, 0, 0, -62, 0, 0, 0, 0, 0, -62, 0, 0, 0, 0, 0, 0, 0, -62,
-        // State 40
         0, 0, 0, 0, 0, 13, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 39
+        0, 0, 0, 0, -61, 0, -61, -61, -61, -61, -61, -61, -61, -61, 0, 0, 0, 0, 0, -61, -61, 0, 0, 0, 0, -61, 0, 0, 0, 0, 0, -61, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 40
+        0, 0, 0, 0, -62, 0, -62, -62, -62, -62, -62, -62, -62, -62, 0, 0, 0, 0, 0, -62, -62, 0, 0, 0, 0, -62, 0, 0, 0, 0, 0, -62, 0, 0, 0, 0, 0, 0, 0, -62,
         // State 41
         0, 0, 0, 0, 0, 14, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 42
-        0, 0, 0, 0, -52, 0, -52, -52, -52, -52, -52, -52, -52, -52, 0, 0, 0, 0, 0, -52, -52, 0, 0, 0, 0, -52, 0, 0, 0, 0, 0, -52, 0, 0, 0, 0, 0, 0, 0, 0,
-        // State 43
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -57, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        // State 44
-        0, 0, 0, 0, -79, 0, -79, -79, -79, -79, -79, -79, -79, -79, 0, 0, 0, 0, 0, -79, -79, 0, 0, 0, 0, -79, 0, 0, 0, 0, 0, -79, 0, 0, 0, 0, 0, 0, 0, 0,
-        // State 45
         0, 0, 0, 0, 0, 15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 43
+        0, 0, 0, 0, -52, 0, -52, -52, -52, -52, -52, -52, -52, -52, 0, 0, 0, 0, 0, -52, -52, 0, 0, 0, 0, -52, 0, 0, 0, 0, 0, -52, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 44
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -57, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 45
+        0, 0, 0, 0, -80, 0, -80, -80, -80, -80, -80, -80, -80, -80, 0, 0, 0, 0, 0, -80, -80, 0, 0, 0, 0, -80, 0, 0, 0, 0, 0, -80, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 46
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 50, 0, 0, 0, 0, 0, 0, 0, 0, 0, -43, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 47
-        0, -19, -19, -19, 0, -19, 0, 0, 0, 0, 0, 0, 0, 0, -19, 0, -19, 0, 0, 0, 0, 0, 0, 0, 0, 0, -19, -19, 0, -19, 0, 0, 0, 0, -19, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, -43, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 48
-        0, 0, 0, 0, 0, 0, 59, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, -19, -19, -19, 0, -19, 0, 0, 0, 0, 0, 0, 0, 0, -19, 0, -19, 0, 0, 0, 0, 0, 0, 0, 0, 0, -19, -19, 0, -19, 0, 0, 0, 0, -19, 0, 0, 0, 0, 0,
         // State 49
-        0, -20, -20, -20, 0, -20, 0, 0, 0, 0, 0, 0, 0, 0, -20, 0, -20, 0, 0, 0, 0, 0, 0, 0, 0, 0, -20, -20, 0, -20, 0, 0, 0, 0, -20, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 61, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 50
-        0, 0, 0, 0, -27, 0, -27, 10, -27, -27, 9, -27, -27, -27, 0, 0, 0, 0, 0, -27, -27, 0, 0, 0, 0, -27, 0, 0, 0, 0, 0, -27, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, -20, -20, -20, 0, -20, 0, 0, 0, 0, 0, 0, 0, 0, -20, 0, -20, 0, 0, 0, 0, 0, 0, 0, 0, 0, -20, -20, 0, -20, 0, 0, 0, 0, -20, 0, 0, 0, 0, 0,
         // State 51
-        0, 0, 0, 0, -26, 0, -26, 10, -26, -26, 9, -26, -26, -26, 0, 0, 0, 0, 0, -26, -26, 0, 0, 0, 0, -26, 0, 0, 0, 0, 0, -26, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -27, 0, -27, 11, -27, -27, 10, -27, -27, -27, 0, 0, 0, 0, 0, -27, -27, 0, 0, 0, 0, -27, 0, 0, 0, 0, 0, -27, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 52
-        0, 0, 0, 0, 0, 0, 0, 0, 0, -74, 0, 0, 0, 0, 0, 0, 0, 0, 0, -74, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -26, 0, -26, 11, -26, -26, 10, -26, -26, -26, 0, 0, 0, 0, 0, -26, -26, 0, 0, 0, 0, -26, 0, 0, 0, 0, 0, -26, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 53
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -40, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -40, 0, 0, 0, 0, 0, 0, 0, -40,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, -76, 0, 0, 0, 0, 0, 0, 0, 0, 0, -76, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 54
-        0, 0, 0, 0, -64, 0, -64, -64, -64, -64, -64, -64, -64, -64, 0, 0, 0, 0, 0, -64, -64, 0, 0, 0, 0, -64, 0, 0, 0, 0, 0, -64, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, -74, 0, 0, 0, 0, 0, 0, 0, 0, 0, -74, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 55
-        0, 0, 0, 0, -63, 0, -63, -63, -63, -63, -63, -63, -63, -63, 0, 0, 0, 0, 0, -63, -63, 0, 0, 0, 0, -63, 0, 0, 0, 0, 0, -63, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 66, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -40, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -40, 0, 0, 0, 0, 0, 0, 0, -40,
         // State 56
-        0, 0, 0, 0, 0, 0, 65, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -64, 0, -64, -64, -64, -64, -64, -64, -64, -64, 0, 0, 0, 0, 0, -64, -64, 0, 0, 0, 0, -64, 0, 0, 0, 0, 0, -64, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 57
-        0, 0, 0, 0, 0, 0, 66, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -63, 0, -63, -63, -63, -63, -63, -63, -63, -63, 0, 0, 0, 0, 0, -63, -63, 0, 0, 0, 0, -63, 0, 0, 0, 0, 0, -63, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 58
-        0, 0, 0, 0, -51, 0, -51, -51, -51, -51, -51, -51, -51, -51, 0, 0, 0, 0, 0, -51, -51, 0, 0, 0, 0, -51, 0, 0, 0, 0, 0, -51, 0, 0, 0, 0, 0, 0, 0, 0,
-        // State 59
         0, 0, 0, 0, 0, 0, 67, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        // State 60
+        // State 59
         0, 0, 0, 0, 0, 0, 68, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 60
+        0, 0, 0, 0, -51, 0, -51, -51, -51, -51, -51, -51, -51, -51, 0, 0, 0, 0, 0, -51, -51, 0, 0, 0, 0, -51, 0, 0, 0, 0, 0, -51, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 61
         0, 0, 0, 0, 0, 0, 69, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 62
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 70, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -41, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -41, 0, 0, 0, 0, 0, 0, 0, -41,
+        0, 0, 0, 0, 0, 0, 70, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 63
-        0, -14, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 71, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 64
-        0, 0, 0, 0, 0, 0, 0, 0, 0, -33, 0, 0, 0, 0, 0, 0, 0, 0, 0, -33, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 72, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -41, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -41, 0, 0, 0, 0, 0, 0, 0, -41,
         // State 65
-        0, 0, 0, 0, 0, 0, 0, 0, 0, -32, 0, 0, 0, 0, 0, 0, 0, 0, 0, -32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, -14, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 66
-        0, 0, 0, 0, 0, 0, 0, 0, 0, -29, 0, 0, 0, 0, 0, 0, 0, 0, 0, -29, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, -33, 0, 0, 0, -33, 0, 0, 0, 0, 0, -33, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 67
-        0, 0, 0, 0, 0, 0, 0, 0, 0, -30, 0, 0, 0, 0, 0, 0, 0, 0, 0, -30, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, -32, 0, 0, 0, -32, 0, 0, 0, 0, 0, -32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 68
-        0, 0, 0, 0, 0, 0, 0, 0, 0, -31, 0, 0, 0, 0, 0, 0, 0, 0, 0, -31, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, -29, 0, 0, 0, -29, 0, 0, 0, 0, 0, -29, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 69
-        0, -15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, -30, 0, 0, 0, -30, 0, 0, 0, 0, 0, -30, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 70
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 22, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, -31, 0, 0, 0, -31, 0, 0, 0, 0, 0, -31, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 71
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -72, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -72, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, -15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 72
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 23, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 79, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 23, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 73
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -70, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -70, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -72, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -72, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 74
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 80, 0, 0, 0, 0, 0, 0, 0, -34, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -34, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 81, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 75
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -70, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -70, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 76
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 82, 0, 0, 0, 0, 0, 0, 0, -34, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -34, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 77
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 82, 0, 0, 0, 0, 0, 0, 0, -35, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -35, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 78
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 84, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 79
-        0, -24, -24, -24, 0, -24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 84, 0, 0, 0, 0, 0, 0, 0, -35, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -35, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 80
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -66, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 86, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 81
-        0, -25, -25, -25, 0, -25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, -24, -24, -24, 0, -24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 82
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -81, 0, 0, 0, 0, 0, 0, 0, -81, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -81, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -66, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 83
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -80, 0, 0, 0, 0, 0, 0, 0, -80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -80, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, -25, -25, -25, 0, -25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 84
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -82, 0, 0, 0, 0, 0, 0, 0, -82, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -82, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 85
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -81, 0, 0, 0, 0, 0, 0, 0, -81, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -81, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 86
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     ];
     fn __action(state: i8, integer: usize) -> i8 {
@@ -3692,15 +3725,15 @@ mod __parse__Query {
         // State 15
         0,
         // State 16
-        -71,
+        0,
         // State 17
-        -67,
+        -71,
         // State 18
-        0,
+        -67,
         // State 19
-        -69,
-        // State 20
         0,
+        // State 20
+        -69,
         // State 21
         0,
         // State 22
@@ -3708,49 +3741,49 @@ mod __parse__Query {
         // State 23
         0,
         // State 24
-        -89,
-        // State 25
-        -50,
-        // State 26
         0,
+        // State 25
+        -90,
+        // State 26
+        -50,
         // State 27
         0,
         // State 28
         0,
         // State 29
-        -65,
+        0,
         // State 30
-        0,
+        -65,
         // State 31
-        -53,
+        0,
         // State 32
-        -55,
+        -53,
         // State 33
-        -28,
+        -55,
         // State 34
-        0,
+        -28,
         // State 35
-        -54,
-        // State 36
         0,
+        // State 36
+        -54,
         // State 37
         0,
         // State 38
-        -61,
-        // State 39
-        -62,
-        // State 40
         0,
+        // State 39
+        -61,
+        // State 40
+        -62,
         // State 41
         0,
         // State 42
-        -52,
+        0,
         // State 43
-        0,
+        -52,
         // State 44
-        -79,
-        // State 45
         0,
+        // State 45
+        -80,
         // State 46
         0,
         // State 47
@@ -3760,35 +3793,35 @@ mod __parse__Query {
         // State 49
         0,
         // State 50
-        -27,
+        0,
         // State 51
-        -26,
+        -27,
         // State 52
-        0,
+        -26,
         // State 53
-        -40,
+        0,
         // State 54
-        -64,
+        0,
         // State 55
-        -63,
+        -40,
         // State 56
-        0,
+        -64,
         // State 57
-        0,
+        -63,
         // State 58
-        -51,
+        0,
         // State 59
         0,
         // State 60
-        0,
+        -51,
         // State 61
         0,
         // State 62
-        -41,
+        0,
         // State 63
         0,
         // State 64
-        0,
+        -41,
         // State 65
         0,
         // State 66
@@ -3802,90 +3835,95 @@ mod __parse__Query {
         // State 70
         0,
         // State 71
-        -72,
+        0,
         // State 72
         0,
         // State 73
-        -70,
+        -72,
         // State 74
-        -34,
-        // State 75
-        -73,
-        // State 76
         0,
+        // State 75
+        -70,
+        // State 76
+        -34,
         // State 77
-        -35,
+        -73,
         // State 78
         0,
         // State 79
-        0,
+        -35,
         // State 80
-        -66,
+        0,
         // State 81
         0,
         // State 82
-        -81,
+        -66,
         // State 83
-        -80,
+        0,
         // State 84
+        -82,
+        // State 85
+        -81,
+        // State 86
         -68,
     ];
     fn __goto(state: i8, nt: usize) -> i8 {
         match nt {
-            8 => 15,
+            8 => 16,
             11 => 2,
-            14 => 20,
-            15 => 25,
-            16 => 26,
-            17 => 71,
+            14 => 21,
+            15 => 26,
+            16 => 27,
+            17 => 73,
             20 => match state {
-                21 => 80,
-                23 => 84,
-                _ => 16,
-            },
-            21 => 27,
-            24 => match state {
-                1..=2 => 28,
-                3 => 48,
                 22 => 82,
-                _ => 72,
+                24 => 86,
+                _ => 17,
+            },
+            21 => 28,
+            24 => match state {
+                1..=2 => 29,
+                3 => 49,
+                23 => 84,
+                _ => 74,
             },
             25 => match state {
-                8 => 54,
-                9 => 55,
-                _ => 29,
+                9 => 56,
+                10 => 57,
+                _ => 30,
             },
-            27 => 30,
-            29 => 31,
+            27 => 31,
+            29 => 32,
             30 => match state {
-                6 => 52,
-                7 | 21 | 23 => 53,
-                10 => 56,
-                11 => 57,
+                6 => 53,
+                7 => 54,
+                8 | 22 | 24 => 55,
+                11 => 58,
                 12 => 59,
-                13 => 60,
-                14 => 61,
-                15 => 62,
-                _ => 32,
-            },
-            31 => match state {
-                4 => 50,
-                5 => 51,
+                13 => 61,
+                14 => 62,
+                15 => 63,
+                16 => 64,
                 _ => 33,
             },
-            32 => 19,
-            33 => 75,
-            34 => 17,
-            35 => 73,
-            36 => 24,
-            37 => match state {
-                2 => 46,
+            31 => match state {
+                4 => 51,
+                5 => 52,
                 _ => 34,
             },
-            39 => 35,
+            32 => 20,
+            33 => 77,
+            34 => 18,
+            35 => 75,
+            36 => 25,
+            37 => match state {
+                2 => 47,
+                _ => 35,
+            },
+            39 => 36,
             40 => match state {
-                20 => 77,
-                _ => 74,
+                21 => 79,
+                _ => 76,
             },
             _ => 0,
         }
@@ -4586,14 +4624,14 @@ mod __parse__Query {
             }
             75 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
+                    states_to_pop: 3,
                     nonterminal_produced: 37,
                 }
             }
             76 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
-                    nonterminal_produced: 38,
+                    nonterminal_produced: 37,
                 }
             }
             77 => {
@@ -4605,13 +4643,13 @@ mod __parse__Query {
             78 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
-                    nonterminal_produced: 39,
+                    nonterminal_produced: 38,
                 }
             }
             79 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 3,
-                    nonterminal_produced: 40,
+                    states_to_pop: 1,
+                    nonterminal_produced: 39,
                 }
             }
             80 => {
@@ -4622,60 +4660,66 @@ mod __parse__Query {
             }
             81 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 10,
-                    nonterminal_produced: 41,
+                    states_to_pop: 3,
+                    nonterminal_produced: 40,
                 }
             }
             82 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 3,
+                    states_to_pop: 10,
                     nonterminal_produced: 41,
                 }
             }
             83 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 5,
+                    states_to_pop: 3,
                     nonterminal_produced: 41,
                 }
             }
             84 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 6,
+                    states_to_pop: 5,
                     nonterminal_produced: 41,
                 }
             }
             85 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 8,
+                    states_to_pop: 6,
                     nonterminal_produced: 41,
                 }
             }
             86 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
+                    states_to_pop: 8,
                     nonterminal_produced: 41,
                 }
             }
             87 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
+                    nonterminal_produced: 41,
+                }
+            }
+            88 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 1,
                     nonterminal_produced: 42,
                 }
             }
-            88 => __state_machine::SimulatedReduce::Accept,
-            89 => {
+            89 => __state_machine::SimulatedReduce::Accept,
+            90 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
                     nonterminal_produced: 44,
                 }
             }
-            90 => {
+            91 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
                     nonterminal_produced: 45,
                 }
             }
-            91 => {
+            92 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
                     nonterminal_produced: 46,
@@ -5027,6 +5071,9 @@ mod __parse__Query {
                 __reduce87(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
             }
             88 => {
+                __reduce88(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
+            }
+            89 => {
                 // __Query = Query => ActionFn(1);
                 let __sym0 = __pop_Variant25(__symbols);
                 let __start = __sym0.0;
@@ -5034,14 +5081,14 @@ mod __parse__Query {
                 let __nt = super::__action1::<>(input, __sym0);
                 return Some(Ok(__nt));
             }
-            89 => {
-                __reduce89(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
-            }
             90 => {
                 __reduce90(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
             }
             91 => {
                 __reduce91(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
+            }
+            92 => {
+                __reduce92(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
             }
             _ => panic!("invalid action code {}", __action)
         };
@@ -5373,13 +5420,13 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Constant> COMMA) = Constant, COMMA => ActionFn(70);
+        // (<Constant> COMMA) = Constant, COMMA => ActionFn(71);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant1(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action70::<>(input, __sym0, __sym1);
+        let __nt = super::__action71::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant1(__nt), __end));
         (2, 0)
     }
@@ -5392,10 +5439,10 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Constant> COMMA)* =  => ActionFn(68);
+        // (<Constant> COMMA)* =  => ActionFn(69);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action68::<>(input, &__start, &__end);
+        let __nt = super::__action69::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant2(__nt), __end));
         (0, 1)
     }
@@ -5408,11 +5455,11 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Constant> COMMA)* = (<Constant> COMMA)+ => ActionFn(69);
+        // (<Constant> COMMA)* = (<Constant> COMMA)+ => ActionFn(70);
         let __sym0 = __pop_Variant2(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action69::<>(input, __sym0);
+        let __nt = super::__action70::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant2(__nt), __end));
         (1, 1)
     }
@@ -5425,13 +5472,13 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Constant> COMMA)+ = Constant, COMMA => ActionFn(87);
+        // (<Constant> COMMA)+ = Constant, COMMA => ActionFn(88);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant1(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action87::<>(input, __sym0, __sym1);
+        let __nt = super::__action88::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant2(__nt), __end));
         (2, 2)
     }
@@ -5444,14 +5491,14 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Constant> COMMA)+ = (<Constant> COMMA)+, Constant, COMMA => ActionFn(88);
+        // (<Constant> COMMA)+ = (<Constant> COMMA)+, Constant, COMMA => ActionFn(89);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant1(__symbols);
         let __sym0 = __pop_Variant2(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action88::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action89::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant2(__nt), __end));
         (3, 2)
     }
@@ -5464,13 +5511,13 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<FieldDefinition> COMMA) = FieldDefinition, COMMA => ActionFn(73);
+        // (<FieldDefinition> COMMA) = FieldDefinition, COMMA => ActionFn(74);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant3(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action73::<>(input, __sym0, __sym1);
+        let __nt = super::__action74::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant3(__nt), __end));
         (2, 3)
     }
@@ -5483,10 +5530,10 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<FieldDefinition> COMMA)* =  => ActionFn(71);
+        // (<FieldDefinition> COMMA)* =  => ActionFn(72);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action71::<>(input, &__start, &__end);
+        let __nt = super::__action72::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant4(__nt), __end));
         (0, 4)
     }
@@ -5499,11 +5546,11 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<FieldDefinition> COMMA)* = (<FieldDefinition> COMMA)+ => ActionFn(72);
+        // (<FieldDefinition> COMMA)* = (<FieldDefinition> COMMA)+ => ActionFn(73);
         let __sym0 = __pop_Variant4(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action72::<>(input, __sym0);
+        let __nt = super::__action73::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant4(__nt), __end));
         (1, 4)
     }
@@ -5516,13 +5563,13 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<FieldDefinition> COMMA)+ = FieldDefinition, COMMA => ActionFn(91);
+        // (<FieldDefinition> COMMA)+ = FieldDefinition, COMMA => ActionFn(92);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant3(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action91::<>(input, __sym0, __sym1);
+        let __nt = super::__action92::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant4(__nt), __end));
         (2, 5)
     }
@@ -5535,14 +5582,14 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<FieldDefinition> COMMA)+ = (<FieldDefinition> COMMA)+, FieldDefinition, COMMA => ActionFn(92);
+        // (<FieldDefinition> COMMA)+ = (<FieldDefinition> COMMA)+, FieldDefinition, COMMA => ActionFn(93);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant3(__symbols);
         let __sym0 = __pop_Variant4(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action92::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action93::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant4(__nt), __end));
         (3, 5)
     }
@@ -5555,13 +5602,13 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<IdToken> COMMA) = IdToken, COMMA => ActionFn(64);
+        // (<IdToken> COMMA) = IdToken, COMMA => ActionFn(65);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action64::<>(input, __sym0, __sym1);
+        let __nt = super::__action65::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant5(__nt), __end));
         (2, 6)
     }
@@ -5574,10 +5621,10 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<IdToken> COMMA)* =  => ActionFn(62);
+        // (<IdToken> COMMA)* =  => ActionFn(63);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action62::<>(input, &__start, &__end);
+        let __nt = super::__action63::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant6(__nt), __end));
         (0, 7)
     }
@@ -5590,11 +5637,11 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<IdToken> COMMA)* = (<IdToken> COMMA)+ => ActionFn(63);
+        // (<IdToken> COMMA)* = (<IdToken> COMMA)+ => ActionFn(64);
         let __sym0 = __pop_Variant6(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action63::<>(input, __sym0);
+        let __nt = super::__action64::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant6(__nt), __end));
         (1, 7)
     }
@@ -5607,13 +5654,13 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<IdToken> COMMA)+ = IdToken, COMMA => ActionFn(95);
+        // (<IdToken> COMMA)+ = IdToken, COMMA => ActionFn(96);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action95::<>(input, __sym0, __sym1);
+        let __nt = super::__action96::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant6(__nt), __end));
         (2, 8)
     }
@@ -5626,14 +5673,14 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<IdToken> COMMA)+ = (<IdToken> COMMA)+, IdToken, COMMA => ActionFn(96);
+        // (<IdToken> COMMA)+ = (<IdToken> COMMA)+, IdToken, COMMA => ActionFn(97);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant5(__symbols);
         let __sym0 = __pop_Variant6(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action96::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action97::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant6(__nt), __end));
         (3, 8)
     }
@@ -5646,13 +5693,13 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<SelectField> COMMA) = SelectField, COMMA => ActionFn(67);
+        // (<SelectField> COMMA) = SelectField, COMMA => ActionFn(68);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant7(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action67::<>(input, __sym0, __sym1);
+        let __nt = super::__action68::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant7(__nt), __end));
         (2, 9)
     }
@@ -5665,10 +5712,10 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<SelectField> COMMA)* =  => ActionFn(65);
+        // (<SelectField> COMMA)* =  => ActionFn(66);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action65::<>(input, &__start, &__end);
+        let __nt = super::__action66::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant8(__nt), __end));
         (0, 10)
     }
@@ -5681,11 +5728,11 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<SelectField> COMMA)* = (<SelectField> COMMA)+ => ActionFn(66);
+        // (<SelectField> COMMA)* = (<SelectField> COMMA)+ => ActionFn(67);
         let __sym0 = __pop_Variant8(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action66::<>(input, __sym0);
+        let __nt = super::__action67::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant8(__nt), __end));
         (1, 10)
     }
@@ -5698,13 +5745,13 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<SelectField> COMMA)+ = SelectField, COMMA => ActionFn(99);
+        // (<SelectField> COMMA)+ = SelectField, COMMA => ActionFn(100);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant7(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action99::<>(input, __sym0, __sym1);
+        let __nt = super::__action100::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant8(__nt), __end));
         (2, 11)
     }
@@ -5717,14 +5764,14 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<SelectField> COMMA)+ = (<SelectField> COMMA)+, SelectField, COMMA => ActionFn(100);
+        // (<SelectField> COMMA)+ = (<SelectField> COMMA)+, SelectField, COMMA => ActionFn(101);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant7(__symbols);
         let __sym0 = __pop_Variant8(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action100::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action101::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant8(__nt), __end));
         (3, 11)
     }
@@ -5737,13 +5784,13 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Term> AND) = Term, AND => ActionFn(76);
+        // (<Term> AND) = Term, AND => ActionFn(77);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant9(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action76::<>(input, __sym0, __sym1);
+        let __nt = super::__action77::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant9(__nt), __end));
         (2, 12)
     }
@@ -5756,10 +5803,10 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Term> AND)* =  => ActionFn(74);
+        // (<Term> AND)* =  => ActionFn(75);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action74::<>(input, &__start, &__end);
+        let __nt = super::__action75::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant10(__nt), __end));
         (0, 13)
     }
@@ -5772,11 +5819,11 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Term> AND)* = (<Term> AND)+ => ActionFn(75);
+        // (<Term> AND)* = (<Term> AND)+ => ActionFn(76);
         let __sym0 = __pop_Variant10(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action75::<>(input, __sym0);
+        let __nt = super::__action76::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant10(__nt), __end));
         (1, 13)
     }
@@ -5789,13 +5836,13 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Term> AND)+ = Term, AND => ActionFn(103);
+        // (<Term> AND)+ = Term, AND => ActionFn(104);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant9(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action103::<>(input, __sym0, __sym1);
+        let __nt = super::__action104::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant10(__nt), __end));
         (2, 14)
     }
@@ -5808,14 +5855,14 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Term> AND)+ = (<Term> AND)+, Term, AND => ActionFn(104);
+        // (<Term> AND)+ = (<Term> AND)+, Term, AND => ActionFn(105);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant9(__symbols);
         let __sym0 = __pop_Variant10(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action104::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action105::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant10(__nt), __end));
         (3, 14)
     }
@@ -5828,14 +5875,14 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AddExpr = AddExpr, PLUS, MulExpr => ActionFn(40);
+        // AddExpr = AddExpr, PLUS, MulExpr => ActionFn(41);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant11(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action40::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action41::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (3, 15)
     }
@@ -5848,14 +5895,14 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AddExpr = AddExpr, MINUS, MulExpr => ActionFn(41);
+        // AddExpr = AddExpr, MINUS, MulExpr => ActionFn(42);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant11(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action41::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action42::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (3, 15)
     }
@@ -5868,11 +5915,11 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AddExpr = MulExpr => ActionFn(42);
+        // AddExpr = MulExpr => ActionFn(43);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action42::<>(input, __sym0);
+        let __nt = super::__action43::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (1, 15)
     }
@@ -5885,7 +5932,7 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AggregationFn = MAX, LPAREN, IdToken, RPAREN => ActionFn(13);
+        // AggregationFn = MAX, LPAREN, IdToken, RPAREN => ActionFn(14);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant5(__symbols);
@@ -5893,7 +5940,7 @@ mod __parse__Query {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action13::<>(input, __sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action14::<>(input, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant12(__nt), __end));
         (4, 16)
     }
@@ -5906,7 +5953,7 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AggregationFn = MIN, LPAREN, IdToken, RPAREN => ActionFn(14);
+        // AggregationFn = MIN, LPAREN, IdToken, RPAREN => ActionFn(15);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant5(__symbols);
@@ -5914,7 +5961,7 @@ mod __parse__Query {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action14::<>(input, __sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action15::<>(input, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant12(__nt), __end));
         (4, 16)
     }
@@ -5927,7 +5974,7 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AggregationFn = SUM, LPAREN, IdToken, RPAREN => ActionFn(15);
+        // AggregationFn = SUM, LPAREN, IdToken, RPAREN => ActionFn(16);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant5(__symbols);
@@ -5935,7 +5982,7 @@ mod __parse__Query {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action15::<>(input, __sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action16::<>(input, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant12(__nt), __end));
         (4, 16)
     }
@@ -5948,7 +5995,7 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AggregationFn = COUNT, LPAREN, IdToken, RPAREN => ActionFn(16);
+        // AggregationFn = COUNT, LPAREN, IdToken, RPAREN => ActionFn(17);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant5(__symbols);
@@ -5956,7 +6003,7 @@ mod __parse__Query {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action16::<>(input, __sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action17::<>(input, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant12(__nt), __end));
         (4, 16)
     }
@@ -5969,7 +6016,7 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AggregationFn = AVG, LPAREN, IdToken, RPAREN => ActionFn(17);
+        // AggregationFn = AVG, LPAREN, IdToken, RPAREN => ActionFn(18);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant5(__symbols);
@@ -5977,7 +6024,7 @@ mod __parse__Query {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action17::<>(input, __sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action18::<>(input, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant12(__nt), __end));
         (4, 16)
     }
@@ -5990,11 +6037,11 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // And<Term> = Term => ActionFn(105);
+        // And<Term> = Term => ActionFn(106);
         let __sym0 = __pop_Variant9(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action105::<>(input, __sym0);
+        let __nt = super::__action106::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant13(__nt), __end));
         (1, 17)
     }
@@ -6007,13 +6054,13 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // And<Term> = (<Term> AND)+, Term => ActionFn(106);
+        // And<Term> = (<Term> AND)+, Term => ActionFn(107);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant9(__symbols);
         let __sym0 = __pop_Variant10(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action106::<>(input, __sym0, __sym1);
+        let __nt = super::__action107::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant13(__nt), __end));
         (2, 17)
     }
@@ -6026,11 +6073,11 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<Constant> = Constant => ActionFn(89);
+        // Comma<Constant> = Constant => ActionFn(90);
         let __sym0 = __pop_Variant1(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action89::<>(input, __sym0);
+        let __nt = super::__action90::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant14(__nt), __end));
         (1, 18)
     }
@@ -6043,13 +6090,13 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<Constant> = (<Constant> COMMA)+, Constant => ActionFn(90);
+        // Comma<Constant> = (<Constant> COMMA)+, Constant => ActionFn(91);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant1(__symbols);
         let __sym0 = __pop_Variant2(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action90::<>(input, __sym0, __sym1);
+        let __nt = super::__action91::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant14(__nt), __end));
         (2, 18)
     }
@@ -6062,11 +6109,11 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<FieldDefinition> = FieldDefinition => ActionFn(93);
+        // Comma<FieldDefinition> = FieldDefinition => ActionFn(94);
         let __sym0 = __pop_Variant3(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action93::<>(input, __sym0);
+        let __nt = super::__action94::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (1, 19)
     }
@@ -6079,13 +6126,13 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<FieldDefinition> = (<FieldDefinition> COMMA)+, FieldDefinition => ActionFn(94);
+        // Comma<FieldDefinition> = (<FieldDefinition> COMMA)+, FieldDefinition => ActionFn(95);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant3(__symbols);
         let __sym0 = __pop_Variant4(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action94::<>(input, __sym0, __sym1);
+        let __nt = super::__action95::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (2, 19)
     }
@@ -6098,11 +6145,11 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<IdToken> = IdToken => ActionFn(97);
+        // Comma<IdToken> = IdToken => ActionFn(98);
         let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action97::<>(input, __sym0);
+        let __nt = super::__action98::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant16(__nt), __end));
         (1, 20)
     }
@@ -6115,13 +6162,13 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<IdToken> = (<IdToken> COMMA)+, IdToken => ActionFn(98);
+        // Comma<IdToken> = (<IdToken> COMMA)+, IdToken => ActionFn(99);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant5(__symbols);
         let __sym0 = __pop_Variant6(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action98::<>(input, __sym0, __sym1);
+        let __nt = super::__action99::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant16(__nt), __end));
         (2, 20)
     }
@@ -6134,11 +6181,11 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<SelectField> = SelectField => ActionFn(101);
+        // Comma<SelectField> = SelectField => ActionFn(102);
         let __sym0 = __pop_Variant7(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action101::<>(input, __sym0);
+        let __nt = super::__action102::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant17(__nt), __end));
         (1, 21)
     }
@@ -6151,13 +6198,13 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<SelectField> = (<SelectField> COMMA)+, SelectField => ActionFn(102);
+        // Comma<SelectField> = (<SelectField> COMMA)+, SelectField => ActionFn(103);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant7(__symbols);
         let __sym0 = __pop_Variant8(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action102::<>(input, __sym0, __sym1);
+        let __nt = super::__action103::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant17(__nt), __end));
         (2, 21)
     }
@@ -6170,11 +6217,11 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Constant = NULL => ActionFn(51);
+        // Constant = NULL => ActionFn(52);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action51::<>(input, __sym0);
+        let __nt = super::__action52::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant1(__nt), __end));
         (1, 22)
     }
@@ -6187,11 +6234,11 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Constant = I32Constant => ActionFn(52);
+        // Constant = I32Constant => ActionFn(53);
         let __sym0 = __pop_Variant21(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action52::<>(input, __sym0);
+        let __nt = super::__action53::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant1(__nt), __end));
         (1, 22)
     }
@@ -6204,11 +6251,11 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Constant = StringConstant => ActionFn(53);
+        // Constant = StringConstant => ActionFn(54);
         let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action53::<>(input, __sym0);
+        let __nt = super::__action54::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant1(__nt), __end));
         (1, 22)
     }
@@ -6221,7 +6268,7 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // CreateCommand = CREATE, TABLE, IdToken, LPAREN, Comma<FieldDefinition>, RPAREN => ActionFn(30);
+        // CreateCommand = CREATE, TABLE, IdToken, LPAREN, Comma<FieldDefinition>, RPAREN => ActionFn(31);
         assert!(__symbols.len() >= 6);
         let __sym5 = __pop_Variant0(__symbols);
         let __sym4 = __pop_Variant15(__symbols);
@@ -6231,7 +6278,7 @@ mod __parse__Query {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym5.2;
-        let __nt = super::__action30::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
+        let __nt = super::__action31::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
         __symbols.push((__start, __Symbol::Variant18(__nt), __end));
         (6, 23)
     }
@@ -6244,7 +6291,7 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // CreateCommand = CREATE, VIEW, IdToken, AS, Query => ActionFn(31);
+        // CreateCommand = CREATE, VIEW, IdToken, AS, Query => ActionFn(32);
         assert!(__symbols.len() >= 5);
         let __sym4 = __pop_Variant25(__symbols);
         let __sym3 = __pop_Variant0(__symbols);
@@ -6253,7 +6300,7 @@ mod __parse__Query {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym4.2;
-        let __nt = super::__action31::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4);
+        let __nt = super::__action32::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4);
         __symbols.push((__start, __Symbol::Variant18(__nt), __end));
         (5, 23)
     }
@@ -6266,7 +6313,7 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // CreateCommand = CREATE, INDEX, IdToken, ON, IdToken, LPAREN, IdToken, RPAREN => ActionFn(32);
+        // CreateCommand = CREATE, INDEX, IdToken, ON, IdToken, LPAREN, IdToken, RPAREN => ActionFn(33);
         assert!(__symbols.len() >= 8);
         let __sym7 = __pop_Variant0(__symbols);
         let __sym6 = __pop_Variant5(__symbols);
@@ -6278,7 +6325,7 @@ mod __parse__Query {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym7.2;
-        let __nt = super::__action32::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
+        let __nt = super::__action33::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
         __symbols.push((__start, __Symbol::Variant18(__nt), __end));
         (8, 23)
     }
@@ -6291,11 +6338,11 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Expression = AddExpr => ActionFn(39);
+        // Expression = AddExpr => ActionFn(40);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action39::<>(input, __sym0);
+        let __nt = super::__action40::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (1, 24)
     }
@@ -6308,14 +6355,14 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Factor = LPAREN, Expression, RPAREN => ActionFn(46);
+        // Factor = LPAREN, Expression, RPAREN => ActionFn(47);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant11(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action46::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action47::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (3, 25)
     }
@@ -6328,11 +6375,11 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Factor = NULL => ActionFn(47);
+        // Factor = NULL => ActionFn(48);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action47::<>(input, __sym0);
+        let __nt = super::__action48::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (1, 25)
     }
@@ -6345,11 +6392,11 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Factor = I32Constant => ActionFn(48);
+        // Factor = I32Constant => ActionFn(49);
         let __sym0 = __pop_Variant21(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action48::<>(input, __sym0);
+        let __nt = super::__action49::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (1, 25)
     }
@@ -6362,11 +6409,11 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Factor = StringConstant => ActionFn(49);
+        // Factor = StringConstant => ActionFn(50);
         let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action49::<>(input, __sym0);
+        let __nt = super::__action50::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (1, 25)
     }
@@ -6379,11 +6426,11 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Factor = IdToken => ActionFn(50);
+        // Factor = IdToken => ActionFn(51);
         let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action50::<>(input, __sym0);
+        let __nt = super::__action51::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (1, 25)
     }
@@ -6396,13 +6443,13 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // FieldDefinition = IdToken, FieldType => ActionFn(33);
+        // FieldDefinition = IdToken, FieldType => ActionFn(34);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant20(__symbols);
         let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action33::<>(input, __sym0, __sym1);
+        let __nt = super::__action34::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant3(__nt), __end));
         (2, 26)
     }
@@ -6449,11 +6496,11 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // FieldType = I32 => ActionFn(34);
+        // FieldType = I32 => ActionFn(35);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action34::<>(input, __sym0);
+        let __nt = super::__action35::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant20(__nt), __end));
         (1, 28)
     }
@@ -6466,7 +6513,7 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // FieldType = VARCHAR, LPAREN, I32Constant, RPAREN => ActionFn(35);
+        // FieldType = VARCHAR, LPAREN, I32Constant, RPAREN => ActionFn(36);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant21(__symbols);
@@ -6474,7 +6521,7 @@ mod __parse__Query {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action35::<>(input, __sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action36::<>(input, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant20(__nt), __end));
         (4, 28)
     }
@@ -6487,11 +6534,11 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // I32Constant = I32_LITERAL => ActionFn(54);
+        // I32Constant = I32_LITERAL => ActionFn(55);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action54::<>(input, __sym0);
+        let __nt = super::__action55::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant21(__nt), __end));
         (1, 29)
     }
@@ -6504,11 +6551,11 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // IdToken = ID => ActionFn(56);
+        // IdToken = ID => ActionFn(57);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action56::<>(input, __sym0);
+        let __nt = super::__action57::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant5(__nt), __end));
         (1, 30)
     }
@@ -6521,14 +6568,14 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // MulExpr = MulExpr, STAR, Factor => ActionFn(43);
+        // MulExpr = MulExpr, STAR, Factor => ActionFn(44);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant11(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action43::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action44::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (3, 31)
     }
@@ -6541,14 +6588,14 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // MulExpr = MulExpr, SLASH, Factor => ActionFn(44);
+        // MulExpr = MulExpr, SLASH, Factor => ActionFn(45);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant11(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action44::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action45::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (3, 31)
     }
@@ -6561,11 +6608,11 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // MulExpr = Factor => ActionFn(45);
+        // MulExpr = Factor => ActionFn(46);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action45::<>(input, __sym0);
+        let __nt = super::__action46::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (1, 31)
     }
@@ -6578,14 +6625,14 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // OptGroupBy = GROUP, BY, Comma<IdToken> => ActionFn(20);
+        // OptGroupBy = GROUP, BY, Comma<IdToken> => ActionFn(21);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant16(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action20::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action21::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant22(__nt), __end));
         (3, 32)
     }
@@ -6598,10 +6645,10 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // OptGroupBy =  => ActionFn(21);
+        // OptGroupBy =  => ActionFn(22);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action21::<>(input, &__start, &__end);
+        let __nt = super::__action22::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant22(__nt), __end));
         (0, 32)
     }
@@ -6614,14 +6661,14 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // OptOrderBy = ORDER, BY, Comma<IdToken> => ActionFn(22);
+        // OptOrderBy = ORDER, BY, Comma<IdToken> => ActionFn(23);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant16(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action22::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action23::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant22(__nt), __end));
         (3, 33)
     }
@@ -6634,10 +6681,10 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // OptOrderBy =  => ActionFn(23);
+        // OptOrderBy =  => ActionFn(24);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action23::<>(input, &__start, &__end);
+        let __nt = super::__action24::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant22(__nt), __end));
         (0, 33)
     }
@@ -6650,13 +6697,13 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // OptPredicate = WHERE, Predicate => ActionFn(18);
+        // OptPredicate = WHERE, Predicate => ActionFn(19);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant24(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action18::<>(input, __sym0, __sym1);
+        let __nt = super::__action19::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant23(__nt), __end));
         (2, 34)
     }
@@ -6669,10 +6716,10 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // OptPredicate =  => ActionFn(19);
+        // OptPredicate =  => ActionFn(20);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action19::<>(input, &__start, &__end);
+        let __nt = super::__action20::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant23(__nt), __end));
         (0, 34)
     }
@@ -6685,11 +6732,11 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Predicate = And<Term> => ActionFn(36);
+        // Predicate = And<Term> => ActionFn(37);
         let __sym0 = __pop_Variant13(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action36::<>(input, __sym0);
+        let __nt = super::__action37::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant24(__nt), __end));
         (1, 35)
     }
@@ -6763,15 +6810,35 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // SelectField = AggregationFn => ActionFn(12);
+        // SelectField = AggregationFn, AS, IdToken => ActionFn(12);
+        assert!(__symbols.len() >= 3);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant12(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym2.2;
+        let __nt = super::__action12::<>(input, __sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant7(__nt), __end));
+        (3, 37)
+    }
+    fn __reduce76<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // SelectField = AggregationFn => ActionFn(13);
         let __sym0 = __pop_Variant12(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action12::<>(input, __sym0);
+        let __nt = super::__action13::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant7(__nt), __end));
         (1, 37)
     }
-    fn __reduce76<
+    fn __reduce77<
         'input,
     >(
         input: &'input str,
@@ -6788,7 +6855,7 @@ mod __parse__Query {
         __symbols.push((__start, __Symbol::Variant26(__nt), __end));
         (1, 38)
     }
-    fn __reduce77<
+    fn __reduce78<
         'input,
     >(
         input: &'input str,
@@ -6805,23 +6872,6 @@ mod __parse__Query {
         __symbols.push((__start, __Symbol::Variant26(__nt), __end));
         (1, 38)
     }
-    fn __reduce78<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // StringConstant = STRING_LITERAL => ActionFn(55);
-        let __sym0 = __pop_Variant0(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action55::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant5(__nt), __end));
-        (1, 39)
-    }
     fn __reduce79<
         'input,
     >(
@@ -6831,16 +6881,13 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Term = Expression, IS, NULL => ActionFn(37);
-        assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant11(__symbols);
+        // StringConstant = STRING_LITERAL => ActionFn(56);
+        let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym2.2;
-        let __nt = super::__action37::<>(input, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant9(__nt), __end));
-        (3, 40)
+        let __end = __sym0.2;
+        let __nt = super::__action56::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant5(__nt), __end));
+        (1, 39)
     }
     fn __reduce80<
         'input,
@@ -6851,9 +6898,9 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Term = Expression, EQ, Expression => ActionFn(38);
+        // Term = Expression, IS, NULL => ActionFn(38);
         assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant11(__symbols);
+        let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
@@ -6871,7 +6918,27 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // UpdateCommand = INSERT, INTO, IdToken, LPAREN, Comma<IdToken>, RPAREN, VALUES, LPAREN, Comma<Constant>, RPAREN => ActionFn(24);
+        // Term = Expression, EQ, Expression => ActionFn(39);
+        assert!(__symbols.len() >= 3);
+        let __sym2 = __pop_Variant11(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant11(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym2.2;
+        let __nt = super::__action39::<>(input, __sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant9(__nt), __end));
+        (3, 40)
+    }
+    fn __reduce82<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // UpdateCommand = INSERT, INTO, IdToken, LPAREN, Comma<IdToken>, RPAREN, VALUES, LPAREN, Comma<Constant>, RPAREN => ActionFn(25);
         assert!(__symbols.len() >= 10);
         let __sym9 = __pop_Variant0(__symbols);
         let __sym8 = __pop_Variant14(__symbols);
@@ -6885,29 +6952,9 @@ mod __parse__Query {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym9.2;
-        let __nt = super::__action24::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9);
+        let __nt = super::__action25::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9);
         __symbols.push((__start, __Symbol::Variant27(__nt), __end));
         (10, 41)
-    }
-    fn __reduce82<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // UpdateCommand = DELETE, FROM, IdToken => ActionFn(25);
-        assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant5(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym2.2;
-        let __nt = super::__action25::<>(input, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant27(__nt), __end));
-        (3, 41)
     }
     fn __reduce83<
         'input,
@@ -6918,18 +6965,16 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // UpdateCommand = DELETE, FROM, IdToken, WHERE, Predicate => ActionFn(26);
-        assert!(__symbols.len() >= 5);
-        let __sym4 = __pop_Variant24(__symbols);
-        let __sym3 = __pop_Variant0(__symbols);
+        // UpdateCommand = DELETE, FROM, IdToken => ActionFn(26);
+        assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant5(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym4.2;
-        let __nt = super::__action26::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4);
+        let __end = __sym2.2;
+        let __nt = super::__action26::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant27(__nt), __end));
-        (5, 41)
+        (3, 41)
     }
     fn __reduce84<
         'input,
@@ -6940,19 +6985,18 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // UpdateCommand = MODIFY, IdToken, SET, IdToken, EQ, Expression => ActionFn(27);
-        assert!(__symbols.len() >= 6);
-        let __sym5 = __pop_Variant11(__symbols);
-        let __sym4 = __pop_Variant0(__symbols);
-        let __sym3 = __pop_Variant5(__symbols);
-        let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant5(__symbols);
+        // UpdateCommand = DELETE, FROM, IdToken, WHERE, Predicate => ActionFn(27);
+        assert!(__symbols.len() >= 5);
+        let __sym4 = __pop_Variant24(__symbols);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym5.2;
-        let __nt = super::__action27::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
+        let __end = __sym4.2;
+        let __nt = super::__action27::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4);
         __symbols.push((__start, __Symbol::Variant27(__nt), __end));
-        (6, 41)
+        (5, 41)
     }
     fn __reduce85<
         'input,
@@ -6963,7 +7007,30 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // UpdateCommand = MODIFY, IdToken, SET, IdToken, EQ, Expression, WHERE, Predicate => ActionFn(28);
+        // UpdateCommand = MODIFY, IdToken, SET, IdToken, EQ, Expression => ActionFn(28);
+        assert!(__symbols.len() >= 6);
+        let __sym5 = __pop_Variant11(__symbols);
+        let __sym4 = __pop_Variant0(__symbols);
+        let __sym3 = __pop_Variant5(__symbols);
+        let __sym2 = __pop_Variant0(__symbols);
+        let __sym1 = __pop_Variant5(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym5.2;
+        let __nt = super::__action28::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
+        __symbols.push((__start, __Symbol::Variant27(__nt), __end));
+        (6, 41)
+    }
+    fn __reduce86<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // UpdateCommand = MODIFY, IdToken, SET, IdToken, EQ, Expression, WHERE, Predicate => ActionFn(29);
         assert!(__symbols.len() >= 8);
         let __sym7 = __pop_Variant24(__symbols);
         let __sym6 = __pop_Variant0(__symbols);
@@ -6975,11 +7042,11 @@ mod __parse__Query {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym7.2;
-        let __nt = super::__action28::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
+        let __nt = super::__action29::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
         __symbols.push((__start, __Symbol::Variant27(__nt), __end));
         (8, 41)
     }
-    fn __reduce86<
+    fn __reduce87<
         'input,
     >(
         input: &'input str,
@@ -6988,15 +7055,15 @@ mod __parse__Query {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // UpdateCommand = CreateCommand => ActionFn(29);
+        // UpdateCommand = CreateCommand => ActionFn(30);
         let __sym0 = __pop_Variant18(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action29::<>(input, __sym0);
+        let __nt = super::__action30::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant27(__nt), __end));
         (1, 41)
     }
-    fn __reduce87<
+    fn __reduce88<
         'input,
     >(
         input: &'input str,
@@ -7013,7 +7080,7 @@ mod __parse__Query {
         __symbols.push((__start, __Symbol::Variant24(__nt), __end));
         (1, 42)
     }
-    fn __reduce89<
+    fn __reduce90<
         'input,
     >(
         input: &'input str,
@@ -7030,7 +7097,7 @@ mod __parse__Query {
         __symbols.push((__start, __Symbol::Variant26(__nt), __end));
         (1, 44)
     }
-    fn __reduce90<
+    fn __reduce91<
         'input,
     >(
         input: &'input str,
@@ -7047,7 +7114,7 @@ mod __parse__Query {
         __symbols.push((__start, __Symbol::Variant9(__nt), __end));
         (1, 45)
     }
-    fn __reduce91<
+    fn __reduce92<
         'input,
     >(
         input: &'input str,
@@ -7127,95 +7194,95 @@ mod __parse__Statement {
     }
     const __ACTION: &[i16] = &[
         // State 0
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 49, 50, 0, 0, 0, 0, 51, 0, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 50, 51, 0, 0, 0, 0, 52, 0, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0,
         // State 1
-        0, 53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 54, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 2
-        0, 53, 72, 67, 0, 10, 0, 71, 0, 0, 0, 0, 0, 0, 65, 0, 66, 0, 0, 0, 0, 0, 0, 0, 0, 0, 68, 69, 0, 70, 0, 0, 0, 0, 73, 0, 0, 0, 0, 0,
+        0, 54, 73, 68, 0, 10, 0, 72, 0, 0, 0, 0, 0, 0, 66, 0, 67, 0, 0, 0, 0, 0, 0, 0, 0, 0, 69, 70, 0, 71, 0, 0, 0, 0, 74, 0, 0, 0, 0, 0,
         // State 3
-        0, 53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 54, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 4
-        0, 53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 54, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 5
-        0, 53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 54, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 6
-        0, 53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 54, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 7
-        0, 53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 54, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 8
-        0, 53, 72, 67, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 65, 0, 66, 0, 0, 0, 0, 0, 0, 0, 0, 0, 68, 69, 0, 70, 0, 0, 0, 0, 73, 0, 0, 0, 0, 0,
+        0, 54, 73, 68, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 66, 0, 67, 0, 0, 0, 0, 0, 0, 0, 0, 0, 69, 70, 0, 71, 0, 0, 0, 0, 74, 0, 0, 0, 0, 0,
         // State 9
-        0, 53, 72, 67, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 70, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 54, 73, 68, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 71, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 10
-        0, 53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 54, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 11
-        0, 53, 72, 67, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 70, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 54, 73, 68, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 71, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 12
-        0, 53, 72, 67, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 70, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 54, 73, 68, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 71, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 13
-        0, 53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 54, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 14
-        0, 53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 54, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 15
-        0, 53, 72, 67, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 70, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 54, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 16
-        0, 53, 72, 67, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 70, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 54, 73, 68, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 71, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 17
-        0, 53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 54, 73, 68, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 71, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 18
-        0, 53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 54, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 19
-        0, 53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 54, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 20
-        0, 53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 54, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 21
-        0, 53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 54, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 22
-        0, 53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 54, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 23
-        0, 53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 54, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 24
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0,
+        0, 54, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 25
-        0, 53, 72, 67, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 70, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0,
         // State 26
-        0, 53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 54, 73, 68, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 71, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 27
-        0, 53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 54, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 28
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -71, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -71, 0, 0, 0, 0, 0, 0, 0, 35,
+        0, 54, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 29
-        0, 53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -71, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -71, 0, 0, 0, 0, 0, 0, 0, 36,
         // State 30
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 116, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 117, 0, 0,
+        0, 54, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 31
-        0, 53, 72, 67, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 70, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 118, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 119, 0, 0,
         // State 32
-        0, 53, 72, 67, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 70, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 54, 73, 68, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 71, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 33
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 124, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -67, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 54, 73, 68, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 71, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 34
-        0, 53, 72, 67, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 70, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 126, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -67, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 35
-        0, 53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 54, 73, 68, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 71, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 36
-        0, 53, 72, 67, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 70, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 54, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 37
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 133, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 54, 73, 68, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 71, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 38
-        0, 0, 0, 67, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 135, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 39
-        0, 53, 72, 67, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 70, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 68, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 40
-        0, 53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 54, 73, 68, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 71, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 41
-        0, 0, 72, 67, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 143, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 54, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 42
-        0, 53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 73, 68, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 145, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 43
-        0, 0, 72, 67, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 143, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 54, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 44
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 73, 68, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 145, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 45
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 46
@@ -7223,204 +7290,208 @@ mod __parse__Statement {
         // State 47
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 48
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 6, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 49
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 6, 0,
         // State 50
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 51
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 52
-        0, 0, 0, 0, -62, -62, -62, -62, -62, -62, -62, -62, -62, -62, 0, 0, 0, 0, 0, -62, -62, -62, 0, 0, 0, -62, 0, 0, 0, 0, -62, -62, 0, -62, 0, 0, 0, -62, 0, -62,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 0, 0, 0, 0, 0, 0,
         // State 53
-        0, 0, 0, 0, 12, 0, -50, 0, 13, -50, 0, -50, -50, -50, 0, 0, 0, 0, 0, -50, -50, 0, 0, 0, 0, -50, 0, 0, 0, 0, 0, -50, 0, 0, 0, 0, 0, 0, 0, -50,
+        0, 0, 0, 0, -62, -62, -62, -62, -62, -62, -62, -62, -62, -62, 0, 0, 0, 0, 0, -62, -62, -62, 0, 0, 0, -62, 0, 0, 0, 0, -62, -62, 0, -62, 0, 0, 0, -62, 0, -62,
         // State 54
-        0, 0, 0, 0, 0, 0, 0, 0, 0, -76, 0, 0, 0, 0, 0, 0, 0, 0, 0, -76, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 12, 0, -50, 0, 13, -50, 0, -50, -50, -50, 0, 0, 0, 0, 0, -50, -50, 0, 0, 0, 0, -50, 0, 0, 0, 0, 0, -50, 0, 0, 0, 0, 0, 0, 0, -50,
         // State 55
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -58, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, -77, 0, 0, 0, 14, 0, 0, 0, 0, 0, -77, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 56
-        0, 0, 0, 0, 0, 0, 0, 0, 0, -75, 0, 0, 0, 14, 0, 0, 0, 0, 0, -75, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -58, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 57
-        0, 0, 0, 0, -65, 0, -65, -65, -65, -65, -65, -65, -65, -65, 0, 0, 0, 0, 0, -65, -65, 0, 0, 0, 0, -65, 0, 0, 0, 0, 0, -65, 0, 0, 0, 0, 0, 0, 0, -65,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, -75, 0, 0, 0, 15, 0, 0, 0, 0, 0, -75, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 58
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -65, 0, -65, -65, -65, -65, -65, -65, -65, -65, 0, 0, 0, 0, 0, -65, -65, 0, 0, 0, 0, -65, 0, 0, 0, 0, 0, -65, 0, 0, 0, 0, 0, 0, 0, -65,
         // State 59
-        0, 0, 0, 0, -53, 0, -53, -53, -53, -53, -53, -53, -53, -53, 0, 0, 0, 0, 0, -53, -53, 0, 0, 0, 0, -53, 0, 0, 0, 0, 0, -53, 0, 0, 0, 0, 0, 0, 0, -53,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 60
-        0, 0, 0, 0, -55, 0, -55, -55, -55, -55, -55, -55, -55, -55, 0, 0, 0, 0, 0, -55, -55, 0, 0, 0, 0, -55, 0, 0, 0, 0, 0, -55, 0, 0, 0, 0, 0, 0, 0, -55,
+        0, 0, 0, 0, -53, 0, -53, -53, -53, -53, -53, -53, -53, -53, 0, 0, 0, 0, 0, -53, -53, 0, 0, 0, 0, -53, 0, 0, 0, 0, 0, -53, 0, 0, 0, 0, 0, 0, 0, -53,
         // State 61
-        0, 0, 0, 0, -28, 0, -28, 17, -28, -28, 16, -28, -28, -28, 0, 0, 0, 0, 0, -28, -28, 0, 0, 0, 0, -28, 0, 0, 0, 0, 0, -28, 0, 0, 0, 0, 0, 0, 0, -28,
+        0, 0, 0, 0, -55, 0, -55, -55, -55, -55, -55, -55, -55, -55, 0, 0, 0, 0, 0, -55, -55, 0, 0, 0, 0, -55, 0, 0, 0, 0, 0, -55, 0, 0, 0, 0, 0, 0, 0, -55,
         // State 62
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 80, 0, 0, 0, 0, 0, 0, 0, 0, 0, -42, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -28, 0, -28, 18, -28, -28, 17, -28, -28, -28, 0, 0, 0, 0, 0, -28, -28, 0, 0, 0, 0, -28, 0, 0, 0, 0, 0, -28, 0, 0, 0, 0, 0, 0, 0, -28,
         // State 63
-        0, 0, 0, 0, -54, 0, -54, -54, -54, -54, -54, -54, -54, -54, 0, 0, 0, 0, 0, -54, -54, 0, 0, 0, 0, -54, 0, 0, 0, 0, 0, -54, 0, 0, 0, 0, 0, 0, 0, -54,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 81, 0, 0, 0, 0, 0, 0, 0, 0, 0, -42, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 64
-        0, 0, 0, 0, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -54, 0, -54, -54, -54, -54, -54, -54, -54, -54, 0, 0, 0, 0, 0, -54, -54, 0, 0, 0, 0, -54, 0, 0, 0, 0, 0, -54, 0, 0, 0, 0, 0, 0, 0, -54,
         // State 65
         0, 0, 0, 0, 0, 19, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 66
-        0, 0, 0, 0, -61, 0, -61, -61, -61, -61, -61, -61, -61, -61, 0, 0, 0, 0, 0, -61, -61, 0, 0, 0, 0, -61, 0, 0, 0, 0, 0, -61, 0, 0, 0, 0, 0, 0, 0, -61,
-        // State 67
         0, 0, 0, 0, 0, 20, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 67
+        0, 0, 0, 0, -61, 0, -61, -61, -61, -61, -61, -61, -61, -61, 0, 0, 0, 0, 0, -61, -61, 0, 0, 0, 0, -61, 0, 0, 0, 0, 0, -61, 0, 0, 0, 0, 0, 0, 0, -61,
         // State 68
         0, 0, 0, 0, 0, 21, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 69
-        0, 0, 0, 0, -52, 0, -52, -52, -52, -52, -52, -52, -52, -52, 0, 0, 0, 0, 0, -52, -52, 0, 0, 0, 0, -52, 0, 0, 0, 0, 0, -52, 0, 0, 0, 0, 0, 0, 0, -52,
-        // State 70
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -57, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        // State 71
-        0, 0, 0, 0, -79, 0, -79, -79, -79, -79, -79, -79, -79, -79, 0, 0, 0, 0, 0, -79, -79, 0, 0, 0, 0, -79, 0, 0, 0, 0, 0, -79, 0, 0, 0, 0, 0, 0, 0, -79,
-        // State 72
         0, 0, 0, 0, 0, 22, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 70
+        0, 0, 0, 0, -52, 0, -52, -52, -52, -52, -52, -52, -52, -52, 0, 0, 0, 0, 0, -52, -52, 0, 0, 0, 0, -52, 0, 0, 0, 0, 0, -52, 0, 0, 0, 0, 0, 0, 0, -52,
+        // State 71
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -57, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 72
+        0, 0, 0, 0, -80, 0, -80, -80, -80, -80, -80, -80, -80, -80, 0, 0, 0, 0, 0, -80, -80, 0, 0, 0, 0, -80, 0, 0, 0, 0, 0, -80, 0, 0, 0, 0, 0, 0, 0, -80,
         // State 73
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 23, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 23, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 74
-        0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 75
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 76
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 26,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 26, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 77
-        0, 0, 0, 0, 0, 27, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 27,
         // State 78
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 83, 0, 0, 0, 0, 0, 0, 0, 0, 0, -43, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 28, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 79
-        0, -19, -19, -19, 0, -19, 0, 0, 0, 0, 0, 0, 0, 0, -19, 0, -19, 0, 0, 0, 0, 0, 0, 0, 0, 0, -19, -19, 0, -19, 0, 0, 0, 0, -19, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 84, 0, 0, 0, 0, 0, 0, 0, 0, 0, -43, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 80
-        0, 0, 0, 0, 0, 0, 92, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, -19, -19, -19, 0, -19, 0, 0, 0, 0, 0, 0, 0, 0, -19, 0, -19, 0, 0, 0, 0, 0, 0, 0, 0, 0, -19, -19, 0, -19, 0, 0, 0, 0, -19, 0, 0, 0, 0, 0,
         // State 81
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 33, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 94, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 82
-        0, -20, -20, -20, 0, -20, 0, 0, 0, 0, 0, 0, 0, 0, -20, 0, -20, 0, 0, 0, 0, 0, 0, 0, 0, 0, -20, -20, 0, -20, 0, 0, 0, 0, -20, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 34, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 83
-        0, 0, 0, 0, -27, 0, -27, 17, -27, -27, 16, -27, -27, -27, 0, 0, 0, 0, 0, -27, -27, 0, 0, 0, 0, -27, 0, 0, 0, 0, 0, -27, 0, 0, 0, 0, 0, 0, 0, -27,
+        0, -20, -20, -20, 0, -20, 0, 0, 0, 0, 0, 0, 0, 0, -20, 0, -20, 0, 0, 0, 0, 0, 0, 0, 0, 0, -20, -20, 0, -20, 0, 0, 0, 0, -20, 0, 0, 0, 0, 0,
         // State 84
-        0, 0, 0, 0, -26, 0, -26, 17, -26, -26, 16, -26, -26, -26, 0, 0, 0, 0, 0, -26, -26, 0, 0, 0, 0, -26, 0, 0, 0, 0, 0, -26, 0, 0, 0, 0, 0, 0, 0, -26,
+        0, 0, 0, 0, -27, 0, -27, 18, -27, -27, 17, -27, -27, -27, 0, 0, 0, 0, 0, -27, -27, 0, 0, 0, 0, -27, 0, 0, 0, 0, 0, -27, 0, 0, 0, 0, 0, 0, 0, -27,
         // State 85
-        0, 0, 0, 0, 0, 0, 0, 0, 0, -74, 0, 0, 0, 0, 0, 0, 0, 0, 0, -74, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -26, 0, -26, 18, -26, -26, 17, -26, -26, -26, 0, 0, 0, 0, 0, -26, -26, 0, 0, 0, 0, -26, 0, 0, 0, 0, 0, -26, 0, 0, 0, 0, 0, 0, 0, -26,
         // State 86
-        0, 0, 0, 0, 0, 0, -40, 0, 0, 106, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -40, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -40, 0, 0, 0, 0, 0, 0, 0, -40,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, -76, 0, 0, 0, 0, 0, 0, 0, 0, 0, -76, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 87
-        0, 0, 0, 0, -64, 0, -64, -64, -64, -64, -64, -64, -64, -64, 0, 0, 0, 0, 0, -64, -64, 0, 0, 0, 0, -64, 0, 0, 0, 0, 0, -64, 0, 0, 0, 0, 0, 0, 0, -64,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, -74, 0, 0, 0, 0, 0, 0, 0, 0, 0, -74, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 88
-        0, 0, 0, 0, -63, 0, -63, -63, -63, -63, -63, -63, -63, -63, 0, 0, 0, 0, 0, -63, -63, 0, 0, 0, 0, -63, 0, 0, 0, 0, 0, -63, 0, 0, 0, 0, 0, 0, 0, -63,
+        0, 0, 0, 0, 0, 0, -40, 0, 0, 108, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -40, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -40, 0, 0, 0, 0, 0, 0, 0, -40,
         // State 89
-        0, 0, 0, 0, 0, 0, 107, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -64, 0, -64, -64, -64, -64, -64, -64, -64, -64, 0, 0, 0, 0, 0, -64, -64, 0, 0, 0, 0, -64, 0, 0, 0, 0, 0, -64, 0, 0, 0, 0, 0, 0, 0, -64,
         // State 90
-        0, 0, 0, 0, 0, 0, 108, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -63, 0, -63, -63, -63, -63, -63, -63, -63, -63, 0, 0, 0, 0, 0, -63, -63, 0, 0, 0, 0, -63, 0, 0, 0, 0, 0, -63, 0, 0, 0, 0, 0, 0, 0, -63,
         // State 91
-        0, 0, 0, 0, -51, 0, -51, -51, -51, -51, -51, -51, -51, -51, 0, 0, 0, 0, 0, -51, -51, 0, 0, 0, 0, -51, 0, 0, 0, 0, 0, -51, 0, 0, 0, 0, 0, 0, 0, -51,
-        // State 92
         0, 0, 0, 0, 0, 0, 109, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        // State 93
+        // State 92
         0, 0, 0, 0, 0, 0, 110, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 93
+        0, 0, 0, 0, -51, 0, -51, -51, -51, -51, -51, -51, -51, -51, 0, 0, 0, 0, 0, -51, -51, 0, 0, 0, 0, -51, 0, 0, 0, 0, 0, -51, 0, 0, 0, 0, 0, 0, 0, -51,
         // State 94
         0, 0, 0, 0, 0, 0, 111, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 95
-        0, 0, 0, 0, 0, 36, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 112, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 96
         0, 0, 0, 0, 0, 0, 113, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 97
-        0, 0, 0, 0, 0, 0, -38, 0, 0, 114, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 37, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 98
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 115, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 99
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -72, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -72, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, -38, 0, 0, 116, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 100
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 37, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 119, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 101
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -72, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -72, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 102
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 120, 0, 0, 0, 0, 0, 0, 0, -34, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -34, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 38, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 121, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 103
-        0, 0, 0, 0, 0, 0, 121, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 104
-        0, 0, 0, 0, 0, 0, -41, 0, 0, 123, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -41, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -41, 0, 0, 0, 0, 0, 0, 0, -41,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 122, 0, 0, 0, 0, 0, 0, 0, -34, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -34, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 105
-        0, -14, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 123, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 106
-        0, 0, 0, 0, 0, 0, 0, 0, 0, -33, 0, 0, 0, 0, 0, 0, 0, 0, 0, -33, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, -41, 0, 0, 125, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -41, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -41, 0, 0, 0, 0, 0, 0, 0, -41,
         // State 107
-        0, 0, 0, 0, 0, 0, 0, 0, 0, -32, 0, 0, 0, 0, 0, 0, 0, 0, 0, -32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, -14, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 108
-        0, 0, 0, 0, 0, 0, 0, 0, 0, -29, 0, 0, 0, 0, 0, 0, 0, 0, 0, -29, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, -33, 0, 0, 0, -33, 0, 0, 0, 0, 0, -33, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 109
-        0, 0, 0, 0, 0, 0, 0, 0, 0, -30, 0, 0, 0, 0, 0, 0, 0, 0, 0, -30, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, -32, 0, 0, 0, -32, 0, 0, 0, 0, 0, -32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 110
-        0, 0, 0, 0, 0, 0, 0, 0, 0, -31, 0, 0, 0, 0, 0, 0, 0, 0, 0, -31, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, -29, 0, 0, 0, -29, 0, 0, 0, 0, 0, -29, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 111
-        0, 0, 0, 0, 0, 0, -39, 0, 0, 127, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, -30, 0, 0, 0, -30, 0, 0, 0, 0, 0, -30, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 112
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, -31, 0, 0, 0, -31, 0, 0, 0, 0, 0, -31, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 113
-        0, -9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, -39, 0, 0, 129, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 114
-        0, 0, 0, 0, 0, 0, -56, 0, 0, -56, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        // State 115
-        0, 0, 0, 0, 0, 0, -59, 0, 0, -59, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        // State 116
-        0, 0, 0, 0, 0, 39, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        // State 117
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128, 0, 0, 0, 0, 0, 0, 0, -35, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -35, 0, 0, 0, 0, 0, 0, 0, 0,
-        // State 118
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 130, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        // State 119
-        0, -24, -24, -24, 0, -24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        // State 120
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 131, 0, 0, 0,
-        // State 121
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 40,
-        // State 122
-        0, -15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        // State 123
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        // State 124
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -70, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -70, 0, 0, 0, 0, 0, 0, 0, 0,
-        // State 125
-        0, 0, 0, 0, 0, 0, 134, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        // State 126
-        0, -10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        // State 127
-        0, -25, -25, -25, 0, -25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        // State 128
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -81, 0, 0, 0, 0, 0, 0, 0, -81, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -81, 0, 0, 0, 0, 0, 0, 0, 0,
-        // State 129
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -80, 0, 0, 0, 0, 0, 0, 0, -80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -80, 0, 0, 0, 0, 0, 0, 0, 0,
-        // State 130
-        0, 0, 0, 0, 0, 42, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        // State 131
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 115
+        0, -9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 116
+        0, 0, 0, 0, 0, 0, -56, 0, 0, -56, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 117
+        0, 0, 0, 0, 0, 0, -59, 0, 0, -59, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 118
+        0, 0, 0, 0, 0, 40, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 119
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 130, 0, 0, 0, 0, 0, 0, 0, -35, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -35, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 120
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 132, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 121
+        0, -24, -24, -24, 0, -24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 122
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 133, 0, 0, 0,
+        // State 123
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 41,
+        // State 124
+        0, -15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 125
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 42, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 126
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -70, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -70, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 127
+        0, 0, 0, 0, 0, 0, 136, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 128
+        0, -10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 129
+        0, -25, -25, -25, 0, -25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 130
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -82, 0, 0, 0, 0, 0, 0, 0, -82, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -82, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 131
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -81, 0, 0, 0, 0, 0, 0, 0, -81, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -81, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 132
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 43, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 43, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 133
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 134
-        0, 0, 0, 0, 0, 0, 138, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 44, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 135
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 136
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -66, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 140, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 137
-        0, 0, 0, 0, 0, 0, -60, 0, 0, -60, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        // State 138
-        0, 0, 0, 0, 0, 0, 146, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        // State 139
-        0, 0, 0, 0, 0, 0, -36, 0, 0, 147, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        // State 140
-        0, 0, 0, 0, 0, 0, -45, 0, 0, -45, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        // State 141
-        0, 0, 0, 0, 0, 0, -46, 0, 0, -46, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        // State 142
-        0, 0, 0, 0, 0, 0, -44, 0, 0, -44, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        // State 143
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 138
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -66, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 139
+        0, 0, 0, 0, 0, 0, -60, 0, 0, -60, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 140
+        0, 0, 0, 0, 0, 0, 148, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 141
+        0, 0, 0, 0, 0, 0, -36, 0, 0, 149, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 142
+        0, 0, 0, 0, 0, 0, -45, 0, 0, -45, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 143
+        0, 0, 0, 0, 0, 0, -46, 0, 0, -46, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 144
-        0, 0, 0, 0, 0, 0, -37, 0, 0, 148, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, -44, 0, 0, -44, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 145
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 146
-        0, 0, -4, -4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, -37, 0, 0, 150, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 147
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 148
+        0, 0, -4, -4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 149
         0, 0, -5, -5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     ];
     fn __action(state: i16, integer: usize) -> i16 {
@@ -7484,9 +7555,9 @@ mod __parse__Statement {
         // State 27
         0,
         // State 28
-        -71,
-        // State 29
         0,
+        // State 29
+        -71,
         // State 30
         0,
         // State 31
@@ -7494,17 +7565,17 @@ mod __parse__Statement {
         // State 32
         0,
         // State 33
-        -67,
-        // State 34
         0,
+        // State 34
+        -67,
         // State 35
         0,
         // State 36
         0,
         // State 37
-        -69,
-        // State 38
         0,
+        // State 38
+        -69,
         // State 39
         0,
         // State 40
@@ -7516,15 +7587,15 @@ mod __parse__Statement {
         // State 43
         0,
         // State 44
-        -87,
-        // State 45
-        -77,
-        // State 46
-        -90,
-        // State 47
-        -78,
-        // State 48
         0,
+        // State 45
+        -88,
+        // State 46
+        -78,
+        // State 47
+        -91,
+        // State 48
+        -79,
         // State 49
         0,
         // State 50
@@ -7532,47 +7603,47 @@ mod __parse__Statement {
         // State 51
         0,
         // State 52
-        -62,
-        // State 53
-        -50,
-        // State 54
         0,
+        // State 53
+        -62,
+        // State 54
+        -50,
         // State 55
         0,
         // State 56
         0,
         // State 57
-        -65,
+        0,
         // State 58
-        0,
+        -65,
         // State 59
-        -53,
+        0,
         // State 60
-        -55,
+        -53,
         // State 61
-        -28,
+        -55,
         // State 62
-        0,
+        -28,
         // State 63
-        -54,
-        // State 64
         0,
+        // State 64
+        -54,
         // State 65
         0,
         // State 66
-        -61,
-        // State 67
         0,
+        // State 67
+        -61,
         // State 68
         0,
         // State 69
-        -52,
+        0,
         // State 70
-        0,
+        -52,
         // State 71
-        -79,
-        // State 72
         0,
+        // State 72
+        -80,
         // State 73
         0,
         // State 74
@@ -7580,9 +7651,9 @@ mod __parse__Statement {
         // State 75
         0,
         // State 76
-        -83,
-        // State 77
         0,
+        // State 77
+        -84,
         // State 78
         0,
         // State 79
@@ -7594,27 +7665,27 @@ mod __parse__Statement {
         // State 82
         0,
         // State 83
-        -27,
+        0,
         // State 84
-        -26,
+        -27,
         // State 85
-        0,
+        -26,
         // State 86
-        -40,
+        0,
         // State 87
-        -64,
+        0,
         // State 88
-        -63,
+        -40,
         // State 89
-        0,
+        -64,
         // State 90
-        0,
+        -63,
         // State 91
-        -51,
+        0,
         // State 92
         0,
         // State 93
-        0,
+        -51,
         // State 94
         0,
         // State 95
@@ -7624,23 +7695,23 @@ mod __parse__Statement {
         // State 97
         0,
         // State 98
-        -48,
+        0,
         // State 99
-        -72,
+        0,
         // State 100
-        0,
+        -48,
         // State 101
-        -84,
+        -72,
         // State 102
-        -34,
-        // State 103
         0,
+        // State 103
+        -85,
         // State 104
-        -41,
+        -34,
         // State 105
         0,
         // State 106
-        0,
+        -41,
         // State 107
         0,
         // State 108
@@ -7652,59 +7723,59 @@ mod __parse__Statement {
         // State 111
         0,
         // State 112
-        -47,
+        0,
         // State 113
         0,
         // State 114
-        0,
+        -47,
         // State 115
         0,
         // State 116
         0,
         // State 117
-        -35,
+        0,
         // State 118
         0,
         // State 119
-        0,
+        -35,
         // State 120
         0,
         // State 121
-        -85,
+        0,
         // State 122
         0,
         // State 123
-        0,
+        -86,
         // State 124
-        -70,
+        0,
         // State 125
         0,
         // State 126
-        0,
+        -70,
         // State 127
         0,
         // State 128
-        -81,
-        // State 129
-        -80,
-        // State 130
         0,
+        // State 129
+        0,
+        // State 130
+        -82,
         // State 131
-        -73,
+        -81,
         // State 132
         0,
         // State 133
-        -49,
+        -73,
         // State 134
         0,
         // State 135
-        -86,
+        -49,
         // State 136
-        -66,
+        0,
         // State 137
-        0,
+        -87,
         // State 138
-        0,
+        -66,
         // State 139
         0,
         // State 140
@@ -7714,115 +7785,120 @@ mod __parse__Statement {
         // State 142
         0,
         // State 143
-        -68,
+        0,
         // State 144
         0,
         // State 145
-        -82,
+        -68,
         // State 146
         0,
         // State 147
+        -83,
+        // State 148
+        0,
+        // State 149
         0,
     ];
     fn __goto(state: i16, nt: usize) -> i16 {
         match nt {
-            2 => 43,
-            5 => 29,
-            8 => 27,
+            2 => 44,
+            5 => 30,
+            8 => 28,
             11 => 8,
-            14 => 31,
-            15 => 53,
-            16 => 54,
-            17 => 99,
-            18 => 138,
-            19 => 96,
+            14 => 32,
+            15 => 54,
+            16 => 55,
+            17 => 101,
+            18 => 140,
+            19 => 98,
             20 => match state {
-                26 => 103,
-                40 => 136,
-                42 => 143,
-                _ => 28,
+                27 => 105,
+                41 => 138,
+                43 => 145,
+                _ => 29,
             },
-            21 => 55,
+            21 => 56,
             22 => match state {
-                43 => 144,
-                _ => 139,
+                44 => 146,
+                _ => 141,
             },
-            23 => 44,
+            23 => 45,
             24 => match state {
-                2 | 8 => 56,
-                9 => 80,
-                32 => 121,
-                36 => 128,
-                _ => 100,
-            },
-            25 => match state {
-                15 => 87,
-                16 => 88,
-                _ => 57,
-            },
-            26 => match state {
-                29 => 111,
-                _ => 97,
-            },
-            27 => 58,
-            28 => 114,
-            29 => match state {
-                38 => 134,
-                41 | 43 => 140,
-                _ => 59,
-            },
-            30 => match state {
-                23 | 29 => 30,
-                1 => 51,
-                3 => 73,
-                4 => 74,
-                5 => 75,
-                6 => 76,
-                7 => 77,
-                10 => 81,
-                13 => 85,
-                14 | 26 | 40 | 42 => 86,
-                17 => 89,
-                18 => 90,
-                19 => 92,
-                20 => 93,
-                21 => 94,
-                22 => 95,
-                27 => 104,
-                35 => 125,
-                _ => 60,
-            },
-            31 => match state {
-                11 => 83,
-                12 => 84,
-                _ => 61,
-            },
-            32 => 37,
-            33 => 131,
-            34 => 33,
-            35 => match state {
-                34 => 124,
-                39 => 135,
-                _ => 101,
-            },
-            36 => match state {
-                24 => 98,
-                _ => 45,
-            },
-            37 => match state {
-                8 => 78,
-                _ => 62,
-            },
-            38 => 46,
-            39 => match state {
-                41 | 43 => 141,
-                _ => 63,
-            },
-            40 => match state {
-                31 => 117,
+                2 | 8 => 57,
+                9 => 81,
+                33 => 123,
+                37 => 130,
                 _ => 102,
             },
-            41 => 47,
+            25 => match state {
+                16 => 89,
+                17 => 90,
+                _ => 58,
+            },
+            26 => match state {
+                30 => 113,
+                _ => 99,
+            },
+            27 => 59,
+            28 => 116,
+            29 => match state {
+                39 => 136,
+                42 | 44 => 142,
+                _ => 60,
+            },
+            30 => match state {
+                24 | 30 => 31,
+                1 => 52,
+                3 => 74,
+                4 => 75,
+                5 => 76,
+                6 => 77,
+                7 => 78,
+                10 => 82,
+                13 => 86,
+                14 => 87,
+                15 | 27 | 41 | 43 => 88,
+                18 => 91,
+                19 => 92,
+                20 => 94,
+                21 => 95,
+                22 => 96,
+                23 => 97,
+                28 => 106,
+                36 => 127,
+                _ => 61,
+            },
+            31 => match state {
+                11 => 84,
+                12 => 85,
+                _ => 62,
+            },
+            32 => 38,
+            33 => 133,
+            34 => 34,
+            35 => match state {
+                35 => 126,
+                40 => 137,
+                _ => 103,
+            },
+            36 => match state {
+                25 => 100,
+                _ => 46,
+            },
+            37 => match state {
+                8 => 79,
+                _ => 63,
+            },
+            38 => 47,
+            39 => match state {
+                42 | 44 => 143,
+                _ => 64,
+            },
+            40 => match state {
+                32 => 119,
+                _ => 104,
+            },
+            41 => 48,
             _ => 0,
         }
     }
@@ -8522,14 +8598,14 @@ mod __parse__Statement {
             }
             75 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
+                    states_to_pop: 3,
                     nonterminal_produced: 37,
                 }
             }
             76 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
-                    nonterminal_produced: 38,
+                    nonterminal_produced: 37,
                 }
             }
             77 => {
@@ -8541,13 +8617,13 @@ mod __parse__Statement {
             78 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
-                    nonterminal_produced: 39,
+                    nonterminal_produced: 38,
                 }
             }
             79 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 3,
-                    nonterminal_produced: 40,
+                    states_to_pop: 1,
+                    nonterminal_produced: 39,
                 }
             }
             80 => {
@@ -8558,60 +8634,66 @@ mod __parse__Statement {
             }
             81 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 10,
-                    nonterminal_produced: 41,
+                    states_to_pop: 3,
+                    nonterminal_produced: 40,
                 }
             }
             82 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 3,
+                    states_to_pop: 10,
                     nonterminal_produced: 41,
                 }
             }
             83 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 5,
+                    states_to_pop: 3,
                     nonterminal_produced: 41,
                 }
             }
             84 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 6,
+                    states_to_pop: 5,
                     nonterminal_produced: 41,
                 }
             }
             85 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 8,
+                    states_to_pop: 6,
                     nonterminal_produced: 41,
                 }
             }
             86 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
+                    states_to_pop: 8,
                     nonterminal_produced: 41,
                 }
             }
             87 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
-                    nonterminal_produced: 42,
+                    nonterminal_produced: 41,
                 }
             }
             88 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
+                    nonterminal_produced: 42,
+                }
+            }
+            89 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 1,
                     nonterminal_produced: 43,
                 }
             }
-            89 => __state_machine::SimulatedReduce::Accept,
-            90 => {
+            90 => __state_machine::SimulatedReduce::Accept,
+            91 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
                     nonterminal_produced: 45,
                 }
             }
-            91 => {
+            92 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
                     nonterminal_produced: 46,
@@ -8966,6 +9048,9 @@ mod __parse__Statement {
                 __reduce88(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
             }
             89 => {
+                __reduce89(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
+            }
+            90 => {
                 // __Statement = Statement => ActionFn(0);
                 let __sym0 = __pop_Variant26(__symbols);
                 let __start = __sym0.0;
@@ -8973,11 +9058,11 @@ mod __parse__Statement {
                 let __nt = super::__action0::<>(input, __sym0);
                 return Some(Ok(__nt));
             }
-            90 => {
-                __reduce90(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
-            }
             91 => {
                 __reduce91(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
+            }
+            92 => {
+                __reduce92(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
             }
             _ => panic!("invalid action code {}", __action)
         };
@@ -9309,13 +9394,13 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Constant> COMMA) = Constant, COMMA => ActionFn(70);
+        // (<Constant> COMMA) = Constant, COMMA => ActionFn(71);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant1(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action70::<>(input, __sym0, __sym1);
+        let __nt = super::__action71::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant1(__nt), __end));
         (2, 0)
     }
@@ -9328,10 +9413,10 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Constant> COMMA)* =  => ActionFn(68);
+        // (<Constant> COMMA)* =  => ActionFn(69);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action68::<>(input, &__start, &__end);
+        let __nt = super::__action69::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant2(__nt), __end));
         (0, 1)
     }
@@ -9344,11 +9429,11 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Constant> COMMA)* = (<Constant> COMMA)+ => ActionFn(69);
+        // (<Constant> COMMA)* = (<Constant> COMMA)+ => ActionFn(70);
         let __sym0 = __pop_Variant2(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action69::<>(input, __sym0);
+        let __nt = super::__action70::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant2(__nt), __end));
         (1, 1)
     }
@@ -9361,13 +9446,13 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Constant> COMMA)+ = Constant, COMMA => ActionFn(87);
+        // (<Constant> COMMA)+ = Constant, COMMA => ActionFn(88);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant1(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action87::<>(input, __sym0, __sym1);
+        let __nt = super::__action88::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant2(__nt), __end));
         (2, 2)
     }
@@ -9380,14 +9465,14 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Constant> COMMA)+ = (<Constant> COMMA)+, Constant, COMMA => ActionFn(88);
+        // (<Constant> COMMA)+ = (<Constant> COMMA)+, Constant, COMMA => ActionFn(89);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant1(__symbols);
         let __sym0 = __pop_Variant2(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action88::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action89::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant2(__nt), __end));
         (3, 2)
     }
@@ -9400,13 +9485,13 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<FieldDefinition> COMMA) = FieldDefinition, COMMA => ActionFn(73);
+        // (<FieldDefinition> COMMA) = FieldDefinition, COMMA => ActionFn(74);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant3(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action73::<>(input, __sym0, __sym1);
+        let __nt = super::__action74::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant3(__nt), __end));
         (2, 3)
     }
@@ -9419,10 +9504,10 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<FieldDefinition> COMMA)* =  => ActionFn(71);
+        // (<FieldDefinition> COMMA)* =  => ActionFn(72);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action71::<>(input, &__start, &__end);
+        let __nt = super::__action72::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant4(__nt), __end));
         (0, 4)
     }
@@ -9435,11 +9520,11 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<FieldDefinition> COMMA)* = (<FieldDefinition> COMMA)+ => ActionFn(72);
+        // (<FieldDefinition> COMMA)* = (<FieldDefinition> COMMA)+ => ActionFn(73);
         let __sym0 = __pop_Variant4(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action72::<>(input, __sym0);
+        let __nt = super::__action73::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant4(__nt), __end));
         (1, 4)
     }
@@ -9452,13 +9537,13 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<FieldDefinition> COMMA)+ = FieldDefinition, COMMA => ActionFn(91);
+        // (<FieldDefinition> COMMA)+ = FieldDefinition, COMMA => ActionFn(92);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant3(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action91::<>(input, __sym0, __sym1);
+        let __nt = super::__action92::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant4(__nt), __end));
         (2, 5)
     }
@@ -9471,14 +9556,14 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<FieldDefinition> COMMA)+ = (<FieldDefinition> COMMA)+, FieldDefinition, COMMA => ActionFn(92);
+        // (<FieldDefinition> COMMA)+ = (<FieldDefinition> COMMA)+, FieldDefinition, COMMA => ActionFn(93);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant3(__symbols);
         let __sym0 = __pop_Variant4(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action92::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action93::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant4(__nt), __end));
         (3, 5)
     }
@@ -9491,13 +9576,13 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<IdToken> COMMA) = IdToken, COMMA => ActionFn(64);
+        // (<IdToken> COMMA) = IdToken, COMMA => ActionFn(65);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action64::<>(input, __sym0, __sym1);
+        let __nt = super::__action65::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant5(__nt), __end));
         (2, 6)
     }
@@ -9510,10 +9595,10 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<IdToken> COMMA)* =  => ActionFn(62);
+        // (<IdToken> COMMA)* =  => ActionFn(63);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action62::<>(input, &__start, &__end);
+        let __nt = super::__action63::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant6(__nt), __end));
         (0, 7)
     }
@@ -9526,11 +9611,11 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<IdToken> COMMA)* = (<IdToken> COMMA)+ => ActionFn(63);
+        // (<IdToken> COMMA)* = (<IdToken> COMMA)+ => ActionFn(64);
         let __sym0 = __pop_Variant6(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action63::<>(input, __sym0);
+        let __nt = super::__action64::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant6(__nt), __end));
         (1, 7)
     }
@@ -9543,13 +9628,13 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<IdToken> COMMA)+ = IdToken, COMMA => ActionFn(95);
+        // (<IdToken> COMMA)+ = IdToken, COMMA => ActionFn(96);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action95::<>(input, __sym0, __sym1);
+        let __nt = super::__action96::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant6(__nt), __end));
         (2, 8)
     }
@@ -9562,14 +9647,14 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<IdToken> COMMA)+ = (<IdToken> COMMA)+, IdToken, COMMA => ActionFn(96);
+        // (<IdToken> COMMA)+ = (<IdToken> COMMA)+, IdToken, COMMA => ActionFn(97);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant5(__symbols);
         let __sym0 = __pop_Variant6(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action96::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action97::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant6(__nt), __end));
         (3, 8)
     }
@@ -9582,13 +9667,13 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<SelectField> COMMA) = SelectField, COMMA => ActionFn(67);
+        // (<SelectField> COMMA) = SelectField, COMMA => ActionFn(68);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant7(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action67::<>(input, __sym0, __sym1);
+        let __nt = super::__action68::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant7(__nt), __end));
         (2, 9)
     }
@@ -9601,10 +9686,10 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<SelectField> COMMA)* =  => ActionFn(65);
+        // (<SelectField> COMMA)* =  => ActionFn(66);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action65::<>(input, &__start, &__end);
+        let __nt = super::__action66::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant8(__nt), __end));
         (0, 10)
     }
@@ -9617,11 +9702,11 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<SelectField> COMMA)* = (<SelectField> COMMA)+ => ActionFn(66);
+        // (<SelectField> COMMA)* = (<SelectField> COMMA)+ => ActionFn(67);
         let __sym0 = __pop_Variant8(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action66::<>(input, __sym0);
+        let __nt = super::__action67::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant8(__nt), __end));
         (1, 10)
     }
@@ -9634,13 +9719,13 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<SelectField> COMMA)+ = SelectField, COMMA => ActionFn(99);
+        // (<SelectField> COMMA)+ = SelectField, COMMA => ActionFn(100);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant7(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action99::<>(input, __sym0, __sym1);
+        let __nt = super::__action100::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant8(__nt), __end));
         (2, 11)
     }
@@ -9653,14 +9738,14 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<SelectField> COMMA)+ = (<SelectField> COMMA)+, SelectField, COMMA => ActionFn(100);
+        // (<SelectField> COMMA)+ = (<SelectField> COMMA)+, SelectField, COMMA => ActionFn(101);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant7(__symbols);
         let __sym0 = __pop_Variant8(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action100::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action101::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant8(__nt), __end));
         (3, 11)
     }
@@ -9673,13 +9758,13 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Term> AND) = Term, AND => ActionFn(76);
+        // (<Term> AND) = Term, AND => ActionFn(77);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant9(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action76::<>(input, __sym0, __sym1);
+        let __nt = super::__action77::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant9(__nt), __end));
         (2, 12)
     }
@@ -9692,10 +9777,10 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Term> AND)* =  => ActionFn(74);
+        // (<Term> AND)* =  => ActionFn(75);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action74::<>(input, &__start, &__end);
+        let __nt = super::__action75::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant10(__nt), __end));
         (0, 13)
     }
@@ -9708,11 +9793,11 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Term> AND)* = (<Term> AND)+ => ActionFn(75);
+        // (<Term> AND)* = (<Term> AND)+ => ActionFn(76);
         let __sym0 = __pop_Variant10(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action75::<>(input, __sym0);
+        let __nt = super::__action76::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant10(__nt), __end));
         (1, 13)
     }
@@ -9725,13 +9810,13 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Term> AND)+ = Term, AND => ActionFn(103);
+        // (<Term> AND)+ = Term, AND => ActionFn(104);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant9(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action103::<>(input, __sym0, __sym1);
+        let __nt = super::__action104::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant10(__nt), __end));
         (2, 14)
     }
@@ -9744,14 +9829,14 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Term> AND)+ = (<Term> AND)+, Term, AND => ActionFn(104);
+        // (<Term> AND)+ = (<Term> AND)+, Term, AND => ActionFn(105);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant9(__symbols);
         let __sym0 = __pop_Variant10(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action104::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action105::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant10(__nt), __end));
         (3, 14)
     }
@@ -9764,14 +9849,14 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AddExpr = AddExpr, PLUS, MulExpr => ActionFn(40);
+        // AddExpr = AddExpr, PLUS, MulExpr => ActionFn(41);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant11(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action40::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action41::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (3, 15)
     }
@@ -9784,14 +9869,14 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AddExpr = AddExpr, MINUS, MulExpr => ActionFn(41);
+        // AddExpr = AddExpr, MINUS, MulExpr => ActionFn(42);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant11(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action41::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action42::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (3, 15)
     }
@@ -9804,11 +9889,11 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AddExpr = MulExpr => ActionFn(42);
+        // AddExpr = MulExpr => ActionFn(43);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action42::<>(input, __sym0);
+        let __nt = super::__action43::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (1, 15)
     }
@@ -9821,7 +9906,7 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AggregationFn = MAX, LPAREN, IdToken, RPAREN => ActionFn(13);
+        // AggregationFn = MAX, LPAREN, IdToken, RPAREN => ActionFn(14);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant5(__symbols);
@@ -9829,7 +9914,7 @@ mod __parse__Statement {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action13::<>(input, __sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action14::<>(input, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant12(__nt), __end));
         (4, 16)
     }
@@ -9842,7 +9927,7 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AggregationFn = MIN, LPAREN, IdToken, RPAREN => ActionFn(14);
+        // AggregationFn = MIN, LPAREN, IdToken, RPAREN => ActionFn(15);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant5(__symbols);
@@ -9850,7 +9935,7 @@ mod __parse__Statement {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action14::<>(input, __sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action15::<>(input, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant12(__nt), __end));
         (4, 16)
     }
@@ -9863,7 +9948,7 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AggregationFn = SUM, LPAREN, IdToken, RPAREN => ActionFn(15);
+        // AggregationFn = SUM, LPAREN, IdToken, RPAREN => ActionFn(16);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant5(__symbols);
@@ -9871,7 +9956,7 @@ mod __parse__Statement {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action15::<>(input, __sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action16::<>(input, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant12(__nt), __end));
         (4, 16)
     }
@@ -9884,7 +9969,7 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AggregationFn = COUNT, LPAREN, IdToken, RPAREN => ActionFn(16);
+        // AggregationFn = COUNT, LPAREN, IdToken, RPAREN => ActionFn(17);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant5(__symbols);
@@ -9892,7 +9977,7 @@ mod __parse__Statement {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action16::<>(input, __sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action17::<>(input, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant12(__nt), __end));
         (4, 16)
     }
@@ -9905,7 +9990,7 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AggregationFn = AVG, LPAREN, IdToken, RPAREN => ActionFn(17);
+        // AggregationFn = AVG, LPAREN, IdToken, RPAREN => ActionFn(18);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant5(__symbols);
@@ -9913,7 +9998,7 @@ mod __parse__Statement {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action17::<>(input, __sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action18::<>(input, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant12(__nt), __end));
         (4, 16)
     }
@@ -9926,11 +10011,11 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // And<Term> = Term => ActionFn(105);
+        // And<Term> = Term => ActionFn(106);
         let __sym0 = __pop_Variant9(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action105::<>(input, __sym0);
+        let __nt = super::__action106::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant13(__nt), __end));
         (1, 17)
     }
@@ -9943,13 +10028,13 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // And<Term> = (<Term> AND)+, Term => ActionFn(106);
+        // And<Term> = (<Term> AND)+, Term => ActionFn(107);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant9(__symbols);
         let __sym0 = __pop_Variant10(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action106::<>(input, __sym0, __sym1);
+        let __nt = super::__action107::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant13(__nt), __end));
         (2, 17)
     }
@@ -9962,11 +10047,11 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<Constant> = Constant => ActionFn(89);
+        // Comma<Constant> = Constant => ActionFn(90);
         let __sym0 = __pop_Variant1(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action89::<>(input, __sym0);
+        let __nt = super::__action90::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant14(__nt), __end));
         (1, 18)
     }
@@ -9979,13 +10064,13 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<Constant> = (<Constant> COMMA)+, Constant => ActionFn(90);
+        // Comma<Constant> = (<Constant> COMMA)+, Constant => ActionFn(91);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant1(__symbols);
         let __sym0 = __pop_Variant2(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action90::<>(input, __sym0, __sym1);
+        let __nt = super::__action91::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant14(__nt), __end));
         (2, 18)
     }
@@ -9998,11 +10083,11 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<FieldDefinition> = FieldDefinition => ActionFn(93);
+        // Comma<FieldDefinition> = FieldDefinition => ActionFn(94);
         let __sym0 = __pop_Variant3(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action93::<>(input, __sym0);
+        let __nt = super::__action94::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (1, 19)
     }
@@ -10015,13 +10100,13 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<FieldDefinition> = (<FieldDefinition> COMMA)+, FieldDefinition => ActionFn(94);
+        // Comma<FieldDefinition> = (<FieldDefinition> COMMA)+, FieldDefinition => ActionFn(95);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant3(__symbols);
         let __sym0 = __pop_Variant4(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action94::<>(input, __sym0, __sym1);
+        let __nt = super::__action95::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (2, 19)
     }
@@ -10034,11 +10119,11 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<IdToken> = IdToken => ActionFn(97);
+        // Comma<IdToken> = IdToken => ActionFn(98);
         let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action97::<>(input, __sym0);
+        let __nt = super::__action98::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant16(__nt), __end));
         (1, 20)
     }
@@ -10051,13 +10136,13 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<IdToken> = (<IdToken> COMMA)+, IdToken => ActionFn(98);
+        // Comma<IdToken> = (<IdToken> COMMA)+, IdToken => ActionFn(99);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant5(__symbols);
         let __sym0 = __pop_Variant6(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action98::<>(input, __sym0, __sym1);
+        let __nt = super::__action99::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant16(__nt), __end));
         (2, 20)
     }
@@ -10070,11 +10155,11 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<SelectField> = SelectField => ActionFn(101);
+        // Comma<SelectField> = SelectField => ActionFn(102);
         let __sym0 = __pop_Variant7(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action101::<>(input, __sym0);
+        let __nt = super::__action102::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant17(__nt), __end));
         (1, 21)
     }
@@ -10087,13 +10172,13 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<SelectField> = (<SelectField> COMMA)+, SelectField => ActionFn(102);
+        // Comma<SelectField> = (<SelectField> COMMA)+, SelectField => ActionFn(103);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant7(__symbols);
         let __sym0 = __pop_Variant8(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action102::<>(input, __sym0, __sym1);
+        let __nt = super::__action103::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant17(__nt), __end));
         (2, 21)
     }
@@ -10106,11 +10191,11 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Constant = NULL => ActionFn(51);
+        // Constant = NULL => ActionFn(52);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action51::<>(input, __sym0);
+        let __nt = super::__action52::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant1(__nt), __end));
         (1, 22)
     }
@@ -10123,11 +10208,11 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Constant = I32Constant => ActionFn(52);
+        // Constant = I32Constant => ActionFn(53);
         let __sym0 = __pop_Variant21(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action52::<>(input, __sym0);
+        let __nt = super::__action53::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant1(__nt), __end));
         (1, 22)
     }
@@ -10140,11 +10225,11 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Constant = StringConstant => ActionFn(53);
+        // Constant = StringConstant => ActionFn(54);
         let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action53::<>(input, __sym0);
+        let __nt = super::__action54::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant1(__nt), __end));
         (1, 22)
     }
@@ -10157,7 +10242,7 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // CreateCommand = CREATE, TABLE, IdToken, LPAREN, Comma<FieldDefinition>, RPAREN => ActionFn(30);
+        // CreateCommand = CREATE, TABLE, IdToken, LPAREN, Comma<FieldDefinition>, RPAREN => ActionFn(31);
         assert!(__symbols.len() >= 6);
         let __sym5 = __pop_Variant0(__symbols);
         let __sym4 = __pop_Variant15(__symbols);
@@ -10167,7 +10252,7 @@ mod __parse__Statement {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym5.2;
-        let __nt = super::__action30::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
+        let __nt = super::__action31::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
         __symbols.push((__start, __Symbol::Variant18(__nt), __end));
         (6, 23)
     }
@@ -10180,7 +10265,7 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // CreateCommand = CREATE, VIEW, IdToken, AS, Query => ActionFn(31);
+        // CreateCommand = CREATE, VIEW, IdToken, AS, Query => ActionFn(32);
         assert!(__symbols.len() >= 5);
         let __sym4 = __pop_Variant25(__symbols);
         let __sym3 = __pop_Variant0(__symbols);
@@ -10189,7 +10274,7 @@ mod __parse__Statement {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym4.2;
-        let __nt = super::__action31::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4);
+        let __nt = super::__action32::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4);
         __symbols.push((__start, __Symbol::Variant18(__nt), __end));
         (5, 23)
     }
@@ -10202,7 +10287,7 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // CreateCommand = CREATE, INDEX, IdToken, ON, IdToken, LPAREN, IdToken, RPAREN => ActionFn(32);
+        // CreateCommand = CREATE, INDEX, IdToken, ON, IdToken, LPAREN, IdToken, RPAREN => ActionFn(33);
         assert!(__symbols.len() >= 8);
         let __sym7 = __pop_Variant0(__symbols);
         let __sym6 = __pop_Variant5(__symbols);
@@ -10214,7 +10299,7 @@ mod __parse__Statement {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym7.2;
-        let __nt = super::__action32::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
+        let __nt = super::__action33::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
         __symbols.push((__start, __Symbol::Variant18(__nt), __end));
         (8, 23)
     }
@@ -10227,11 +10312,11 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Expression = AddExpr => ActionFn(39);
+        // Expression = AddExpr => ActionFn(40);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action39::<>(input, __sym0);
+        let __nt = super::__action40::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (1, 24)
     }
@@ -10244,14 +10329,14 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Factor = LPAREN, Expression, RPAREN => ActionFn(46);
+        // Factor = LPAREN, Expression, RPAREN => ActionFn(47);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant11(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action46::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action47::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (3, 25)
     }
@@ -10264,11 +10349,11 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Factor = NULL => ActionFn(47);
+        // Factor = NULL => ActionFn(48);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action47::<>(input, __sym0);
+        let __nt = super::__action48::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (1, 25)
     }
@@ -10281,11 +10366,11 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Factor = I32Constant => ActionFn(48);
+        // Factor = I32Constant => ActionFn(49);
         let __sym0 = __pop_Variant21(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action48::<>(input, __sym0);
+        let __nt = super::__action49::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (1, 25)
     }
@@ -10298,11 +10383,11 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Factor = StringConstant => ActionFn(49);
+        // Factor = StringConstant => ActionFn(50);
         let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action49::<>(input, __sym0);
+        let __nt = super::__action50::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (1, 25)
     }
@@ -10315,11 +10400,11 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Factor = IdToken => ActionFn(50);
+        // Factor = IdToken => ActionFn(51);
         let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action50::<>(input, __sym0);
+        let __nt = super::__action51::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (1, 25)
     }
@@ -10332,13 +10417,13 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // FieldDefinition = IdToken, FieldType => ActionFn(33);
+        // FieldDefinition = IdToken, FieldType => ActionFn(34);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant20(__symbols);
         let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action33::<>(input, __sym0, __sym1);
+        let __nt = super::__action34::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant3(__nt), __end));
         (2, 26)
     }
@@ -10385,11 +10470,11 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // FieldType = I32 => ActionFn(34);
+        // FieldType = I32 => ActionFn(35);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action34::<>(input, __sym0);
+        let __nt = super::__action35::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant20(__nt), __end));
         (1, 28)
     }
@@ -10402,7 +10487,7 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // FieldType = VARCHAR, LPAREN, I32Constant, RPAREN => ActionFn(35);
+        // FieldType = VARCHAR, LPAREN, I32Constant, RPAREN => ActionFn(36);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant21(__symbols);
@@ -10410,7 +10495,7 @@ mod __parse__Statement {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action35::<>(input, __sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action36::<>(input, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant20(__nt), __end));
         (4, 28)
     }
@@ -10423,11 +10508,11 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // I32Constant = I32_LITERAL => ActionFn(54);
+        // I32Constant = I32_LITERAL => ActionFn(55);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action54::<>(input, __sym0);
+        let __nt = super::__action55::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant21(__nt), __end));
         (1, 29)
     }
@@ -10440,11 +10525,11 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // IdToken = ID => ActionFn(56);
+        // IdToken = ID => ActionFn(57);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action56::<>(input, __sym0);
+        let __nt = super::__action57::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant5(__nt), __end));
         (1, 30)
     }
@@ -10457,14 +10542,14 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // MulExpr = MulExpr, STAR, Factor => ActionFn(43);
+        // MulExpr = MulExpr, STAR, Factor => ActionFn(44);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant11(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action43::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action44::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (3, 31)
     }
@@ -10477,14 +10562,14 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // MulExpr = MulExpr, SLASH, Factor => ActionFn(44);
+        // MulExpr = MulExpr, SLASH, Factor => ActionFn(45);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant11(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action44::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action45::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (3, 31)
     }
@@ -10497,11 +10582,11 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // MulExpr = Factor => ActionFn(45);
+        // MulExpr = Factor => ActionFn(46);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action45::<>(input, __sym0);
+        let __nt = super::__action46::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (1, 31)
     }
@@ -10514,14 +10599,14 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // OptGroupBy = GROUP, BY, Comma<IdToken> => ActionFn(20);
+        // OptGroupBy = GROUP, BY, Comma<IdToken> => ActionFn(21);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant16(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action20::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action21::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant22(__nt), __end));
         (3, 32)
     }
@@ -10534,10 +10619,10 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // OptGroupBy =  => ActionFn(21);
+        // OptGroupBy =  => ActionFn(22);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action21::<>(input, &__start, &__end);
+        let __nt = super::__action22::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant22(__nt), __end));
         (0, 32)
     }
@@ -10550,14 +10635,14 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // OptOrderBy = ORDER, BY, Comma<IdToken> => ActionFn(22);
+        // OptOrderBy = ORDER, BY, Comma<IdToken> => ActionFn(23);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant16(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action22::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action23::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant22(__nt), __end));
         (3, 33)
     }
@@ -10570,10 +10655,10 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // OptOrderBy =  => ActionFn(23);
+        // OptOrderBy =  => ActionFn(24);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action23::<>(input, &__start, &__end);
+        let __nt = super::__action24::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant22(__nt), __end));
         (0, 33)
     }
@@ -10586,13 +10671,13 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // OptPredicate = WHERE, Predicate => ActionFn(18);
+        // OptPredicate = WHERE, Predicate => ActionFn(19);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant24(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action18::<>(input, __sym0, __sym1);
+        let __nt = super::__action19::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant23(__nt), __end));
         (2, 34)
     }
@@ -10605,10 +10690,10 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // OptPredicate =  => ActionFn(19);
+        // OptPredicate =  => ActionFn(20);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action19::<>(input, &__start, &__end);
+        let __nt = super::__action20::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant23(__nt), __end));
         (0, 34)
     }
@@ -10621,11 +10706,11 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Predicate = And<Term> => ActionFn(36);
+        // Predicate = And<Term> => ActionFn(37);
         let __sym0 = __pop_Variant13(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action36::<>(input, __sym0);
+        let __nt = super::__action37::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant24(__nt), __end));
         (1, 35)
     }
@@ -10699,15 +10784,35 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // SelectField = AggregationFn => ActionFn(12);
+        // SelectField = AggregationFn, AS, IdToken => ActionFn(12);
+        assert!(__symbols.len() >= 3);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant12(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym2.2;
+        let __nt = super::__action12::<>(input, __sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant7(__nt), __end));
+        (3, 37)
+    }
+    fn __reduce76<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // SelectField = AggregationFn => ActionFn(13);
         let __sym0 = __pop_Variant12(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action12::<>(input, __sym0);
+        let __nt = super::__action13::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant7(__nt), __end));
         (1, 37)
     }
-    fn __reduce76<
+    fn __reduce77<
         'input,
     >(
         input: &'input str,
@@ -10724,7 +10829,7 @@ mod __parse__Statement {
         __symbols.push((__start, __Symbol::Variant26(__nt), __end));
         (1, 38)
     }
-    fn __reduce77<
+    fn __reduce78<
         'input,
     >(
         input: &'input str,
@@ -10741,23 +10846,6 @@ mod __parse__Statement {
         __symbols.push((__start, __Symbol::Variant26(__nt), __end));
         (1, 38)
     }
-    fn __reduce78<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // StringConstant = STRING_LITERAL => ActionFn(55);
-        let __sym0 = __pop_Variant0(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action55::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant5(__nt), __end));
-        (1, 39)
-    }
     fn __reduce79<
         'input,
     >(
@@ -10767,16 +10855,13 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Term = Expression, IS, NULL => ActionFn(37);
-        assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant11(__symbols);
+        // StringConstant = STRING_LITERAL => ActionFn(56);
+        let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym2.2;
-        let __nt = super::__action37::<>(input, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant9(__nt), __end));
-        (3, 40)
+        let __end = __sym0.2;
+        let __nt = super::__action56::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant5(__nt), __end));
+        (1, 39)
     }
     fn __reduce80<
         'input,
@@ -10787,9 +10872,9 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Term = Expression, EQ, Expression => ActionFn(38);
+        // Term = Expression, IS, NULL => ActionFn(38);
         assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant11(__symbols);
+        let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
@@ -10807,7 +10892,27 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // UpdateCommand = INSERT, INTO, IdToken, LPAREN, Comma<IdToken>, RPAREN, VALUES, LPAREN, Comma<Constant>, RPAREN => ActionFn(24);
+        // Term = Expression, EQ, Expression => ActionFn(39);
+        assert!(__symbols.len() >= 3);
+        let __sym2 = __pop_Variant11(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant11(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym2.2;
+        let __nt = super::__action39::<>(input, __sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant9(__nt), __end));
+        (3, 40)
+    }
+    fn __reduce82<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // UpdateCommand = INSERT, INTO, IdToken, LPAREN, Comma<IdToken>, RPAREN, VALUES, LPAREN, Comma<Constant>, RPAREN => ActionFn(25);
         assert!(__symbols.len() >= 10);
         let __sym9 = __pop_Variant0(__symbols);
         let __sym8 = __pop_Variant14(__symbols);
@@ -10821,29 +10926,9 @@ mod __parse__Statement {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym9.2;
-        let __nt = super::__action24::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9);
+        let __nt = super::__action25::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9);
         __symbols.push((__start, __Symbol::Variant27(__nt), __end));
         (10, 41)
-    }
-    fn __reduce82<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // UpdateCommand = DELETE, FROM, IdToken => ActionFn(25);
-        assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant5(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym2.2;
-        let __nt = super::__action25::<>(input, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant27(__nt), __end));
-        (3, 41)
     }
     fn __reduce83<
         'input,
@@ -10854,18 +10939,16 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // UpdateCommand = DELETE, FROM, IdToken, WHERE, Predicate => ActionFn(26);
-        assert!(__symbols.len() >= 5);
-        let __sym4 = __pop_Variant24(__symbols);
-        let __sym3 = __pop_Variant0(__symbols);
+        // UpdateCommand = DELETE, FROM, IdToken => ActionFn(26);
+        assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant5(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym4.2;
-        let __nt = super::__action26::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4);
+        let __end = __sym2.2;
+        let __nt = super::__action26::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant27(__nt), __end));
-        (5, 41)
+        (3, 41)
     }
     fn __reduce84<
         'input,
@@ -10876,19 +10959,18 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // UpdateCommand = MODIFY, IdToken, SET, IdToken, EQ, Expression => ActionFn(27);
-        assert!(__symbols.len() >= 6);
-        let __sym5 = __pop_Variant11(__symbols);
-        let __sym4 = __pop_Variant0(__symbols);
-        let __sym3 = __pop_Variant5(__symbols);
-        let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant5(__symbols);
+        // UpdateCommand = DELETE, FROM, IdToken, WHERE, Predicate => ActionFn(27);
+        assert!(__symbols.len() >= 5);
+        let __sym4 = __pop_Variant24(__symbols);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym5.2;
-        let __nt = super::__action27::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
+        let __end = __sym4.2;
+        let __nt = super::__action27::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4);
         __symbols.push((__start, __Symbol::Variant27(__nt), __end));
-        (6, 41)
+        (5, 41)
     }
     fn __reduce85<
         'input,
@@ -10899,7 +10981,30 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // UpdateCommand = MODIFY, IdToken, SET, IdToken, EQ, Expression, WHERE, Predicate => ActionFn(28);
+        // UpdateCommand = MODIFY, IdToken, SET, IdToken, EQ, Expression => ActionFn(28);
+        assert!(__symbols.len() >= 6);
+        let __sym5 = __pop_Variant11(__symbols);
+        let __sym4 = __pop_Variant0(__symbols);
+        let __sym3 = __pop_Variant5(__symbols);
+        let __sym2 = __pop_Variant0(__symbols);
+        let __sym1 = __pop_Variant5(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym5.2;
+        let __nt = super::__action28::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
+        __symbols.push((__start, __Symbol::Variant27(__nt), __end));
+        (6, 41)
+    }
+    fn __reduce86<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // UpdateCommand = MODIFY, IdToken, SET, IdToken, EQ, Expression, WHERE, Predicate => ActionFn(29);
         assert!(__symbols.len() >= 8);
         let __sym7 = __pop_Variant24(__symbols);
         let __sym6 = __pop_Variant0(__symbols);
@@ -10911,11 +11016,11 @@ mod __parse__Statement {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym7.2;
-        let __nt = super::__action28::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
+        let __nt = super::__action29::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
         __symbols.push((__start, __Symbol::Variant27(__nt), __end));
         (8, 41)
     }
-    fn __reduce86<
+    fn __reduce87<
         'input,
     >(
         input: &'input str,
@@ -10924,15 +11029,15 @@ mod __parse__Statement {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // UpdateCommand = CreateCommand => ActionFn(29);
+        // UpdateCommand = CreateCommand => ActionFn(30);
         let __sym0 = __pop_Variant18(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action29::<>(input, __sym0);
+        let __nt = super::__action30::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant27(__nt), __end));
         (1, 41)
     }
-    fn __reduce87<
+    fn __reduce88<
         'input,
     >(
         input: &'input str,
@@ -10949,7 +11054,7 @@ mod __parse__Statement {
         __symbols.push((__start, __Symbol::Variant24(__nt), __end));
         (1, 42)
     }
-    fn __reduce88<
+    fn __reduce89<
         'input,
     >(
         input: &'input str,
@@ -10966,7 +11071,7 @@ mod __parse__Statement {
         __symbols.push((__start, __Symbol::Variant25(__nt), __end));
         (1, 43)
     }
-    fn __reduce90<
+    fn __reduce91<
         'input,
     >(
         input: &'input str,
@@ -10983,7 +11088,7 @@ mod __parse__Statement {
         __symbols.push((__start, __Symbol::Variant9(__nt), __end));
         (1, 45)
     }
-    fn __reduce91<
+    fn __reduce92<
         'input,
     >(
         input: &'input str,
@@ -11099,7 +11204,7 @@ mod __parse__Term {
         // State 17
         0, 0, 0, 0, -52, 0, -52, -52, -52, 0, -52, -52, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -52, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 18
-        0, 0, 0, 0, -79, 0, -79, -79, -79, 0, -79, -79, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -79, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -80, 0, -80, -80, -80, 0, -80, -80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 19
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 20
@@ -11152,7 +11257,7 @@ mod __parse__Term {
         // State 13
         -54,
         // State 14
-        -91,
+        -92,
         // State 15
         -61,
         // State 16
@@ -11160,7 +11265,7 @@ mod __parse__Term {
         // State 17
         -52,
         // State 18
-        -79,
+        -80,
         // State 19
         0,
         // State 20
@@ -11170,9 +11275,9 @@ mod __parse__Term {
         // State 22
         -26,
         // State 23
-        -81,
+        -82,
         // State 24
-        -80,
+        -81,
         // State 25
         -64,
         // State 26
@@ -11901,14 +12006,14 @@ mod __parse__Term {
             }
             75 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
+                    states_to_pop: 3,
                     nonterminal_produced: 37,
                 }
             }
             76 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
-                    nonterminal_produced: 38,
+                    nonterminal_produced: 37,
                 }
             }
             77 => {
@@ -11920,13 +12025,13 @@ mod __parse__Term {
             78 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
-                    nonterminal_produced: 39,
+                    nonterminal_produced: 38,
                 }
             }
             79 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 3,
-                    nonterminal_produced: 40,
+                    states_to_pop: 1,
+                    nonterminal_produced: 39,
                 }
             }
             80 => {
@@ -11937,60 +12042,66 @@ mod __parse__Term {
             }
             81 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 10,
-                    nonterminal_produced: 41,
+                    states_to_pop: 3,
+                    nonterminal_produced: 40,
                 }
             }
             82 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 3,
+                    states_to_pop: 10,
                     nonterminal_produced: 41,
                 }
             }
             83 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 5,
+                    states_to_pop: 3,
                     nonterminal_produced: 41,
                 }
             }
             84 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 6,
+                    states_to_pop: 5,
                     nonterminal_produced: 41,
                 }
             }
             85 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 8,
+                    states_to_pop: 6,
                     nonterminal_produced: 41,
                 }
             }
             86 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
+                    states_to_pop: 8,
                     nonterminal_produced: 41,
                 }
             }
             87 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
-                    nonterminal_produced: 42,
+                    nonterminal_produced: 41,
                 }
             }
             88 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
-                    nonterminal_produced: 43,
+                    nonterminal_produced: 42,
                 }
             }
             89 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
+                    nonterminal_produced: 43,
+                }
+            }
+            90 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 1,
                     nonterminal_produced: 44,
                 }
             }
-            90 => __state_machine::SimulatedReduce::Accept,
-            91 => {
+            91 => __state_machine::SimulatedReduce::Accept,
+            92 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
                     nonterminal_produced: 46,
@@ -12348,6 +12459,9 @@ mod __parse__Term {
                 __reduce89(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
             }
             90 => {
+                __reduce90(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
+            }
+            91 => {
                 // __Term = Term => ActionFn(4);
                 let __sym0 = __pop_Variant9(__symbols);
                 let __start = __sym0.0;
@@ -12355,8 +12469,8 @@ mod __parse__Term {
                 let __nt = super::__action4::<>(input, __sym0);
                 return Some(Ok(__nt));
             }
-            91 => {
-                __reduce91(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
+            92 => {
+                __reduce92(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
             }
             _ => panic!("invalid action code {}", __action)
         };
@@ -12688,13 +12802,13 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Constant> COMMA) = Constant, COMMA => ActionFn(70);
+        // (<Constant> COMMA) = Constant, COMMA => ActionFn(71);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant1(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action70::<>(input, __sym0, __sym1);
+        let __nt = super::__action71::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant1(__nt), __end));
         (2, 0)
     }
@@ -12707,10 +12821,10 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Constant> COMMA)* =  => ActionFn(68);
+        // (<Constant> COMMA)* =  => ActionFn(69);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action68::<>(input, &__start, &__end);
+        let __nt = super::__action69::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant2(__nt), __end));
         (0, 1)
     }
@@ -12723,11 +12837,11 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Constant> COMMA)* = (<Constant> COMMA)+ => ActionFn(69);
+        // (<Constant> COMMA)* = (<Constant> COMMA)+ => ActionFn(70);
         let __sym0 = __pop_Variant2(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action69::<>(input, __sym0);
+        let __nt = super::__action70::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant2(__nt), __end));
         (1, 1)
     }
@@ -12740,13 +12854,13 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Constant> COMMA)+ = Constant, COMMA => ActionFn(87);
+        // (<Constant> COMMA)+ = Constant, COMMA => ActionFn(88);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant1(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action87::<>(input, __sym0, __sym1);
+        let __nt = super::__action88::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant2(__nt), __end));
         (2, 2)
     }
@@ -12759,14 +12873,14 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Constant> COMMA)+ = (<Constant> COMMA)+, Constant, COMMA => ActionFn(88);
+        // (<Constant> COMMA)+ = (<Constant> COMMA)+, Constant, COMMA => ActionFn(89);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant1(__symbols);
         let __sym0 = __pop_Variant2(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action88::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action89::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant2(__nt), __end));
         (3, 2)
     }
@@ -12779,13 +12893,13 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<FieldDefinition> COMMA) = FieldDefinition, COMMA => ActionFn(73);
+        // (<FieldDefinition> COMMA) = FieldDefinition, COMMA => ActionFn(74);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant3(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action73::<>(input, __sym0, __sym1);
+        let __nt = super::__action74::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant3(__nt), __end));
         (2, 3)
     }
@@ -12798,10 +12912,10 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<FieldDefinition> COMMA)* =  => ActionFn(71);
+        // (<FieldDefinition> COMMA)* =  => ActionFn(72);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action71::<>(input, &__start, &__end);
+        let __nt = super::__action72::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant4(__nt), __end));
         (0, 4)
     }
@@ -12814,11 +12928,11 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<FieldDefinition> COMMA)* = (<FieldDefinition> COMMA)+ => ActionFn(72);
+        // (<FieldDefinition> COMMA)* = (<FieldDefinition> COMMA)+ => ActionFn(73);
         let __sym0 = __pop_Variant4(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action72::<>(input, __sym0);
+        let __nt = super::__action73::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant4(__nt), __end));
         (1, 4)
     }
@@ -12831,13 +12945,13 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<FieldDefinition> COMMA)+ = FieldDefinition, COMMA => ActionFn(91);
+        // (<FieldDefinition> COMMA)+ = FieldDefinition, COMMA => ActionFn(92);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant3(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action91::<>(input, __sym0, __sym1);
+        let __nt = super::__action92::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant4(__nt), __end));
         (2, 5)
     }
@@ -12850,14 +12964,14 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<FieldDefinition> COMMA)+ = (<FieldDefinition> COMMA)+, FieldDefinition, COMMA => ActionFn(92);
+        // (<FieldDefinition> COMMA)+ = (<FieldDefinition> COMMA)+, FieldDefinition, COMMA => ActionFn(93);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant3(__symbols);
         let __sym0 = __pop_Variant4(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action92::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action93::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant4(__nt), __end));
         (3, 5)
     }
@@ -12870,13 +12984,13 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<IdToken> COMMA) = IdToken, COMMA => ActionFn(64);
+        // (<IdToken> COMMA) = IdToken, COMMA => ActionFn(65);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action64::<>(input, __sym0, __sym1);
+        let __nt = super::__action65::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant5(__nt), __end));
         (2, 6)
     }
@@ -12889,10 +13003,10 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<IdToken> COMMA)* =  => ActionFn(62);
+        // (<IdToken> COMMA)* =  => ActionFn(63);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action62::<>(input, &__start, &__end);
+        let __nt = super::__action63::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant6(__nt), __end));
         (0, 7)
     }
@@ -12905,11 +13019,11 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<IdToken> COMMA)* = (<IdToken> COMMA)+ => ActionFn(63);
+        // (<IdToken> COMMA)* = (<IdToken> COMMA)+ => ActionFn(64);
         let __sym0 = __pop_Variant6(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action63::<>(input, __sym0);
+        let __nt = super::__action64::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant6(__nt), __end));
         (1, 7)
     }
@@ -12922,13 +13036,13 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<IdToken> COMMA)+ = IdToken, COMMA => ActionFn(95);
+        // (<IdToken> COMMA)+ = IdToken, COMMA => ActionFn(96);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action95::<>(input, __sym0, __sym1);
+        let __nt = super::__action96::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant6(__nt), __end));
         (2, 8)
     }
@@ -12941,14 +13055,14 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<IdToken> COMMA)+ = (<IdToken> COMMA)+, IdToken, COMMA => ActionFn(96);
+        // (<IdToken> COMMA)+ = (<IdToken> COMMA)+, IdToken, COMMA => ActionFn(97);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant5(__symbols);
         let __sym0 = __pop_Variant6(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action96::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action97::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant6(__nt), __end));
         (3, 8)
     }
@@ -12961,13 +13075,13 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<SelectField> COMMA) = SelectField, COMMA => ActionFn(67);
+        // (<SelectField> COMMA) = SelectField, COMMA => ActionFn(68);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant7(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action67::<>(input, __sym0, __sym1);
+        let __nt = super::__action68::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant7(__nt), __end));
         (2, 9)
     }
@@ -12980,10 +13094,10 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<SelectField> COMMA)* =  => ActionFn(65);
+        // (<SelectField> COMMA)* =  => ActionFn(66);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action65::<>(input, &__start, &__end);
+        let __nt = super::__action66::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant8(__nt), __end));
         (0, 10)
     }
@@ -12996,11 +13110,11 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<SelectField> COMMA)* = (<SelectField> COMMA)+ => ActionFn(66);
+        // (<SelectField> COMMA)* = (<SelectField> COMMA)+ => ActionFn(67);
         let __sym0 = __pop_Variant8(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action66::<>(input, __sym0);
+        let __nt = super::__action67::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant8(__nt), __end));
         (1, 10)
     }
@@ -13013,13 +13127,13 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<SelectField> COMMA)+ = SelectField, COMMA => ActionFn(99);
+        // (<SelectField> COMMA)+ = SelectField, COMMA => ActionFn(100);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant7(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action99::<>(input, __sym0, __sym1);
+        let __nt = super::__action100::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant8(__nt), __end));
         (2, 11)
     }
@@ -13032,14 +13146,14 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<SelectField> COMMA)+ = (<SelectField> COMMA)+, SelectField, COMMA => ActionFn(100);
+        // (<SelectField> COMMA)+ = (<SelectField> COMMA)+, SelectField, COMMA => ActionFn(101);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant7(__symbols);
         let __sym0 = __pop_Variant8(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action100::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action101::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant8(__nt), __end));
         (3, 11)
     }
@@ -13052,13 +13166,13 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Term> AND) = Term, AND => ActionFn(76);
+        // (<Term> AND) = Term, AND => ActionFn(77);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant9(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action76::<>(input, __sym0, __sym1);
+        let __nt = super::__action77::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant9(__nt), __end));
         (2, 12)
     }
@@ -13071,10 +13185,10 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Term> AND)* =  => ActionFn(74);
+        // (<Term> AND)* =  => ActionFn(75);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action74::<>(input, &__start, &__end);
+        let __nt = super::__action75::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant10(__nt), __end));
         (0, 13)
     }
@@ -13087,11 +13201,11 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Term> AND)* = (<Term> AND)+ => ActionFn(75);
+        // (<Term> AND)* = (<Term> AND)+ => ActionFn(76);
         let __sym0 = __pop_Variant10(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action75::<>(input, __sym0);
+        let __nt = super::__action76::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant10(__nt), __end));
         (1, 13)
     }
@@ -13104,13 +13218,13 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Term> AND)+ = Term, AND => ActionFn(103);
+        // (<Term> AND)+ = Term, AND => ActionFn(104);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant9(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action103::<>(input, __sym0, __sym1);
+        let __nt = super::__action104::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant10(__nt), __end));
         (2, 14)
     }
@@ -13123,14 +13237,14 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Term> AND)+ = (<Term> AND)+, Term, AND => ActionFn(104);
+        // (<Term> AND)+ = (<Term> AND)+, Term, AND => ActionFn(105);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant9(__symbols);
         let __sym0 = __pop_Variant10(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action104::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action105::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant10(__nt), __end));
         (3, 14)
     }
@@ -13143,14 +13257,14 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AddExpr = AddExpr, PLUS, MulExpr => ActionFn(40);
+        // AddExpr = AddExpr, PLUS, MulExpr => ActionFn(41);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant11(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action40::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action41::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (3, 15)
     }
@@ -13163,14 +13277,14 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AddExpr = AddExpr, MINUS, MulExpr => ActionFn(41);
+        // AddExpr = AddExpr, MINUS, MulExpr => ActionFn(42);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant11(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action41::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action42::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (3, 15)
     }
@@ -13183,11 +13297,11 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AddExpr = MulExpr => ActionFn(42);
+        // AddExpr = MulExpr => ActionFn(43);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action42::<>(input, __sym0);
+        let __nt = super::__action43::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (1, 15)
     }
@@ -13200,7 +13314,7 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AggregationFn = MAX, LPAREN, IdToken, RPAREN => ActionFn(13);
+        // AggregationFn = MAX, LPAREN, IdToken, RPAREN => ActionFn(14);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant5(__symbols);
@@ -13208,7 +13322,7 @@ mod __parse__Term {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action13::<>(input, __sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action14::<>(input, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant12(__nt), __end));
         (4, 16)
     }
@@ -13221,7 +13335,7 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AggregationFn = MIN, LPAREN, IdToken, RPAREN => ActionFn(14);
+        // AggregationFn = MIN, LPAREN, IdToken, RPAREN => ActionFn(15);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant5(__symbols);
@@ -13229,7 +13343,7 @@ mod __parse__Term {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action14::<>(input, __sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action15::<>(input, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant12(__nt), __end));
         (4, 16)
     }
@@ -13242,7 +13356,7 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AggregationFn = SUM, LPAREN, IdToken, RPAREN => ActionFn(15);
+        // AggregationFn = SUM, LPAREN, IdToken, RPAREN => ActionFn(16);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant5(__symbols);
@@ -13250,7 +13364,7 @@ mod __parse__Term {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action15::<>(input, __sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action16::<>(input, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant12(__nt), __end));
         (4, 16)
     }
@@ -13263,7 +13377,7 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AggregationFn = COUNT, LPAREN, IdToken, RPAREN => ActionFn(16);
+        // AggregationFn = COUNT, LPAREN, IdToken, RPAREN => ActionFn(17);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant5(__symbols);
@@ -13271,7 +13385,7 @@ mod __parse__Term {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action16::<>(input, __sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action17::<>(input, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant12(__nt), __end));
         (4, 16)
     }
@@ -13284,7 +13398,7 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AggregationFn = AVG, LPAREN, IdToken, RPAREN => ActionFn(17);
+        // AggregationFn = AVG, LPAREN, IdToken, RPAREN => ActionFn(18);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant5(__symbols);
@@ -13292,7 +13406,7 @@ mod __parse__Term {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action17::<>(input, __sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action18::<>(input, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant12(__nt), __end));
         (4, 16)
     }
@@ -13305,11 +13419,11 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // And<Term> = Term => ActionFn(105);
+        // And<Term> = Term => ActionFn(106);
         let __sym0 = __pop_Variant9(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action105::<>(input, __sym0);
+        let __nt = super::__action106::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant13(__nt), __end));
         (1, 17)
     }
@@ -13322,13 +13436,13 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // And<Term> = (<Term> AND)+, Term => ActionFn(106);
+        // And<Term> = (<Term> AND)+, Term => ActionFn(107);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant9(__symbols);
         let __sym0 = __pop_Variant10(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action106::<>(input, __sym0, __sym1);
+        let __nt = super::__action107::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant13(__nt), __end));
         (2, 17)
     }
@@ -13341,11 +13455,11 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<Constant> = Constant => ActionFn(89);
+        // Comma<Constant> = Constant => ActionFn(90);
         let __sym0 = __pop_Variant1(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action89::<>(input, __sym0);
+        let __nt = super::__action90::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant14(__nt), __end));
         (1, 18)
     }
@@ -13358,13 +13472,13 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<Constant> = (<Constant> COMMA)+, Constant => ActionFn(90);
+        // Comma<Constant> = (<Constant> COMMA)+, Constant => ActionFn(91);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant1(__symbols);
         let __sym0 = __pop_Variant2(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action90::<>(input, __sym0, __sym1);
+        let __nt = super::__action91::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant14(__nt), __end));
         (2, 18)
     }
@@ -13377,11 +13491,11 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<FieldDefinition> = FieldDefinition => ActionFn(93);
+        // Comma<FieldDefinition> = FieldDefinition => ActionFn(94);
         let __sym0 = __pop_Variant3(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action93::<>(input, __sym0);
+        let __nt = super::__action94::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (1, 19)
     }
@@ -13394,13 +13508,13 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<FieldDefinition> = (<FieldDefinition> COMMA)+, FieldDefinition => ActionFn(94);
+        // Comma<FieldDefinition> = (<FieldDefinition> COMMA)+, FieldDefinition => ActionFn(95);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant3(__symbols);
         let __sym0 = __pop_Variant4(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action94::<>(input, __sym0, __sym1);
+        let __nt = super::__action95::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (2, 19)
     }
@@ -13413,11 +13527,11 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<IdToken> = IdToken => ActionFn(97);
+        // Comma<IdToken> = IdToken => ActionFn(98);
         let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action97::<>(input, __sym0);
+        let __nt = super::__action98::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant16(__nt), __end));
         (1, 20)
     }
@@ -13430,13 +13544,13 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<IdToken> = (<IdToken> COMMA)+, IdToken => ActionFn(98);
+        // Comma<IdToken> = (<IdToken> COMMA)+, IdToken => ActionFn(99);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant5(__symbols);
         let __sym0 = __pop_Variant6(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action98::<>(input, __sym0, __sym1);
+        let __nt = super::__action99::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant16(__nt), __end));
         (2, 20)
     }
@@ -13449,11 +13563,11 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<SelectField> = SelectField => ActionFn(101);
+        // Comma<SelectField> = SelectField => ActionFn(102);
         let __sym0 = __pop_Variant7(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action101::<>(input, __sym0);
+        let __nt = super::__action102::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant17(__nt), __end));
         (1, 21)
     }
@@ -13466,13 +13580,13 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<SelectField> = (<SelectField> COMMA)+, SelectField => ActionFn(102);
+        // Comma<SelectField> = (<SelectField> COMMA)+, SelectField => ActionFn(103);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant7(__symbols);
         let __sym0 = __pop_Variant8(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action102::<>(input, __sym0, __sym1);
+        let __nt = super::__action103::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant17(__nt), __end));
         (2, 21)
     }
@@ -13485,11 +13599,11 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Constant = NULL => ActionFn(51);
+        // Constant = NULL => ActionFn(52);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action51::<>(input, __sym0);
+        let __nt = super::__action52::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant1(__nt), __end));
         (1, 22)
     }
@@ -13502,11 +13616,11 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Constant = I32Constant => ActionFn(52);
+        // Constant = I32Constant => ActionFn(53);
         let __sym0 = __pop_Variant21(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action52::<>(input, __sym0);
+        let __nt = super::__action53::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant1(__nt), __end));
         (1, 22)
     }
@@ -13519,11 +13633,11 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Constant = StringConstant => ActionFn(53);
+        // Constant = StringConstant => ActionFn(54);
         let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action53::<>(input, __sym0);
+        let __nt = super::__action54::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant1(__nt), __end));
         (1, 22)
     }
@@ -13536,7 +13650,7 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // CreateCommand = CREATE, TABLE, IdToken, LPAREN, Comma<FieldDefinition>, RPAREN => ActionFn(30);
+        // CreateCommand = CREATE, TABLE, IdToken, LPAREN, Comma<FieldDefinition>, RPAREN => ActionFn(31);
         assert!(__symbols.len() >= 6);
         let __sym5 = __pop_Variant0(__symbols);
         let __sym4 = __pop_Variant15(__symbols);
@@ -13546,7 +13660,7 @@ mod __parse__Term {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym5.2;
-        let __nt = super::__action30::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
+        let __nt = super::__action31::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
         __symbols.push((__start, __Symbol::Variant18(__nt), __end));
         (6, 23)
     }
@@ -13559,7 +13673,7 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // CreateCommand = CREATE, VIEW, IdToken, AS, Query => ActionFn(31);
+        // CreateCommand = CREATE, VIEW, IdToken, AS, Query => ActionFn(32);
         assert!(__symbols.len() >= 5);
         let __sym4 = __pop_Variant25(__symbols);
         let __sym3 = __pop_Variant0(__symbols);
@@ -13568,7 +13682,7 @@ mod __parse__Term {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym4.2;
-        let __nt = super::__action31::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4);
+        let __nt = super::__action32::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4);
         __symbols.push((__start, __Symbol::Variant18(__nt), __end));
         (5, 23)
     }
@@ -13581,7 +13695,7 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // CreateCommand = CREATE, INDEX, IdToken, ON, IdToken, LPAREN, IdToken, RPAREN => ActionFn(32);
+        // CreateCommand = CREATE, INDEX, IdToken, ON, IdToken, LPAREN, IdToken, RPAREN => ActionFn(33);
         assert!(__symbols.len() >= 8);
         let __sym7 = __pop_Variant0(__symbols);
         let __sym6 = __pop_Variant5(__symbols);
@@ -13593,7 +13707,7 @@ mod __parse__Term {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym7.2;
-        let __nt = super::__action32::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
+        let __nt = super::__action33::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
         __symbols.push((__start, __Symbol::Variant18(__nt), __end));
         (8, 23)
     }
@@ -13606,11 +13720,11 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Expression = AddExpr => ActionFn(39);
+        // Expression = AddExpr => ActionFn(40);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action39::<>(input, __sym0);
+        let __nt = super::__action40::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (1, 24)
     }
@@ -13623,14 +13737,14 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Factor = LPAREN, Expression, RPAREN => ActionFn(46);
+        // Factor = LPAREN, Expression, RPAREN => ActionFn(47);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant11(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action46::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action47::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (3, 25)
     }
@@ -13643,11 +13757,11 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Factor = NULL => ActionFn(47);
+        // Factor = NULL => ActionFn(48);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action47::<>(input, __sym0);
+        let __nt = super::__action48::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (1, 25)
     }
@@ -13660,11 +13774,11 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Factor = I32Constant => ActionFn(48);
+        // Factor = I32Constant => ActionFn(49);
         let __sym0 = __pop_Variant21(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action48::<>(input, __sym0);
+        let __nt = super::__action49::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (1, 25)
     }
@@ -13677,11 +13791,11 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Factor = StringConstant => ActionFn(49);
+        // Factor = StringConstant => ActionFn(50);
         let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action49::<>(input, __sym0);
+        let __nt = super::__action50::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (1, 25)
     }
@@ -13694,11 +13808,11 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Factor = IdToken => ActionFn(50);
+        // Factor = IdToken => ActionFn(51);
         let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action50::<>(input, __sym0);
+        let __nt = super::__action51::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (1, 25)
     }
@@ -13711,13 +13825,13 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // FieldDefinition = IdToken, FieldType => ActionFn(33);
+        // FieldDefinition = IdToken, FieldType => ActionFn(34);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant20(__symbols);
         let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action33::<>(input, __sym0, __sym1);
+        let __nt = super::__action34::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant3(__nt), __end));
         (2, 26)
     }
@@ -13764,11 +13878,11 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // FieldType = I32 => ActionFn(34);
+        // FieldType = I32 => ActionFn(35);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action34::<>(input, __sym0);
+        let __nt = super::__action35::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant20(__nt), __end));
         (1, 28)
     }
@@ -13781,7 +13895,7 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // FieldType = VARCHAR, LPAREN, I32Constant, RPAREN => ActionFn(35);
+        // FieldType = VARCHAR, LPAREN, I32Constant, RPAREN => ActionFn(36);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant21(__symbols);
@@ -13789,7 +13903,7 @@ mod __parse__Term {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action35::<>(input, __sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action36::<>(input, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant20(__nt), __end));
         (4, 28)
     }
@@ -13802,11 +13916,11 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // I32Constant = I32_LITERAL => ActionFn(54);
+        // I32Constant = I32_LITERAL => ActionFn(55);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action54::<>(input, __sym0);
+        let __nt = super::__action55::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant21(__nt), __end));
         (1, 29)
     }
@@ -13819,11 +13933,11 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // IdToken = ID => ActionFn(56);
+        // IdToken = ID => ActionFn(57);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action56::<>(input, __sym0);
+        let __nt = super::__action57::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant5(__nt), __end));
         (1, 30)
     }
@@ -13836,14 +13950,14 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // MulExpr = MulExpr, STAR, Factor => ActionFn(43);
+        // MulExpr = MulExpr, STAR, Factor => ActionFn(44);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant11(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action43::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action44::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (3, 31)
     }
@@ -13856,14 +13970,14 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // MulExpr = MulExpr, SLASH, Factor => ActionFn(44);
+        // MulExpr = MulExpr, SLASH, Factor => ActionFn(45);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant11(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action44::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action45::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (3, 31)
     }
@@ -13876,11 +13990,11 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // MulExpr = Factor => ActionFn(45);
+        // MulExpr = Factor => ActionFn(46);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action45::<>(input, __sym0);
+        let __nt = super::__action46::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (1, 31)
     }
@@ -13893,14 +14007,14 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // OptGroupBy = GROUP, BY, Comma<IdToken> => ActionFn(20);
+        // OptGroupBy = GROUP, BY, Comma<IdToken> => ActionFn(21);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant16(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action20::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action21::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant22(__nt), __end));
         (3, 32)
     }
@@ -13913,10 +14027,10 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // OptGroupBy =  => ActionFn(21);
+        // OptGroupBy =  => ActionFn(22);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action21::<>(input, &__start, &__end);
+        let __nt = super::__action22::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant22(__nt), __end));
         (0, 32)
     }
@@ -13929,14 +14043,14 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // OptOrderBy = ORDER, BY, Comma<IdToken> => ActionFn(22);
+        // OptOrderBy = ORDER, BY, Comma<IdToken> => ActionFn(23);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant16(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action22::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action23::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant22(__nt), __end));
         (3, 33)
     }
@@ -13949,10 +14063,10 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // OptOrderBy =  => ActionFn(23);
+        // OptOrderBy =  => ActionFn(24);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action23::<>(input, &__start, &__end);
+        let __nt = super::__action24::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant22(__nt), __end));
         (0, 33)
     }
@@ -13965,13 +14079,13 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // OptPredicate = WHERE, Predicate => ActionFn(18);
+        // OptPredicate = WHERE, Predicate => ActionFn(19);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant24(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action18::<>(input, __sym0, __sym1);
+        let __nt = super::__action19::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant23(__nt), __end));
         (2, 34)
     }
@@ -13984,10 +14098,10 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // OptPredicate =  => ActionFn(19);
+        // OptPredicate =  => ActionFn(20);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action19::<>(input, &__start, &__end);
+        let __nt = super::__action20::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant23(__nt), __end));
         (0, 34)
     }
@@ -14000,11 +14114,11 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Predicate = And<Term> => ActionFn(36);
+        // Predicate = And<Term> => ActionFn(37);
         let __sym0 = __pop_Variant13(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action36::<>(input, __sym0);
+        let __nt = super::__action37::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant24(__nt), __end));
         (1, 35)
     }
@@ -14078,15 +14192,35 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // SelectField = AggregationFn => ActionFn(12);
+        // SelectField = AggregationFn, AS, IdToken => ActionFn(12);
+        assert!(__symbols.len() >= 3);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant12(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym2.2;
+        let __nt = super::__action12::<>(input, __sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant7(__nt), __end));
+        (3, 37)
+    }
+    fn __reduce76<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // SelectField = AggregationFn => ActionFn(13);
         let __sym0 = __pop_Variant12(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action12::<>(input, __sym0);
+        let __nt = super::__action13::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant7(__nt), __end));
         (1, 37)
     }
-    fn __reduce76<
+    fn __reduce77<
         'input,
     >(
         input: &'input str,
@@ -14103,7 +14237,7 @@ mod __parse__Term {
         __symbols.push((__start, __Symbol::Variant26(__nt), __end));
         (1, 38)
     }
-    fn __reduce77<
+    fn __reduce78<
         'input,
     >(
         input: &'input str,
@@ -14120,23 +14254,6 @@ mod __parse__Term {
         __symbols.push((__start, __Symbol::Variant26(__nt), __end));
         (1, 38)
     }
-    fn __reduce78<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // StringConstant = STRING_LITERAL => ActionFn(55);
-        let __sym0 = __pop_Variant0(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action55::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant5(__nt), __end));
-        (1, 39)
-    }
     fn __reduce79<
         'input,
     >(
@@ -14146,16 +14263,13 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Term = Expression, IS, NULL => ActionFn(37);
-        assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant11(__symbols);
+        // StringConstant = STRING_LITERAL => ActionFn(56);
+        let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym2.2;
-        let __nt = super::__action37::<>(input, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant9(__nt), __end));
-        (3, 40)
+        let __end = __sym0.2;
+        let __nt = super::__action56::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant5(__nt), __end));
+        (1, 39)
     }
     fn __reduce80<
         'input,
@@ -14166,9 +14280,9 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Term = Expression, EQ, Expression => ActionFn(38);
+        // Term = Expression, IS, NULL => ActionFn(38);
         assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant11(__symbols);
+        let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
@@ -14186,7 +14300,27 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // UpdateCommand = INSERT, INTO, IdToken, LPAREN, Comma<IdToken>, RPAREN, VALUES, LPAREN, Comma<Constant>, RPAREN => ActionFn(24);
+        // Term = Expression, EQ, Expression => ActionFn(39);
+        assert!(__symbols.len() >= 3);
+        let __sym2 = __pop_Variant11(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant11(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym2.2;
+        let __nt = super::__action39::<>(input, __sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant9(__nt), __end));
+        (3, 40)
+    }
+    fn __reduce82<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // UpdateCommand = INSERT, INTO, IdToken, LPAREN, Comma<IdToken>, RPAREN, VALUES, LPAREN, Comma<Constant>, RPAREN => ActionFn(25);
         assert!(__symbols.len() >= 10);
         let __sym9 = __pop_Variant0(__symbols);
         let __sym8 = __pop_Variant14(__symbols);
@@ -14200,29 +14334,9 @@ mod __parse__Term {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym9.2;
-        let __nt = super::__action24::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9);
+        let __nt = super::__action25::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9);
         __symbols.push((__start, __Symbol::Variant27(__nt), __end));
         (10, 41)
-    }
-    fn __reduce82<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // UpdateCommand = DELETE, FROM, IdToken => ActionFn(25);
-        assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant5(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym2.2;
-        let __nt = super::__action25::<>(input, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant27(__nt), __end));
-        (3, 41)
     }
     fn __reduce83<
         'input,
@@ -14233,18 +14347,16 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // UpdateCommand = DELETE, FROM, IdToken, WHERE, Predicate => ActionFn(26);
-        assert!(__symbols.len() >= 5);
-        let __sym4 = __pop_Variant24(__symbols);
-        let __sym3 = __pop_Variant0(__symbols);
+        // UpdateCommand = DELETE, FROM, IdToken => ActionFn(26);
+        assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant5(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym4.2;
-        let __nt = super::__action26::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4);
+        let __end = __sym2.2;
+        let __nt = super::__action26::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant27(__nt), __end));
-        (5, 41)
+        (3, 41)
     }
     fn __reduce84<
         'input,
@@ -14255,19 +14367,18 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // UpdateCommand = MODIFY, IdToken, SET, IdToken, EQ, Expression => ActionFn(27);
-        assert!(__symbols.len() >= 6);
-        let __sym5 = __pop_Variant11(__symbols);
-        let __sym4 = __pop_Variant0(__symbols);
-        let __sym3 = __pop_Variant5(__symbols);
-        let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant5(__symbols);
+        // UpdateCommand = DELETE, FROM, IdToken, WHERE, Predicate => ActionFn(27);
+        assert!(__symbols.len() >= 5);
+        let __sym4 = __pop_Variant24(__symbols);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym5.2;
-        let __nt = super::__action27::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
+        let __end = __sym4.2;
+        let __nt = super::__action27::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4);
         __symbols.push((__start, __Symbol::Variant27(__nt), __end));
-        (6, 41)
+        (5, 41)
     }
     fn __reduce85<
         'input,
@@ -14278,7 +14389,30 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // UpdateCommand = MODIFY, IdToken, SET, IdToken, EQ, Expression, WHERE, Predicate => ActionFn(28);
+        // UpdateCommand = MODIFY, IdToken, SET, IdToken, EQ, Expression => ActionFn(28);
+        assert!(__symbols.len() >= 6);
+        let __sym5 = __pop_Variant11(__symbols);
+        let __sym4 = __pop_Variant0(__symbols);
+        let __sym3 = __pop_Variant5(__symbols);
+        let __sym2 = __pop_Variant0(__symbols);
+        let __sym1 = __pop_Variant5(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym5.2;
+        let __nt = super::__action28::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
+        __symbols.push((__start, __Symbol::Variant27(__nt), __end));
+        (6, 41)
+    }
+    fn __reduce86<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // UpdateCommand = MODIFY, IdToken, SET, IdToken, EQ, Expression, WHERE, Predicate => ActionFn(29);
         assert!(__symbols.len() >= 8);
         let __sym7 = __pop_Variant24(__symbols);
         let __sym6 = __pop_Variant0(__symbols);
@@ -14290,11 +14424,11 @@ mod __parse__Term {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym7.2;
-        let __nt = super::__action28::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
+        let __nt = super::__action29::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
         __symbols.push((__start, __Symbol::Variant27(__nt), __end));
         (8, 41)
     }
-    fn __reduce86<
+    fn __reduce87<
         'input,
     >(
         input: &'input str,
@@ -14303,15 +14437,15 @@ mod __parse__Term {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // UpdateCommand = CreateCommand => ActionFn(29);
+        // UpdateCommand = CreateCommand => ActionFn(30);
         let __sym0 = __pop_Variant18(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action29::<>(input, __sym0);
+        let __nt = super::__action30::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant27(__nt), __end));
         (1, 41)
     }
-    fn __reduce87<
+    fn __reduce88<
         'input,
     >(
         input: &'input str,
@@ -14328,7 +14462,7 @@ mod __parse__Term {
         __symbols.push((__start, __Symbol::Variant24(__nt), __end));
         (1, 42)
     }
-    fn __reduce88<
+    fn __reduce89<
         'input,
     >(
         input: &'input str,
@@ -14345,7 +14479,7 @@ mod __parse__Term {
         __symbols.push((__start, __Symbol::Variant25(__nt), __end));
         (1, 43)
     }
-    fn __reduce89<
+    fn __reduce90<
         'input,
     >(
         input: &'input str,
@@ -14362,7 +14496,7 @@ mod __parse__Term {
         __symbols.push((__start, __Symbol::Variant26(__nt), __end));
         (1, 44)
     }
-    fn __reduce91<
+    fn __reduce92<
         'input,
     >(
         input: &'input str,
@@ -14442,181 +14576,181 @@ mod __parse__UpdateCommand {
     }
     const __ACTION: &[i16] = &[
         // State 0
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 47, 48, 0, 0, 0, 0, 49, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 48, 49, 0, 0, 0, 0, 50, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 1
-        0, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 52, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 2
-        0, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 52, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 3
-        0, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 52, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 4
-        0, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 52, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 5
-        0, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 52, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 6
-        0, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 52, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 7
-        0, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 52, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 8
-        0, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 52, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 9
-        0, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 52, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 10
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 16, 0, 0, 0, 0, 0, 0, 0,
         // State 11
-        0, 51, 74, 72, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 73, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 52, 75, 73, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 74, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 12
-        0, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 52, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 13
-        0, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 52, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 14
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 81, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 82, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 82, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 83, 0, 0,
         // State 15
-        0, 51, 74, 72, 0, 18, 0, 92, 0, 0, 0, 0, 0, 0, 88, 0, 89, 0, 0, 0, 0, 0, 0, 0, 0, 0, 90, 91, 0, 73, 0, 0, 0, 0, 93, 0, 0, 0, 0, 0,
+        0, 52, 75, 73, 0, 18, 0, 93, 0, 0, 0, 0, 0, 0, 89, 0, 90, 0, 0, 0, 0, 0, 0, 0, 0, 0, 91, 92, 0, 74, 0, 0, 0, 0, 94, 0, 0, 0, 0, 0,
         // State 16
-        0, 51, 74, 72, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 73, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 52, 75, 73, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 74, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 17
-        0, 51, 74, 72, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 73, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 52, 75, 73, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 74, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 18
-        0, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 52, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 19
-        0, 51, 74, 72, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 73, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 52, 75, 73, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 74, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 20
-        0, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 52, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 21
-        0, 51, 74, 72, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 88, 0, 89, 0, 0, 0, 0, 0, 0, 0, 0, 0, 90, 91, 0, 73, 0, 0, 0, 0, 93, 0, 0, 0, 0, 0,
+        0, 52, 75, 73, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 89, 0, 90, 0, 0, 0, 0, 0, 0, 0, 0, 0, 91, 92, 0, 74, 0, 0, 0, 0, 94, 0, 0, 0, 0, 0,
         // State 22
-        0, 51, 74, 72, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 73, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 52, 75, 73, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 74, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 23
-        0, 51, 74, 72, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 73, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 52, 75, 73, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 74, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 24
-        0, 51, 74, 72, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 73, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 52, 75, 73, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 74, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 25
-        0, 51, 74, 72, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 73, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 52, 75, 73, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 74, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 26
-        0, 51, 74, 72, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 73, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 52, 75, 73, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 74, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 27
-        0, 0, 0, 72, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 73, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 28
-        0, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 52, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 29
-        0, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 52, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 30
-        0, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 52, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 31
-        0, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 52, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 32
-        0, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 52, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 33
-        0, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 52, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 34
-        0, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 52, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 35
-        0, 51, 74, 72, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 73, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 52, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 36
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -71, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -71, 0, 0, 0, 0, 0, 0, 0, 40,
+        0, 52, 75, 73, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 74, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 37
-        0, 0, 74, 72, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 136, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -71, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -71, 0, 0, 0, 0, 0, 0, 0, 41,
         // State 38
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 137, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -67, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 75, 73, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 138, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 39
-        0, 51, 74, 72, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 73, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 139, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -67, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 40
-        0, 0, 74, 72, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 136, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 52, 75, 73, 0, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 74, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 41
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 143, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 75, 73, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 138, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 42
-        0, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 145, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 43
-        0, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 52, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 44
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 52, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 45
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 46
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 5, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 47
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 5, 0,
         // State 48
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 49
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 50
-        0, 0, 0, 0, -62, -62, -62, -62, -62, -62, -62, -62, -62, -62, 0, 0, 0, 0, 0, -62, -62, -62, 0, 0, 0, -62, 0, 0, 0, 0, -62, -62, 0, -62, 0, 0, 0, -62, 0, -62,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0,
         // State 51
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -62, -62, -62, -62, -62, -62, -62, -62, -62, -62, 0, 0, 0, 0, 0, -62, -62, -62, 0, 0, 0, -62, 0, 0, 0, 0, -62, -62, 0, -62, 0, 0, 0, -62, 0, -62,
         // State 52
-        0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 53
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 54
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 12,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 55
-        0, 0, 0, 0, 0, 13, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 12,
         // State 56
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 20, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 13, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 57
-        0, 0, 0, 0, 0, 21, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 20, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 58
-        0, 0, 0, 0, 0, 0, 78, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 21, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 59
-        0, 0, 0, 0, 0, 0, -38, 0, 0, 79, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 79, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 60
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, -38, 0, 0, 80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 61
-        0, 0, 0, 0, 23, 0, -50, 0, 24, -50, 0, -50, -50, -50, 0, 0, 0, 0, 0, -50, -50, 0, 0, 0, 0, -50, 0, 0, 0, 0, 0, -50, 0, 0, 0, 0, 0, 0, 0, -50,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 62
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -72, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -72, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 23, 0, -50, 0, 24, -50, 0, -50, -50, -50, 0, 0, 0, 0, 0, -50, -50, 0, 0, 0, 0, -50, 0, 0, 0, 0, 0, -50, 0, 0, 0, 0, 0, 0, 0, -50,
         // State 63
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 95, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -72, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -72, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 64
-        0, 0, 0, 0, -65, 0, -65, -65, -65, -65, -65, -65, -65, -65, 0, 0, 0, 0, 0, -65, -65, 0, 0, 0, 0, -65, 0, 0, 0, 0, 0, -65, 0, 0, 0, 0, 0, 0, 0, -65,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 96, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 65
-        0, 0, 0, 0, -53, 0, -53, -53, -53, -53, -53, -53, -53, -53, 0, 0, 0, 0, 0, -53, -53, 0, 0, 0, 0, -53, 0, 0, 0, 0, 0, -53, 0, 0, 0, 0, 0, 0, 0, -53,
+        0, 0, 0, 0, -65, 0, -65, -65, -65, -65, -65, -65, -65, -65, 0, 0, 0, 0, 0, -65, -65, 0, 0, 0, 0, -65, 0, 0, 0, 0, 0, -65, 0, 0, 0, 0, 0, 0, 0, -65,
         // State 66
-        0, 0, 0, 0, -55, 0, -55, -55, -55, -55, -55, -55, -55, -55, 0, 0, 0, 0, 0, -55, -55, 0, 0, 0, 0, -55, 0, 0, 0, 0, 0, -55, 0, 0, 0, 0, 0, 0, 0, -55,
+        0, 0, 0, 0, -53, 0, -53, -53, -53, -53, -53, -53, -53, -53, 0, 0, 0, 0, 0, -53, -53, 0, 0, 0, 0, -53, 0, 0, 0, 0, 0, -53, 0, 0, 0, 0, 0, 0, 0, -53,
         // State 67
-        0, 0, 0, 0, -28, 0, -28, 27, -28, -28, 26, -28, -28, -28, 0, 0, 0, 0, 0, -28, -28, 0, 0, 0, 0, -28, 0, 0, 0, 0, 0, -28, 0, 0, 0, 0, 0, 0, 0, -28,
+        0, 0, 0, 0, -55, 0, -55, -55, -55, -55, -55, -55, -55, -55, 0, 0, 0, 0, 0, -55, -55, 0, 0, 0, 0, -55, 0, 0, 0, 0, 0, -55, 0, 0, 0, 0, 0, 0, 0, -55,
         // State 68
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -28, 0, -28, 27, -28, -28, 26, -28, -28, -28, 0, 0, 0, 0, 0, -28, -28, 0, 0, 0, 0, -28, 0, 0, 0, 0, 0, -28, 0, 0, 0, 0, 0, 0, 0, -28,
         // State 69
-        0, 0, 0, 0, -54, 0, -54, -54, -54, -54, -54, -54, -54, -54, 0, 0, 0, 0, 0, -54, -54, 0, 0, 0, 0, -54, 0, 0, 0, 0, 0, -54, 0, 0, 0, 0, 0, 0, 0, -54,
-        // State 70
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 96, 0, 0, 0, 0, 0, 0, 0, -34, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -34, 0, 0, 0, 0, 0, 0, 0, 0,
-        // State 71
-        0, 0, 0, 0, -61, 0, -61, -61, -61, -61, -61, -61, -61, -61, 0, 0, 0, 0, 0, -61, -61, 0, 0, 0, 0, -61, 0, 0, 0, 0, 0, -61, 0, 0, 0, 0, 0, 0, 0, -61,
-        // State 72
-        0, 0, 0, 0, -52, 0, -52, -52, -52, -52, -52, -52, -52, -52, 0, 0, 0, 0, 0, -52, -52, 0, 0, 0, 0, -52, 0, 0, 0, 0, 0, -52, 0, 0, 0, 0, 0, 0, 0, -52,
-        // State 73
-        0, 0, 0, 0, -79, 0, -79, -79, -79, -79, -79, -79, -79, -79, 0, 0, 0, 0, 0, -79, -79, 0, 0, 0, 0, -79, 0, 0, 0, 0, 0, -79, 0, 0, 0, 0, 0, 0, 0, -79,
-        // State 74
-        0, 0, 0, 0, 0, 0, 99, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        // State 75
-        0, 0, 0, 0, 0, 0, -40, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -40, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -40, 0, 0, 0, 0, 0, 0, 0, -40,
-        // State 76
-        0, 0, 0, 0, 0, 0, -39, 0, 0, 103, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        // State 77
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 70
+        0, 0, 0, 0, -54, 0, -54, -54, -54, -54, -54, -54, -54, -54, 0, 0, 0, 0, 0, -54, -54, 0, 0, 0, 0, -54, 0, 0, 0, 0, 0, -54, 0, 0, 0, 0, 0, 0, 0, -54,
+        // State 71
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 97, 0, 0, 0, 0, 0, 0, 0, -34, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -34, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 72
+        0, 0, 0, 0, -61, 0, -61, -61, -61, -61, -61, -61, -61, -61, 0, 0, 0, 0, 0, -61, -61, 0, 0, 0, 0, -61, 0, 0, 0, 0, 0, -61, 0, 0, 0, 0, 0, 0, 0, -61,
+        // State 73
+        0, 0, 0, 0, -52, 0, -52, -52, -52, -52, -52, -52, -52, -52, 0, 0, 0, 0, 0, -52, -52, 0, 0, 0, 0, -52, 0, 0, 0, 0, 0, -52, 0, 0, 0, 0, 0, 0, 0, -52,
+        // State 74
+        0, 0, 0, 0, -80, 0, -80, -80, -80, -80, -80, -80, -80, -80, 0, 0, 0, 0, 0, -80, -80, 0, 0, 0, 0, -80, 0, 0, 0, 0, 0, -80, 0, 0, 0, 0, 0, 0, 0, -80,
+        // State 75
+        0, 0, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 76
+        0, 0, 0, 0, 0, 0, -40, 0, 0, 101, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -40, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -40, 0, 0, 0, 0, 0, 0, 0, -40,
+        // State 77
+        0, 0, 0, 0, 0, 0, -39, 0, 0, 104, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 78
-        0, -9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 79
-        0, 0, 0, 0, 0, 0, -56, 0, 0, -56, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, -9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 80
-        0, 0, 0, 0, 0, 0, -59, 0, 0, -59, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, -56, 0, 0, -56, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 81
-        0, 0, 0, 0, 0, 28, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, -59, 0, 0, -59, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 82
-        0, 0, 0, 0, 0, 0, 0, 0, 0, -76, 0, 0, 0, 0, 0, 0, 0, 0, 0, -76, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 28, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 83
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -58, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, -77, 0, 0, 0, 29, 0, 0, 0, 0, 0, -77, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 84
-        0, 0, 0, 0, 0, 0, 0, 0, 0, -75, 0, 0, 0, 29, 0, 0, 0, 0, 0, -75, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -58, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 85
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 30, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, -75, 0, 0, 0, 30, 0, 0, 0, 0, 0, -75, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 86
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 105, 0, 0, 0, 0, 0, 0, 0, 0, 0, -42, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 31, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 87
-        0, 0, 0, 0, 0, 31, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 106, 0, 0, 0, 0, 0, 0, 0, 0, 0, -42, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 88
         0, 0, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 89
@@ -14624,65 +14758,65 @@ mod __parse__UpdateCommand {
         // State 90
         0, 0, 0, 0, 0, 34, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 91
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -57, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        // State 92
         0, 0, 0, 0, 0, 35, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 92
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -57, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 93
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 106, 0, 0, 0, 0, 0, 0, 0, -35, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -35, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 36, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 94
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 110, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 107, 0, 0, 0, 0, 0, 0, 0, -35, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -35, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 95
-        0, -24, -24, -24, 0, -24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 111, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 96
-        0, 0, 0, 0, 0, 0, 113, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, -24, -24, -24, 0, -24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 97
-        0, 0, 0, 0, 0, 0, -41, 0, 0, 114, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -41, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -41, 0, 0, 0, 0, 0, 0, 0, -41,
+        0, 0, 0, 0, 0, 0, 114, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 98
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 115, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, -41, 0, 0, 115, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -41, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -41, 0, 0, 0, 0, 0, 0, 0, -41,
         // State 99
-        0, -14, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 116, 0, 0, 0,
         // State 100
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 36,
+        0, -14, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 101
-        0, 0, 0, 0, 0, 0, 116, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 37,
         // State 102
-        0, -10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 117, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 103
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 118, 0, 0, 0, 0, 0, 0, 0, 0, 0, -43, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, -10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 104
-        0, -19, -19, -19, 0, -19, 0, 0, 0, 0, 0, 0, 0, 0, -19, 0, -19, 0, 0, 0, 0, 0, 0, 0, 0, 0, -19, -19, 0, -19, 0, 0, 0, 0, -19, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 119, 0, 0, 0, 0, 0, 0, 0, 0, 0, -43, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 105
-        0, -25, -25, -25, 0, -25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, -19, -19, -19, 0, -19, 0, 0, 0, 0, 0, 0, 0, 0, -19, 0, -19, 0, 0, 0, 0, 0, 0, 0, 0, 0, -19, -19, 0, -19, 0, 0, 0, 0, -19, 0, 0, 0, 0, 0,
         // State 106
-        0, 0, 0, 0, -27, 0, -27, 27, -27, -27, 26, -27, -27, -27, 0, 0, 0, 0, 0, -27, -27, 0, 0, 0, 0, -27, 0, 0, 0, 0, 0, -27, 0, 0, 0, 0, 0, 0, 0, -27,
+        0, -25, -25, -25, 0, -25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 107
-        0, 0, 0, 0, -26, 0, -26, 27, -26, -26, 26, -26, -26, -26, 0, 0, 0, 0, 0, -26, -26, 0, 0, 0, 0, -26, 0, 0, 0, 0, 0, -26, 0, 0, 0, 0, 0, 0, 0, -26,
+        0, 0, 0, 0, -27, 0, -27, 27, -27, -27, 26, -27, -27, -27, 0, 0, 0, 0, 0, -27, -27, 0, 0, 0, 0, -27, 0, 0, 0, 0, 0, -27, 0, 0, 0, 0, 0, 0, 0, -27,
         // State 108
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -81, 0, 0, 0, 0, 0, 0, 0, -81, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -81, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -26, 0, -26, 27, -26, -26, 26, -26, -26, -26, 0, 0, 0, 0, 0, -26, -26, 0, 0, 0, 0, -26, 0, 0, 0, 0, 0, -26, 0, 0, 0, 0, 0, 0, 0, -26,
         // State 109
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -80, 0, 0, 0, 0, 0, 0, 0, -80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -80, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -82, 0, 0, 0, 0, 0, 0, 0, -82, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -82, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 110
-        0, 0, 0, 0, -64, 0, -64, -64, -64, -64, -64, -64, -64, -64, 0, 0, 0, 0, 0, -64, -64, 0, 0, 0, 0, -64, 0, 0, 0, 0, 0, -64, 0, 0, 0, 0, 0, 0, 0, -64,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -81, 0, 0, 0, 0, 0, 0, 0, -81, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -81, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 111
-        0, 0, 0, 0, -63, 0, -63, -63, -63, -63, -63, -63, -63, -63, 0, 0, 0, 0, 0, -63, -63, 0, 0, 0, 0, -63, 0, 0, 0, 0, 0, -63, 0, 0, 0, 0, 0, 0, 0, -63,
+        0, 0, 0, 0, -64, 0, -64, -64, -64, -64, -64, -64, -64, -64, 0, 0, 0, 0, 0, -64, -64, 0, 0, 0, 0, -64, 0, 0, 0, 0, 0, -64, 0, 0, 0, 0, 0, 0, 0, -64,
         // State 112
-        0, 0, 0, 0, -51, 0, -51, -51, -51, -51, -51, -51, -51, -51, 0, 0, 0, 0, 0, -51, -51, 0, 0, 0, 0, -51, 0, 0, 0, 0, 0, -51, 0, 0, 0, 0, 0, 0, 0, -51,
+        0, 0, 0, 0, -63, 0, -63, -63, -63, -63, -63, -63, -63, -63, 0, 0, 0, 0, 0, -63, -63, 0, 0, 0, 0, -63, 0, 0, 0, 0, 0, -63, 0, 0, 0, 0, 0, 0, 0, -63,
         // State 113
-        0, -15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, -51, 0, -51, -51, -51, -51, -51, -51, -51, -51, 0, 0, 0, 0, 0, -51, -51, 0, 0, 0, 0, -51, 0, 0, 0, 0, 0, -51, 0, 0, 0, 0, 0, 0, 0, -51,
         // State 114
-        0, 0, 0, 0, 0, 38, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, -15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 115
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 39, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 116
-        0, 0, 0, 0, 0, 0, 126, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 117
-        0, -20, -20, -20, 0, -20, 0, 0, 0, 0, 0, 0, 0, 0, -20, 0, -20, 0, 0, 0, 0, 0, 0, 0, 0, 0, -20, -20, 0, -20, 0, 0, 0, 0, -20, 0, 0, 0, 0, 0,
-        // State 118
-        0, 0, 0, 0, 0, 0, 0, 0, 0, -74, 0, 0, 0, 0, 0, 0, 0, 0, 0, -74, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        // State 119
-        0, 0, 0, 0, 0, 0, 127, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        // State 120
         0, 0, 0, 0, 0, 0, 128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 118
+        0, -20, -20, -20, 0, -20, 0, 0, 0, 0, 0, 0, 0, 0, -20, 0, -20, 0, 0, 0, 0, 0, 0, 0, 0, 0, -20, -20, 0, -20, 0, 0, 0, 0, -20, 0, 0, 0, 0, 0,
+        // State 119
+        0, 0, 0, 0, 0, 0, 0, 0, 0, -76, 0, 0, 0, 0, 0, 0, 0, 0, 0, -76, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 120
+        0, 0, 0, 0, 0, 0, 0, 0, 0, -74, 0, 0, 0, 0, 0, 0, 0, 0, 0, -74, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 121
         0, 0, 0, 0, 0, 0, 129, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 122
@@ -14690,48 +14824,52 @@ mod __parse__UpdateCommand {
         // State 123
         0, 0, 0, 0, 0, 0, 131, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 124
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 132, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 125
-        0, 0, 0, 0, 0, 0, -60, 0, 0, -60, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 133, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 126
-        0, 0, 0, 0, 0, 0, 0, 0, 0, -33, 0, 0, 0, 0, 0, 0, 0, 0, 0, -33, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        // State 127
-        0, 0, 0, 0, 0, 0, 0, 0, 0, -32, 0, 0, 0, 0, 0, 0, 0, 0, 0, -32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        // State 128
-        0, 0, 0, 0, 0, 0, 0, 0, 0, -29, 0, 0, 0, 0, 0, 0, 0, 0, 0, -29, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        // State 129
-        0, 0, 0, 0, 0, 0, 0, 0, 0, -30, 0, 0, 0, 0, 0, 0, 0, 0, 0, -30, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        // State 130
-        0, 0, 0, 0, 0, 0, 0, 0, 0, -31, 0, 0, 0, 0, 0, 0, 0, 0, 0, -31, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        // State 131
-        0, 0, 0, 0, 0, 0, 140, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        // State 132
-        0, 0, 0, 0, 0, 0, -36, 0, 0, 141, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        // State 133
-        0, 0, 0, 0, 0, 0, -45, 0, 0, -45, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        // State 134
-        0, 0, 0, 0, 0, 0, -46, 0, 0, -46, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        // State 135
-        0, 0, 0, 0, 0, 0, -44, 0, 0, -44, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        // State 136
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 43, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        // State 137
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -70, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -70, 0, 0, 0, 0, 0, 0, 0, 0,
-        // State 138
-        0, 0, 0, 0, 0, 0, -37, 0, 0, 144, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        // State 139
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 127
+        0, 0, 0, 0, 0, 0, -60, 0, 0, -60, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 128
+        0, 0, 0, 0, 0, 0, 0, 0, 0, -33, 0, 0, 0, -33, 0, 0, 0, 0, 0, -33, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 129
+        0, 0, 0, 0, 0, 0, 0, 0, 0, -32, 0, 0, 0, -32, 0, 0, 0, 0, 0, -32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 130
+        0, 0, 0, 0, 0, 0, 0, 0, 0, -29, 0, 0, 0, -29, 0, 0, 0, 0, 0, -29, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 131
+        0, 0, 0, 0, 0, 0, 0, 0, 0, -30, 0, 0, 0, -30, 0, 0, 0, 0, 0, -30, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 132
+        0, 0, 0, 0, 0, 0, 0, 0, 0, -31, 0, 0, 0, -31, 0, 0, 0, 0, 0, -31, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 133
+        0, 0, 0, 0, 0, 0, 142, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 134
+        0, 0, 0, 0, 0, 0, -36, 0, 0, 143, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 135
+        0, 0, 0, 0, 0, 0, -45, 0, 0, -45, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 136
+        0, 0, 0, 0, 0, 0, -46, 0, 0, -46, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 137
+        0, 0, 0, 0, 0, 0, -44, 0, 0, -44, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 138
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 44, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 139
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -70, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -70, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 140
-        0, 0, -4, -4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, -37, 0, 0, 146, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 141
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 142
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 44, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, -4, -4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 143
-        0, 0, -5, -5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 144
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -66, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 45, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         // State 145
+        0, 0, -5, -5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 146
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -66, 0, 0, 0, 0, 0, 0, 0, 0,
+        // State 147
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     ];
     fn __action(state: i16, integer: usize) -> i16 {
@@ -14811,27 +14949,27 @@ mod __parse__UpdateCommand {
         // State 35
         0,
         // State 36
-        -71,
+        0,
         // State 37
-        0,
+        -71,
         // State 38
-        -67,
-        // State 39
         0,
+        // State 39
+        -67,
         // State 40
         0,
         // State 41
-        -69,
-        // State 42
         0,
+        // State 42
+        -69,
         // State 43
         0,
         // State 44
-        -87,
-        // State 45
-        -92,
-        // State 46
         0,
+        // State 45
+        -88,
+        // State 46
+        -93,
         // State 47
         0,
         // State 48
@@ -14839,17 +14977,17 @@ mod __parse__UpdateCommand {
         // State 49
         0,
         // State 50
-        -62,
-        // State 51
         0,
+        // State 51
+        -62,
         // State 52
         0,
         // State 53
         0,
         // State 54
-        -83,
-        // State 55
         0,
+        // State 55
+        -84,
         // State 56
         0,
         // State 57
@@ -14859,43 +14997,43 @@ mod __parse__UpdateCommand {
         // State 59
         0,
         // State 60
-        -48,
+        0,
         // State 61
-        -50,
+        -48,
         // State 62
-        -72,
+        -50,
         // State 63
-        0,
+        -72,
         // State 64
-        -65,
+        0,
         // State 65
-        -53,
+        -65,
         // State 66
-        -55,
+        -53,
         // State 67
-        -28,
+        -55,
         // State 68
-        -84,
+        -28,
         // State 69
-        -54,
+        -85,
         // State 70
-        -34,
+        -54,
         // State 71
-        -61,
+        -34,
         // State 72
-        -52,
+        -61,
         // State 73
-        -79,
+        -52,
         // State 74
-        0,
+        -80,
         // State 75
-        -40,
+        0,
         // State 76
-        0,
+        -40,
         // State 77
-        -47,
-        // State 78
         0,
+        // State 78
+        -47,
         // State 79
         0,
         // State 80
@@ -14925,23 +15063,23 @@ mod __parse__UpdateCommand {
         // State 92
         0,
         // State 93
-        -35,
-        // State 94
         0,
+        // State 94
+        -35,
         // State 95
         0,
         // State 96
         0,
         // State 97
-        -41,
-        // State 98
         0,
+        // State 98
+        -41,
         // State 99
         0,
         // State 100
-        -85,
-        // State 101
         0,
+        // State 101
+        -86,
         // State 102
         0,
         // State 103
@@ -14951,27 +15089,27 @@ mod __parse__UpdateCommand {
         // State 105
         0,
         // State 106
-        -27,
-        // State 107
-        -26,
-        // State 108
-        -81,
-        // State 109
-        -80,
-        // State 110
-        -64,
-        // State 111
-        -63,
-        // State 112
-        -51,
-        // State 113
         0,
+        // State 107
+        -27,
+        // State 108
+        -26,
+        // State 109
+        -82,
+        // State 110
+        -81,
+        // State 111
+        -64,
+        // State 112
+        -63,
+        // State 113
+        -51,
         // State 114
         0,
         // State 115
-        -49,
-        // State 116
         0,
+        // State 116
+        -49,
         // State 117
         0,
         // State 118
@@ -14987,11 +15125,11 @@ mod __parse__UpdateCommand {
         // State 123
         0,
         // State 124
-        -86,
+        0,
         // State 125
         0,
         // State 126
-        0,
+        -87,
         // State 127
         0,
         // State 128
@@ -15013,119 +15151,124 @@ mod __parse__UpdateCommand {
         // State 136
         0,
         // State 137
-        -70,
+        0,
         // State 138
         0,
         // State 139
-        -82,
+        -70,
         // State 140
         0,
         // State 141
-        -73,
+        -83,
         // State 142
         0,
         // State 143
-        0,
+        -73,
         // State 144
-        -66,
+        0,
         // State 145
+        0,
+        // State 146
+        -66,
+        // State 147
         -68,
     ];
     fn __goto(state: i16, nt: usize) -> i16 {
         match nt {
-            2 => 40,
+            2 => 41,
             5 => 13,
             8 => 18,
             11 => 21,
             14 => 16,
-            15 => 61,
-            16 => 82,
-            17 => 62,
-            18 => 131,
-            19 => 58,
+            15 => 62,
+            16 => 83,
+            17 => 63,
+            18 => 133,
+            19 => 59,
             20 => match state {
-                12 => 74,
-                42 => 144,
-                43 => 145,
-                _ => 36,
+                12 => 75,
+                43 => 146,
+                44 => 147,
+                _ => 37,
             },
-            21 => 83,
+            21 => 84,
             22 => match state {
-                40 => 138,
-                _ => 132,
+                41 => 140,
+                _ => 134,
             },
-            23 => 44,
+            23 => 45,
             24 => match state {
-                15 | 21 => 84,
-                17 => 96,
-                19 => 100,
-                24 => 108,
-                _ => 63,
-            },
-            25 => match state {
-                25 => 110,
-                26 => 111,
+                15 | 21 => 85,
+                17 => 97,
+                19 => 101,
+                24 => 109,
                 _ => 64,
             },
-            26 => match state {
-                13 => 76,
-                _ => 59,
-            },
-            27 => 85,
-            28 => 79,
-            29 => match state {
-                27 => 116,
-                37 | 40 => 133,
+            25 => match state {
+                25 => 111,
+                26 => 112,
                 _ => 65,
+            },
+            26 => match state {
+                13 => 77,
+                _ => 60,
+            },
+            27 => 86,
+            28 => 80,
+            29 => match state {
+                27 => 117,
+                38 | 41 => 135,
+                _ => 66,
             },
             30 => match state {
                 9 | 13 => 14,
-                1 => 49,
-                2 => 51,
-                3 => 52,
-                4 => 53,
-                5 => 54,
-                6 => 55,
-                7 => 56,
-                8 => 57,
-                12 | 29 | 42..=43 => 75,
-                18 => 97,
-                20 => 101,
-                28 => 118,
-                30 => 119,
-                31 => 120,
-                32 => 121,
-                33 => 122,
-                34 => 123,
-                _ => 66,
-            },
-            31 => match state {
-                22 => 106,
-                23 => 107,
+                1 => 50,
+                2 => 52,
+                3 => 53,
+                4 => 54,
+                5 => 55,
+                6 => 56,
+                7 => 57,
+                8 => 58,
+                12 | 30 | 43..=44 => 76,
+                18 => 98,
+                20 => 102,
+                28 => 119,
+                29 => 120,
+                31 => 121,
+                32 => 122,
+                33 => 123,
+                34 => 124,
+                35 => 125,
                 _ => 67,
             },
-            32 => 41,
-            33 => 141,
-            34 => 38,
-            35 => match state {
-                35 => 124,
-                39 => 137,
+            31 => match state {
+                22 => 107,
+                23 => 108,
                 _ => 68,
             },
-            36 => 60,
-            37 => match state {
-                21 => 103,
-                _ => 86,
-            },
-            39 => match state {
-                37 | 40 => 134,
+            32 => 42,
+            33 => 143,
+            34 => 39,
+            35 => match state {
+                36 => 126,
+                40 => 139,
                 _ => 69,
             },
-            40 => match state {
-                16 => 93,
+            36 => 61,
+            37 => match state {
+                21 => 104,
+                _ => 87,
+            },
+            39 => match state {
+                38 | 41 => 136,
                 _ => 70,
             },
-            41 => 45,
+            40 => match state {
+                16 => 94,
+                _ => 71,
+            },
+            41 => 46,
             _ => 0,
         }
     }
@@ -15825,14 +15968,14 @@ mod __parse__UpdateCommand {
             }
             75 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
+                    states_to_pop: 3,
                     nonterminal_produced: 37,
                 }
             }
             76 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
-                    nonterminal_produced: 38,
+                    nonterminal_produced: 37,
                 }
             }
             77 => {
@@ -15844,13 +15987,13 @@ mod __parse__UpdateCommand {
             78 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
-                    nonterminal_produced: 39,
+                    nonterminal_produced: 38,
                 }
             }
             79 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 3,
-                    nonterminal_produced: 40,
+                    states_to_pop: 1,
+                    nonterminal_produced: 39,
                 }
             }
             80 => {
@@ -15861,65 +16004,71 @@ mod __parse__UpdateCommand {
             }
             81 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 10,
-                    nonterminal_produced: 41,
+                    states_to_pop: 3,
+                    nonterminal_produced: 40,
                 }
             }
             82 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 3,
+                    states_to_pop: 10,
                     nonterminal_produced: 41,
                 }
             }
             83 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 5,
+                    states_to_pop: 3,
                     nonterminal_produced: 41,
                 }
             }
             84 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 6,
+                    states_to_pop: 5,
                     nonterminal_produced: 41,
                 }
             }
             85 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 8,
+                    states_to_pop: 6,
                     nonterminal_produced: 41,
                 }
             }
             86 => {
                 __state_machine::SimulatedReduce::Reduce {
-                    states_to_pop: 1,
+                    states_to_pop: 8,
                     nonterminal_produced: 41,
                 }
             }
             87 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
-                    nonterminal_produced: 42,
+                    nonterminal_produced: 41,
                 }
             }
             88 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
-                    nonterminal_produced: 43,
+                    nonterminal_produced: 42,
                 }
             }
             89 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
-                    nonterminal_produced: 44,
+                    nonterminal_produced: 43,
                 }
             }
             90 => {
                 __state_machine::SimulatedReduce::Reduce {
                     states_to_pop: 1,
+                    nonterminal_produced: 44,
+                }
+            }
+            91 => {
+                __state_machine::SimulatedReduce::Reduce {
+                    states_to_pop: 1,
                     nonterminal_produced: 45,
                 }
             }
-            91 => __state_machine::SimulatedReduce::Accept,
+            92 => __state_machine::SimulatedReduce::Accept,
             _ => panic!("invalid reduction index {}", __reduce_index)
         }
     }
@@ -16275,6 +16424,9 @@ mod __parse__UpdateCommand {
                 __reduce90(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
             }
             91 => {
+                __reduce91(input, __lookahead_start, __symbols, core::marker::PhantomData::<(&())>)
+            }
+            92 => {
                 // __UpdateCommand = UpdateCommand => ActionFn(2);
                 let __sym0 = __pop_Variant27(__symbols);
                 let __start = __sym0.0;
@@ -16612,13 +16764,13 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Constant> COMMA) = Constant, COMMA => ActionFn(70);
+        // (<Constant> COMMA) = Constant, COMMA => ActionFn(71);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant1(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action70::<>(input, __sym0, __sym1);
+        let __nt = super::__action71::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant1(__nt), __end));
         (2, 0)
     }
@@ -16631,10 +16783,10 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Constant> COMMA)* =  => ActionFn(68);
+        // (<Constant> COMMA)* =  => ActionFn(69);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action68::<>(input, &__start, &__end);
+        let __nt = super::__action69::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant2(__nt), __end));
         (0, 1)
     }
@@ -16647,11 +16799,11 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Constant> COMMA)* = (<Constant> COMMA)+ => ActionFn(69);
+        // (<Constant> COMMA)* = (<Constant> COMMA)+ => ActionFn(70);
         let __sym0 = __pop_Variant2(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action69::<>(input, __sym0);
+        let __nt = super::__action70::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant2(__nt), __end));
         (1, 1)
     }
@@ -16664,13 +16816,13 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Constant> COMMA)+ = Constant, COMMA => ActionFn(87);
+        // (<Constant> COMMA)+ = Constant, COMMA => ActionFn(88);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant1(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action87::<>(input, __sym0, __sym1);
+        let __nt = super::__action88::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant2(__nt), __end));
         (2, 2)
     }
@@ -16683,14 +16835,14 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Constant> COMMA)+ = (<Constant> COMMA)+, Constant, COMMA => ActionFn(88);
+        // (<Constant> COMMA)+ = (<Constant> COMMA)+, Constant, COMMA => ActionFn(89);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant1(__symbols);
         let __sym0 = __pop_Variant2(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action88::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action89::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant2(__nt), __end));
         (3, 2)
     }
@@ -16703,13 +16855,13 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<FieldDefinition> COMMA) = FieldDefinition, COMMA => ActionFn(73);
+        // (<FieldDefinition> COMMA) = FieldDefinition, COMMA => ActionFn(74);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant3(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action73::<>(input, __sym0, __sym1);
+        let __nt = super::__action74::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant3(__nt), __end));
         (2, 3)
     }
@@ -16722,10 +16874,10 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<FieldDefinition> COMMA)* =  => ActionFn(71);
+        // (<FieldDefinition> COMMA)* =  => ActionFn(72);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action71::<>(input, &__start, &__end);
+        let __nt = super::__action72::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant4(__nt), __end));
         (0, 4)
     }
@@ -16738,11 +16890,11 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<FieldDefinition> COMMA)* = (<FieldDefinition> COMMA)+ => ActionFn(72);
+        // (<FieldDefinition> COMMA)* = (<FieldDefinition> COMMA)+ => ActionFn(73);
         let __sym0 = __pop_Variant4(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action72::<>(input, __sym0);
+        let __nt = super::__action73::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant4(__nt), __end));
         (1, 4)
     }
@@ -16755,13 +16907,13 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<FieldDefinition> COMMA)+ = FieldDefinition, COMMA => ActionFn(91);
+        // (<FieldDefinition> COMMA)+ = FieldDefinition, COMMA => ActionFn(92);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant3(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action91::<>(input, __sym0, __sym1);
+        let __nt = super::__action92::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant4(__nt), __end));
         (2, 5)
     }
@@ -16774,14 +16926,14 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<FieldDefinition> COMMA)+ = (<FieldDefinition> COMMA)+, FieldDefinition, COMMA => ActionFn(92);
+        // (<FieldDefinition> COMMA)+ = (<FieldDefinition> COMMA)+, FieldDefinition, COMMA => ActionFn(93);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant3(__symbols);
         let __sym0 = __pop_Variant4(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action92::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action93::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant4(__nt), __end));
         (3, 5)
     }
@@ -16794,13 +16946,13 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<IdToken> COMMA) = IdToken, COMMA => ActionFn(64);
+        // (<IdToken> COMMA) = IdToken, COMMA => ActionFn(65);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action64::<>(input, __sym0, __sym1);
+        let __nt = super::__action65::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant5(__nt), __end));
         (2, 6)
     }
@@ -16813,10 +16965,10 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<IdToken> COMMA)* =  => ActionFn(62);
+        // (<IdToken> COMMA)* =  => ActionFn(63);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action62::<>(input, &__start, &__end);
+        let __nt = super::__action63::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant6(__nt), __end));
         (0, 7)
     }
@@ -16829,11 +16981,11 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<IdToken> COMMA)* = (<IdToken> COMMA)+ => ActionFn(63);
+        // (<IdToken> COMMA)* = (<IdToken> COMMA)+ => ActionFn(64);
         let __sym0 = __pop_Variant6(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action63::<>(input, __sym0);
+        let __nt = super::__action64::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant6(__nt), __end));
         (1, 7)
     }
@@ -16846,13 +16998,13 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<IdToken> COMMA)+ = IdToken, COMMA => ActionFn(95);
+        // (<IdToken> COMMA)+ = IdToken, COMMA => ActionFn(96);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action95::<>(input, __sym0, __sym1);
+        let __nt = super::__action96::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant6(__nt), __end));
         (2, 8)
     }
@@ -16865,14 +17017,14 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<IdToken> COMMA)+ = (<IdToken> COMMA)+, IdToken, COMMA => ActionFn(96);
+        // (<IdToken> COMMA)+ = (<IdToken> COMMA)+, IdToken, COMMA => ActionFn(97);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant5(__symbols);
         let __sym0 = __pop_Variant6(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action96::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action97::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant6(__nt), __end));
         (3, 8)
     }
@@ -16885,13 +17037,13 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<SelectField> COMMA) = SelectField, COMMA => ActionFn(67);
+        // (<SelectField> COMMA) = SelectField, COMMA => ActionFn(68);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant7(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action67::<>(input, __sym0, __sym1);
+        let __nt = super::__action68::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant7(__nt), __end));
         (2, 9)
     }
@@ -16904,10 +17056,10 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<SelectField> COMMA)* =  => ActionFn(65);
+        // (<SelectField> COMMA)* =  => ActionFn(66);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action65::<>(input, &__start, &__end);
+        let __nt = super::__action66::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant8(__nt), __end));
         (0, 10)
     }
@@ -16920,11 +17072,11 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<SelectField> COMMA)* = (<SelectField> COMMA)+ => ActionFn(66);
+        // (<SelectField> COMMA)* = (<SelectField> COMMA)+ => ActionFn(67);
         let __sym0 = __pop_Variant8(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action66::<>(input, __sym0);
+        let __nt = super::__action67::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant8(__nt), __end));
         (1, 10)
     }
@@ -16937,13 +17089,13 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<SelectField> COMMA)+ = SelectField, COMMA => ActionFn(99);
+        // (<SelectField> COMMA)+ = SelectField, COMMA => ActionFn(100);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant7(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action99::<>(input, __sym0, __sym1);
+        let __nt = super::__action100::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant8(__nt), __end));
         (2, 11)
     }
@@ -16956,14 +17108,14 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<SelectField> COMMA)+ = (<SelectField> COMMA)+, SelectField, COMMA => ActionFn(100);
+        // (<SelectField> COMMA)+ = (<SelectField> COMMA)+, SelectField, COMMA => ActionFn(101);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant7(__symbols);
         let __sym0 = __pop_Variant8(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action100::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action101::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant8(__nt), __end));
         (3, 11)
     }
@@ -16976,13 +17128,13 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Term> AND) = Term, AND => ActionFn(76);
+        // (<Term> AND) = Term, AND => ActionFn(77);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant9(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action76::<>(input, __sym0, __sym1);
+        let __nt = super::__action77::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant9(__nt), __end));
         (2, 12)
     }
@@ -16995,10 +17147,10 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Term> AND)* =  => ActionFn(74);
+        // (<Term> AND)* =  => ActionFn(75);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action74::<>(input, &__start, &__end);
+        let __nt = super::__action75::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant10(__nt), __end));
         (0, 13)
     }
@@ -17011,11 +17163,11 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Term> AND)* = (<Term> AND)+ => ActionFn(75);
+        // (<Term> AND)* = (<Term> AND)+ => ActionFn(76);
         let __sym0 = __pop_Variant10(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action75::<>(input, __sym0);
+        let __nt = super::__action76::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant10(__nt), __end));
         (1, 13)
     }
@@ -17028,13 +17180,13 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Term> AND)+ = Term, AND => ActionFn(103);
+        // (<Term> AND)+ = Term, AND => ActionFn(104);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant9(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action103::<>(input, __sym0, __sym1);
+        let __nt = super::__action104::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant10(__nt), __end));
         (2, 14)
     }
@@ -17047,14 +17199,14 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // (<Term> AND)+ = (<Term> AND)+, Term, AND => ActionFn(104);
+        // (<Term> AND)+ = (<Term> AND)+, Term, AND => ActionFn(105);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant9(__symbols);
         let __sym0 = __pop_Variant10(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action104::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action105::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant10(__nt), __end));
         (3, 14)
     }
@@ -17067,14 +17219,14 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AddExpr = AddExpr, PLUS, MulExpr => ActionFn(40);
+        // AddExpr = AddExpr, PLUS, MulExpr => ActionFn(41);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant11(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action40::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action41::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (3, 15)
     }
@@ -17087,14 +17239,14 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AddExpr = AddExpr, MINUS, MulExpr => ActionFn(41);
+        // AddExpr = AddExpr, MINUS, MulExpr => ActionFn(42);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant11(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action41::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action42::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (3, 15)
     }
@@ -17107,11 +17259,11 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AddExpr = MulExpr => ActionFn(42);
+        // AddExpr = MulExpr => ActionFn(43);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action42::<>(input, __sym0);
+        let __nt = super::__action43::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (1, 15)
     }
@@ -17124,7 +17276,7 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AggregationFn = MAX, LPAREN, IdToken, RPAREN => ActionFn(13);
+        // AggregationFn = MAX, LPAREN, IdToken, RPAREN => ActionFn(14);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant5(__symbols);
@@ -17132,7 +17284,7 @@ mod __parse__UpdateCommand {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action13::<>(input, __sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action14::<>(input, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant12(__nt), __end));
         (4, 16)
     }
@@ -17145,7 +17297,7 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AggregationFn = MIN, LPAREN, IdToken, RPAREN => ActionFn(14);
+        // AggregationFn = MIN, LPAREN, IdToken, RPAREN => ActionFn(15);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant5(__symbols);
@@ -17153,7 +17305,7 @@ mod __parse__UpdateCommand {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action14::<>(input, __sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action15::<>(input, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant12(__nt), __end));
         (4, 16)
     }
@@ -17166,7 +17318,7 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AggregationFn = SUM, LPAREN, IdToken, RPAREN => ActionFn(15);
+        // AggregationFn = SUM, LPAREN, IdToken, RPAREN => ActionFn(16);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant5(__symbols);
@@ -17174,7 +17326,7 @@ mod __parse__UpdateCommand {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action15::<>(input, __sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action16::<>(input, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant12(__nt), __end));
         (4, 16)
     }
@@ -17187,7 +17339,7 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AggregationFn = COUNT, LPAREN, IdToken, RPAREN => ActionFn(16);
+        // AggregationFn = COUNT, LPAREN, IdToken, RPAREN => ActionFn(17);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant5(__symbols);
@@ -17195,7 +17347,7 @@ mod __parse__UpdateCommand {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action16::<>(input, __sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action17::<>(input, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant12(__nt), __end));
         (4, 16)
     }
@@ -17208,7 +17360,7 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // AggregationFn = AVG, LPAREN, IdToken, RPAREN => ActionFn(17);
+        // AggregationFn = AVG, LPAREN, IdToken, RPAREN => ActionFn(18);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant5(__symbols);
@@ -17216,7 +17368,7 @@ mod __parse__UpdateCommand {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action17::<>(input, __sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action18::<>(input, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant12(__nt), __end));
         (4, 16)
     }
@@ -17229,11 +17381,11 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // And<Term> = Term => ActionFn(105);
+        // And<Term> = Term => ActionFn(106);
         let __sym0 = __pop_Variant9(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action105::<>(input, __sym0);
+        let __nt = super::__action106::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant13(__nt), __end));
         (1, 17)
     }
@@ -17246,13 +17398,13 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // And<Term> = (<Term> AND)+, Term => ActionFn(106);
+        // And<Term> = (<Term> AND)+, Term => ActionFn(107);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant9(__symbols);
         let __sym0 = __pop_Variant10(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action106::<>(input, __sym0, __sym1);
+        let __nt = super::__action107::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant13(__nt), __end));
         (2, 17)
     }
@@ -17265,11 +17417,11 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<Constant> = Constant => ActionFn(89);
+        // Comma<Constant> = Constant => ActionFn(90);
         let __sym0 = __pop_Variant1(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action89::<>(input, __sym0);
+        let __nt = super::__action90::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant14(__nt), __end));
         (1, 18)
     }
@@ -17282,13 +17434,13 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<Constant> = (<Constant> COMMA)+, Constant => ActionFn(90);
+        // Comma<Constant> = (<Constant> COMMA)+, Constant => ActionFn(91);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant1(__symbols);
         let __sym0 = __pop_Variant2(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action90::<>(input, __sym0, __sym1);
+        let __nt = super::__action91::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant14(__nt), __end));
         (2, 18)
     }
@@ -17301,11 +17453,11 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<FieldDefinition> = FieldDefinition => ActionFn(93);
+        // Comma<FieldDefinition> = FieldDefinition => ActionFn(94);
         let __sym0 = __pop_Variant3(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action93::<>(input, __sym0);
+        let __nt = super::__action94::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (1, 19)
     }
@@ -17318,13 +17470,13 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<FieldDefinition> = (<FieldDefinition> COMMA)+, FieldDefinition => ActionFn(94);
+        // Comma<FieldDefinition> = (<FieldDefinition> COMMA)+, FieldDefinition => ActionFn(95);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant3(__symbols);
         let __sym0 = __pop_Variant4(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action94::<>(input, __sym0, __sym1);
+        let __nt = super::__action95::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (2, 19)
     }
@@ -17337,11 +17489,11 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<IdToken> = IdToken => ActionFn(97);
+        // Comma<IdToken> = IdToken => ActionFn(98);
         let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action97::<>(input, __sym0);
+        let __nt = super::__action98::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant16(__nt), __end));
         (1, 20)
     }
@@ -17354,13 +17506,13 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<IdToken> = (<IdToken> COMMA)+, IdToken => ActionFn(98);
+        // Comma<IdToken> = (<IdToken> COMMA)+, IdToken => ActionFn(99);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant5(__symbols);
         let __sym0 = __pop_Variant6(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action98::<>(input, __sym0, __sym1);
+        let __nt = super::__action99::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant16(__nt), __end));
         (2, 20)
     }
@@ -17373,11 +17525,11 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<SelectField> = SelectField => ActionFn(101);
+        // Comma<SelectField> = SelectField => ActionFn(102);
         let __sym0 = __pop_Variant7(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action101::<>(input, __sym0);
+        let __nt = super::__action102::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant17(__nt), __end));
         (1, 21)
     }
@@ -17390,13 +17542,13 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Comma<SelectField> = (<SelectField> COMMA)+, SelectField => ActionFn(102);
+        // Comma<SelectField> = (<SelectField> COMMA)+, SelectField => ActionFn(103);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant7(__symbols);
         let __sym0 = __pop_Variant8(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action102::<>(input, __sym0, __sym1);
+        let __nt = super::__action103::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant17(__nt), __end));
         (2, 21)
     }
@@ -17409,11 +17561,11 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Constant = NULL => ActionFn(51);
+        // Constant = NULL => ActionFn(52);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action51::<>(input, __sym0);
+        let __nt = super::__action52::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant1(__nt), __end));
         (1, 22)
     }
@@ -17426,11 +17578,11 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Constant = I32Constant => ActionFn(52);
+        // Constant = I32Constant => ActionFn(53);
         let __sym0 = __pop_Variant21(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action52::<>(input, __sym0);
+        let __nt = super::__action53::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant1(__nt), __end));
         (1, 22)
     }
@@ -17443,11 +17595,11 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Constant = StringConstant => ActionFn(53);
+        // Constant = StringConstant => ActionFn(54);
         let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action53::<>(input, __sym0);
+        let __nt = super::__action54::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant1(__nt), __end));
         (1, 22)
     }
@@ -17460,7 +17612,7 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // CreateCommand = CREATE, TABLE, IdToken, LPAREN, Comma<FieldDefinition>, RPAREN => ActionFn(30);
+        // CreateCommand = CREATE, TABLE, IdToken, LPAREN, Comma<FieldDefinition>, RPAREN => ActionFn(31);
         assert!(__symbols.len() >= 6);
         let __sym5 = __pop_Variant0(__symbols);
         let __sym4 = __pop_Variant15(__symbols);
@@ -17470,7 +17622,7 @@ mod __parse__UpdateCommand {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym5.2;
-        let __nt = super::__action30::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
+        let __nt = super::__action31::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
         __symbols.push((__start, __Symbol::Variant18(__nt), __end));
         (6, 23)
     }
@@ -17483,7 +17635,7 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // CreateCommand = CREATE, VIEW, IdToken, AS, Query => ActionFn(31);
+        // CreateCommand = CREATE, VIEW, IdToken, AS, Query => ActionFn(32);
         assert!(__symbols.len() >= 5);
         let __sym4 = __pop_Variant25(__symbols);
         let __sym3 = __pop_Variant0(__symbols);
@@ -17492,7 +17644,7 @@ mod __parse__UpdateCommand {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym4.2;
-        let __nt = super::__action31::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4);
+        let __nt = super::__action32::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4);
         __symbols.push((__start, __Symbol::Variant18(__nt), __end));
         (5, 23)
     }
@@ -17505,7 +17657,7 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // CreateCommand = CREATE, INDEX, IdToken, ON, IdToken, LPAREN, IdToken, RPAREN => ActionFn(32);
+        // CreateCommand = CREATE, INDEX, IdToken, ON, IdToken, LPAREN, IdToken, RPAREN => ActionFn(33);
         assert!(__symbols.len() >= 8);
         let __sym7 = __pop_Variant0(__symbols);
         let __sym6 = __pop_Variant5(__symbols);
@@ -17517,7 +17669,7 @@ mod __parse__UpdateCommand {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym7.2;
-        let __nt = super::__action32::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
+        let __nt = super::__action33::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
         __symbols.push((__start, __Symbol::Variant18(__nt), __end));
         (8, 23)
     }
@@ -17530,11 +17682,11 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Expression = AddExpr => ActionFn(39);
+        // Expression = AddExpr => ActionFn(40);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action39::<>(input, __sym0);
+        let __nt = super::__action40::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (1, 24)
     }
@@ -17547,14 +17699,14 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Factor = LPAREN, Expression, RPAREN => ActionFn(46);
+        // Factor = LPAREN, Expression, RPAREN => ActionFn(47);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant11(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action46::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action47::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (3, 25)
     }
@@ -17567,11 +17719,11 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Factor = NULL => ActionFn(47);
+        // Factor = NULL => ActionFn(48);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action47::<>(input, __sym0);
+        let __nt = super::__action48::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (1, 25)
     }
@@ -17584,11 +17736,11 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Factor = I32Constant => ActionFn(48);
+        // Factor = I32Constant => ActionFn(49);
         let __sym0 = __pop_Variant21(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action48::<>(input, __sym0);
+        let __nt = super::__action49::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (1, 25)
     }
@@ -17601,11 +17753,11 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Factor = StringConstant => ActionFn(49);
+        // Factor = StringConstant => ActionFn(50);
         let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action49::<>(input, __sym0);
+        let __nt = super::__action50::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (1, 25)
     }
@@ -17618,11 +17770,11 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Factor = IdToken => ActionFn(50);
+        // Factor = IdToken => ActionFn(51);
         let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action50::<>(input, __sym0);
+        let __nt = super::__action51::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (1, 25)
     }
@@ -17635,13 +17787,13 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // FieldDefinition = IdToken, FieldType => ActionFn(33);
+        // FieldDefinition = IdToken, FieldType => ActionFn(34);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant20(__symbols);
         let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action33::<>(input, __sym0, __sym1);
+        let __nt = super::__action34::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant3(__nt), __end));
         (2, 26)
     }
@@ -17688,11 +17840,11 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // FieldType = I32 => ActionFn(34);
+        // FieldType = I32 => ActionFn(35);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action34::<>(input, __sym0);
+        let __nt = super::__action35::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant20(__nt), __end));
         (1, 28)
     }
@@ -17705,7 +17857,7 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // FieldType = VARCHAR, LPAREN, I32Constant, RPAREN => ActionFn(35);
+        // FieldType = VARCHAR, LPAREN, I32Constant, RPAREN => ActionFn(36);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant21(__symbols);
@@ -17713,7 +17865,7 @@ mod __parse__UpdateCommand {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action35::<>(input, __sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action36::<>(input, __sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant20(__nt), __end));
         (4, 28)
     }
@@ -17726,11 +17878,11 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // I32Constant = I32_LITERAL => ActionFn(54);
+        // I32Constant = I32_LITERAL => ActionFn(55);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action54::<>(input, __sym0);
+        let __nt = super::__action55::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant21(__nt), __end));
         (1, 29)
     }
@@ -17743,11 +17895,11 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // IdToken = ID => ActionFn(56);
+        // IdToken = ID => ActionFn(57);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action56::<>(input, __sym0);
+        let __nt = super::__action57::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant5(__nt), __end));
         (1, 30)
     }
@@ -17760,14 +17912,14 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // MulExpr = MulExpr, STAR, Factor => ActionFn(43);
+        // MulExpr = MulExpr, STAR, Factor => ActionFn(44);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant11(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action43::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action44::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (3, 31)
     }
@@ -17780,14 +17932,14 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // MulExpr = MulExpr, SLASH, Factor => ActionFn(44);
+        // MulExpr = MulExpr, SLASH, Factor => ActionFn(45);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant11(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action44::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action45::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (3, 31)
     }
@@ -17800,11 +17952,11 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // MulExpr = Factor => ActionFn(45);
+        // MulExpr = Factor => ActionFn(46);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action45::<>(input, __sym0);
+        let __nt = super::__action46::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant11(__nt), __end));
         (1, 31)
     }
@@ -17817,14 +17969,14 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // OptGroupBy = GROUP, BY, Comma<IdToken> => ActionFn(20);
+        // OptGroupBy = GROUP, BY, Comma<IdToken> => ActionFn(21);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant16(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action20::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action21::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant22(__nt), __end));
         (3, 32)
     }
@@ -17837,10 +17989,10 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // OptGroupBy =  => ActionFn(21);
+        // OptGroupBy =  => ActionFn(22);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action21::<>(input, &__start, &__end);
+        let __nt = super::__action22::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant22(__nt), __end));
         (0, 32)
     }
@@ -17853,14 +18005,14 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // OptOrderBy = ORDER, BY, Comma<IdToken> => ActionFn(22);
+        // OptOrderBy = ORDER, BY, Comma<IdToken> => ActionFn(23);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant16(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action22::<>(input, __sym0, __sym1, __sym2);
+        let __nt = super::__action23::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant22(__nt), __end));
         (3, 33)
     }
@@ -17873,10 +18025,10 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // OptOrderBy =  => ActionFn(23);
+        // OptOrderBy =  => ActionFn(24);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action23::<>(input, &__start, &__end);
+        let __nt = super::__action24::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant22(__nt), __end));
         (0, 33)
     }
@@ -17889,13 +18041,13 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // OptPredicate = WHERE, Predicate => ActionFn(18);
+        // OptPredicate = WHERE, Predicate => ActionFn(19);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant24(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action18::<>(input, __sym0, __sym1);
+        let __nt = super::__action19::<>(input, __sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant23(__nt), __end));
         (2, 34)
     }
@@ -17908,10 +18060,10 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // OptPredicate =  => ActionFn(19);
+        // OptPredicate =  => ActionFn(20);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2)).unwrap_or_default();
         let __end = __start;
-        let __nt = super::__action19::<>(input, &__start, &__end);
+        let __nt = super::__action20::<>(input, &__start, &__end);
         __symbols.push((__start, __Symbol::Variant23(__nt), __end));
         (0, 34)
     }
@@ -17924,11 +18076,11 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Predicate = And<Term> => ActionFn(36);
+        // Predicate = And<Term> => ActionFn(37);
         let __sym0 = __pop_Variant13(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action36::<>(input, __sym0);
+        let __nt = super::__action37::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant24(__nt), __end));
         (1, 35)
     }
@@ -18002,15 +18154,35 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // SelectField = AggregationFn => ActionFn(12);
+        // SelectField = AggregationFn, AS, IdToken => ActionFn(12);
+        assert!(__symbols.len() >= 3);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant12(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym2.2;
+        let __nt = super::__action12::<>(input, __sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant7(__nt), __end));
+        (3, 37)
+    }
+    fn __reduce76<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // SelectField = AggregationFn => ActionFn(13);
         let __sym0 = __pop_Variant12(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action12::<>(input, __sym0);
+        let __nt = super::__action13::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant7(__nt), __end));
         (1, 37)
     }
-    fn __reduce76<
+    fn __reduce77<
         'input,
     >(
         input: &'input str,
@@ -18027,7 +18199,7 @@ mod __parse__UpdateCommand {
         __symbols.push((__start, __Symbol::Variant26(__nt), __end));
         (1, 38)
     }
-    fn __reduce77<
+    fn __reduce78<
         'input,
     >(
         input: &'input str,
@@ -18044,23 +18216,6 @@ mod __parse__UpdateCommand {
         __symbols.push((__start, __Symbol::Variant26(__nt), __end));
         (1, 38)
     }
-    fn __reduce78<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // StringConstant = STRING_LITERAL => ActionFn(55);
-        let __sym0 = __pop_Variant0(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym0.2;
-        let __nt = super::__action55::<>(input, __sym0);
-        __symbols.push((__start, __Symbol::Variant5(__nt), __end));
-        (1, 39)
-    }
     fn __reduce79<
         'input,
     >(
@@ -18070,16 +18225,13 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Term = Expression, IS, NULL => ActionFn(37);
-        assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant11(__symbols);
+        // StringConstant = STRING_LITERAL => ActionFn(56);
+        let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym2.2;
-        let __nt = super::__action37::<>(input, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant9(__nt), __end));
-        (3, 40)
+        let __end = __sym0.2;
+        let __nt = super::__action56::<>(input, __sym0);
+        __symbols.push((__start, __Symbol::Variant5(__nt), __end));
+        (1, 39)
     }
     fn __reduce80<
         'input,
@@ -18090,9 +18242,9 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // Term = Expression, EQ, Expression => ActionFn(38);
+        // Term = Expression, IS, NULL => ActionFn(38);
         assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant11(__symbols);
+        let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant11(__symbols);
         let __start = __sym0.0;
@@ -18110,7 +18262,27 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // UpdateCommand = INSERT, INTO, IdToken, LPAREN, Comma<IdToken>, RPAREN, VALUES, LPAREN, Comma<Constant>, RPAREN => ActionFn(24);
+        // Term = Expression, EQ, Expression => ActionFn(39);
+        assert!(__symbols.len() >= 3);
+        let __sym2 = __pop_Variant11(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
+        let __sym0 = __pop_Variant11(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym2.2;
+        let __nt = super::__action39::<>(input, __sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant9(__nt), __end));
+        (3, 40)
+    }
+    fn __reduce82<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // UpdateCommand = INSERT, INTO, IdToken, LPAREN, Comma<IdToken>, RPAREN, VALUES, LPAREN, Comma<Constant>, RPAREN => ActionFn(25);
         assert!(__symbols.len() >= 10);
         let __sym9 = __pop_Variant0(__symbols);
         let __sym8 = __pop_Variant14(__symbols);
@@ -18124,29 +18296,9 @@ mod __parse__UpdateCommand {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym9.2;
-        let __nt = super::__action24::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9);
+        let __nt = super::__action25::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9);
         __symbols.push((__start, __Symbol::Variant27(__nt), __end));
         (10, 41)
-    }
-    fn __reduce82<
-        'input,
-    >(
-        input: &'input str,
-        __lookahead_start: Option<&usize>,
-        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
-        _: core::marker::PhantomData<(&'input ())>,
-    ) -> (usize, usize)
-    {
-        // UpdateCommand = DELETE, FROM, IdToken => ActionFn(25);
-        assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant5(__symbols);
-        let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant0(__symbols);
-        let __start = __sym0.0;
-        let __end = __sym2.2;
-        let __nt = super::__action25::<>(input, __sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant27(__nt), __end));
-        (3, 41)
     }
     fn __reduce83<
         'input,
@@ -18157,18 +18309,16 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // UpdateCommand = DELETE, FROM, IdToken, WHERE, Predicate => ActionFn(26);
-        assert!(__symbols.len() >= 5);
-        let __sym4 = __pop_Variant24(__symbols);
-        let __sym3 = __pop_Variant0(__symbols);
+        // UpdateCommand = DELETE, FROM, IdToken => ActionFn(26);
+        assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant5(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym4.2;
-        let __nt = super::__action26::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4);
+        let __end = __sym2.2;
+        let __nt = super::__action26::<>(input, __sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant27(__nt), __end));
-        (5, 41)
+        (3, 41)
     }
     fn __reduce84<
         'input,
@@ -18179,19 +18329,18 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // UpdateCommand = MODIFY, IdToken, SET, IdToken, EQ, Expression => ActionFn(27);
-        assert!(__symbols.len() >= 6);
-        let __sym5 = __pop_Variant11(__symbols);
-        let __sym4 = __pop_Variant0(__symbols);
-        let __sym3 = __pop_Variant5(__symbols);
-        let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant5(__symbols);
+        // UpdateCommand = DELETE, FROM, IdToken, WHERE, Predicate => ActionFn(27);
+        assert!(__symbols.len() >= 5);
+        let __sym4 = __pop_Variant24(__symbols);
+        let __sym3 = __pop_Variant0(__symbols);
+        let __sym2 = __pop_Variant5(__symbols);
+        let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
-        let __end = __sym5.2;
-        let __nt = super::__action27::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
+        let __end = __sym4.2;
+        let __nt = super::__action27::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4);
         __symbols.push((__start, __Symbol::Variant27(__nt), __end));
-        (6, 41)
+        (5, 41)
     }
     fn __reduce85<
         'input,
@@ -18202,7 +18351,30 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // UpdateCommand = MODIFY, IdToken, SET, IdToken, EQ, Expression, WHERE, Predicate => ActionFn(28);
+        // UpdateCommand = MODIFY, IdToken, SET, IdToken, EQ, Expression => ActionFn(28);
+        assert!(__symbols.len() >= 6);
+        let __sym5 = __pop_Variant11(__symbols);
+        let __sym4 = __pop_Variant0(__symbols);
+        let __sym3 = __pop_Variant5(__symbols);
+        let __sym2 = __pop_Variant0(__symbols);
+        let __sym1 = __pop_Variant5(__symbols);
+        let __sym0 = __pop_Variant0(__symbols);
+        let __start = __sym0.0;
+        let __end = __sym5.2;
+        let __nt = super::__action28::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
+        __symbols.push((__start, __Symbol::Variant27(__nt), __end));
+        (6, 41)
+    }
+    fn __reduce86<
+        'input,
+    >(
+        input: &'input str,
+        __lookahead_start: Option<&usize>,
+        __symbols: &mut alloc::vec::Vec<(usize,__Symbol<'input>,usize)>,
+        _: core::marker::PhantomData<(&'input ())>,
+    ) -> (usize, usize)
+    {
+        // UpdateCommand = MODIFY, IdToken, SET, IdToken, EQ, Expression, WHERE, Predicate => ActionFn(29);
         assert!(__symbols.len() >= 8);
         let __sym7 = __pop_Variant24(__symbols);
         let __sym6 = __pop_Variant0(__symbols);
@@ -18214,11 +18386,11 @@ mod __parse__UpdateCommand {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym7.2;
-        let __nt = super::__action28::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
+        let __nt = super::__action29::<>(input, __sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
         __symbols.push((__start, __Symbol::Variant27(__nt), __end));
         (8, 41)
     }
-    fn __reduce86<
+    fn __reduce87<
         'input,
     >(
         input: &'input str,
@@ -18227,15 +18399,15 @@ mod __parse__UpdateCommand {
         _: core::marker::PhantomData<(&'input ())>,
     ) -> (usize, usize)
     {
-        // UpdateCommand = CreateCommand => ActionFn(29);
+        // UpdateCommand = CreateCommand => ActionFn(30);
         let __sym0 = __pop_Variant18(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action29::<>(input, __sym0);
+        let __nt = super::__action30::<>(input, __sym0);
         __symbols.push((__start, __Symbol::Variant27(__nt), __end));
         (1, 41)
     }
-    fn __reduce87<
+    fn __reduce88<
         'input,
     >(
         input: &'input str,
@@ -18252,7 +18424,7 @@ mod __parse__UpdateCommand {
         __symbols.push((__start, __Symbol::Variant24(__nt), __end));
         (1, 42)
     }
-    fn __reduce88<
+    fn __reduce89<
         'input,
     >(
         input: &'input str,
@@ -18269,7 +18441,7 @@ mod __parse__UpdateCommand {
         __symbols.push((__start, __Symbol::Variant25(__nt), __end));
         (1, 43)
     }
-    fn __reduce89<
+    fn __reduce90<
         'input,
     >(
         input: &'input str,
@@ -18286,7 +18458,7 @@ mod __parse__UpdateCommand {
         __symbols.push((__start, __Symbol::Variant26(__nt), __end));
         (1, 44)
     }
-    fn __reduce90<
+    fn __reduce91<
         'input,
     >(
         input: &'input str,
@@ -18585,8 +18757,10 @@ fn __action11<'input>(
 fn __action12<'input>(
     input: &'input str,
     (_, a, _): (usize, AggregationFn, usize),
+    (_, _, _): (usize, &'input str, usize),
+    (_, alias, _): (usize, String, usize),
 ) -> statement::SelectField {
-    statement::SelectField::Aggregation(a)
+    statement::SelectField::Aggregation(a.with_alias(&alias))
 }
 
 #[allow(unused_variables)]
@@ -18597,12 +18771,9 @@ fn __action12<'input>(
 )]
 fn __action13<'input>(
     input: &'input str,
-    (_, _, _): (usize, &'input str, usize),
-    (_, _, _): (usize, &'input str, usize),
-    (_, f, _): (usize, String, usize),
-    (_, _, _): (usize, &'input str, usize),
-) -> AggregationFn {
-    AggregationFn::from(MaxFn::new(&f))
+    (_, a, _): (usize, AggregationFn, usize),
+) -> statement::SelectField {
+    statement::SelectField::Aggregation(a)
 }
 
 #[allow(unused_variables)]
@@ -18618,7 +18789,7 @@ fn __action14<'input>(
     (_, f, _): (usize, String, usize),
     (_, _, _): (usize, &'input str, usize),
 ) -> AggregationFn {
-    AggregationFn::from(MinFn::new(&f))
+    AggregationFn::from(MaxFn::new(&f))
 }
 
 #[allow(unused_variables)]
@@ -18634,7 +18805,7 @@ fn __action15<'input>(
     (_, f, _): (usize, String, usize),
     (_, _, _): (usize, &'input str, usize),
 ) -> AggregationFn {
-    AggregationFn::from(SumFn::new(&f))
+    AggregationFn::from(MinFn::new(&f))
 }
 
 #[allow(unused_variables)]
@@ -18650,7 +18821,7 @@ fn __action16<'input>(
     (_, f, _): (usize, String, usize),
     (_, _, _): (usize, &'input str, usize),
 ) -> AggregationFn {
-    AggregationFn::from(CountFn::new(&f))
+    AggregationFn::from(SumFn::new(&f))
 }
 
 #[allow(unused_variables)]
@@ -18666,7 +18837,7 @@ fn __action17<'input>(
     (_, f, _): (usize, String, usize),
     (_, _, _): (usize, &'input str, usize),
 ) -> AggregationFn {
-    AggregationFn::from(AvgFn::new(&f))
+    AggregationFn::from(CountFn::new(&f))
 }
 
 #[allow(unused_variables)]
@@ -18676,6 +18847,22 @@ fn __action17<'input>(
     clippy::just_underscores_and_digits
 )]
 fn __action18<'input>(
+    input: &'input str,
+    (_, _, _): (usize, &'input str, usize),
+    (_, _, _): (usize, &'input str, usize),
+    (_, f, _): (usize, String, usize),
+    (_, _, _): (usize, &'input str, usize),
+) -> AggregationFn {
+    AggregationFn::from(AvgFn::new(&f))
+}
+
+#[allow(unused_variables)]
+#[allow(
+    clippy::too_many_arguments,
+    clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits
+)]
+fn __action19<'input>(
     input: &'input str,
     (_, _, _): (usize, &'input str, usize),
     (_, p, _): (usize, predicate::Predicate, usize),
@@ -18689,7 +18876,7 @@ fn __action18<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action19<'input>(
+fn __action20<'input>(
     input: &'input str,
     __lookbehind: &usize,
     __lookahead: &usize,
@@ -18703,27 +18890,13 @@ fn __action19<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action20<'input>(
+fn __action21<'input>(
     input: &'input str,
     (_, _, _): (usize, &'input str, usize),
     (_, _, _): (usize, &'input str, usize),
     (_, os, _): (usize, Vec<String>, usize),
 ) -> Option<Vec<String>> {
     Some(os)
-}
-
-#[allow(unused_variables)]
-#[allow(
-    clippy::too_many_arguments,
-    clippy::needless_lifetimes,
-    clippy::just_underscores_and_digits
-)]
-fn __action21<'input>(
-    input: &'input str,
-    __lookbehind: &usize,
-    __lookahead: &usize,
-) -> Option<Vec<String>> {
-    None
 }
 
 #[allow(unused_variables)]
@@ -18734,6 +18907,20 @@ fn __action21<'input>(
 )]
 fn __action22<'input>(
     input: &'input str,
+    __lookbehind: &usize,
+    __lookahead: &usize,
+) -> Option<Vec<String>> {
+    None
+}
+
+#[allow(unused_variables)]
+#[allow(
+    clippy::too_many_arguments,
+    clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits
+)]
+fn __action23<'input>(
+    input: &'input str,
     (_, _, _): (usize, &'input str, usize),
     (_, _, _): (usize, &'input str, usize),
     (_, os, _): (usize, Vec<String>, usize),
@@ -18747,7 +18934,7 @@ fn __action22<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action23<'input>(
+fn __action24<'input>(
     input: &'input str,
     __lookbehind: &usize,
     __lookahead: &usize,
@@ -18761,7 +18948,7 @@ fn __action23<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action24<'input>(
+fn __action25<'input>(
     input: &'input str,
     (_, _, _): (usize, &'input str, usize),
     (_, _, _): (usize, &'input str, usize),
@@ -18783,7 +18970,7 @@ fn __action24<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action25<'input>(
+fn __action26<'input>(
     input: &'input str,
     (_, _, _): (usize, &'input str, usize),
     (_, _, _): (usize, &'input str, usize),
@@ -18798,7 +18985,7 @@ fn __action25<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action26<'input>(
+fn __action27<'input>(
     input: &'input str,
     (_, _, _): (usize, &'input str, usize),
     (_, _, _): (usize, &'input str, usize),
@@ -18815,7 +19002,7 @@ fn __action26<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action27<'input>(
+fn __action28<'input>(
     input: &'input str,
     (_, _, _): (usize, &'input str, usize),
     (_, t, _): (usize, String, usize),
@@ -18833,7 +19020,7 @@ fn __action27<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action28<'input>(
+fn __action29<'input>(
     input: &'input str,
     (_, _, _): (usize, &'input str, usize),
     (_, t, _): (usize, String, usize),
@@ -18853,7 +19040,7 @@ fn __action28<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action29<'input>(
+fn __action30<'input>(
     input: &'input str,
     (_, c, _): (usize, statement::CreateCommand, usize),
 ) -> statement::UpdateCommand {
@@ -18866,7 +19053,7 @@ fn __action29<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action30<'input>(
+fn __action31<'input>(
     input: &'input str,
     (_, _, _): (usize, &'input str, usize),
     (_, _, _): (usize, &'input str, usize),
@@ -18884,7 +19071,7 @@ fn __action30<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action31<'input>(
+fn __action32<'input>(
     input: &'input str,
     (_, _, _): (usize, &'input str, usize),
     (_, _, _): (usize, &'input str, usize),
@@ -18901,7 +19088,7 @@ fn __action31<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action32<'input>(
+fn __action33<'input>(
     input: &'input str,
     (_, _, _): (usize, &'input str, usize),
     (_, _, _): (usize, &'input str, usize),
@@ -18921,7 +19108,7 @@ fn __action32<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action33<'input>(
+fn __action34<'input>(
     input: &'input str,
     (_, n, _): (usize, String, usize),
     (_, t, _): (usize, Spec, usize),
@@ -18935,7 +19122,7 @@ fn __action33<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action34<'input>(input: &'input str, (_, __0, _): (usize, &'input str, usize)) -> Spec {
+fn __action35<'input>(input: &'input str, (_, __0, _): (usize, &'input str, usize)) -> Spec {
     Spec::I32
 }
 
@@ -18945,7 +19132,7 @@ fn __action34<'input>(input: &'input str, (_, __0, _): (usize, &'input str, usiz
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action35<'input>(
+fn __action36<'input>(
     input: &'input str,
     (_, _, _): (usize, &'input str, usize),
     (_, _, _): (usize, &'input str, usize),
@@ -18961,7 +19148,7 @@ fn __action35<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action36<'input>(
+fn __action37<'input>(
     input: &'input str,
     (_, ts, _): (usize, Vec<predicate::Term>, usize),
 ) -> predicate::Predicate {
@@ -18974,7 +19161,7 @@ fn __action36<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action37<'input>(
+fn __action38<'input>(
     input: &'input str,
     (_, e, _): (usize, expression::Expression, usize),
     (_, _, _): (usize, &'input str, usize),
@@ -18989,7 +19176,7 @@ fn __action37<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action38<'input>(
+fn __action39<'input>(
     input: &'input str,
     (_, l, _): (usize, expression::Expression, usize),
     (_, _, _): (usize, &'input str, usize),
@@ -19004,26 +19191,11 @@ fn __action38<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action39<'input>(
+fn __action40<'input>(
     input: &'input str,
     (_, e, _): (usize, expression::Expression, usize),
 ) -> expression::Expression {
     e
-}
-
-#[allow(unused_variables)]
-#[allow(
-    clippy::too_many_arguments,
-    clippy::needless_lifetimes,
-    clippy::just_underscores_and_digits
-)]
-fn __action40<'input>(
-    input: &'input str,
-    (_, l, _): (usize, expression::Expression, usize),
-    (_, _, _): (usize, &'input str, usize),
-    (_, r, _): (usize, expression::Expression, usize),
-) -> expression::Expression {
-    expression::Expression::Add(Box::new(l), Box::new(r))
 }
 
 #[allow(unused_variables)]
@@ -19038,7 +19210,7 @@ fn __action41<'input>(
     (_, _, _): (usize, &'input str, usize),
     (_, r, _): (usize, expression::Expression, usize),
 ) -> expression::Expression {
-    expression::Expression::Sub(Box::new(l), Box::new(r))
+    expression::Expression::Add(Box::new(l), Box::new(r))
 }
 
 #[allow(unused_variables)]
@@ -19049,9 +19221,11 @@ fn __action41<'input>(
 )]
 fn __action42<'input>(
     input: &'input str,
-    (_, e, _): (usize, expression::Expression, usize),
+    (_, l, _): (usize, expression::Expression, usize),
+    (_, _, _): (usize, &'input str, usize),
+    (_, r, _): (usize, expression::Expression, usize),
 ) -> expression::Expression {
-    e
+    expression::Expression::Sub(Box::new(l), Box::new(r))
 }
 
 #[allow(unused_variables)]
@@ -19062,11 +19236,9 @@ fn __action42<'input>(
 )]
 fn __action43<'input>(
     input: &'input str,
-    (_, l, _): (usize, expression::Expression, usize),
-    (_, _, _): (usize, &'input str, usize),
-    (_, r, _): (usize, expression::Expression, usize),
+    (_, e, _): (usize, expression::Expression, usize),
 ) -> expression::Expression {
-    expression::Expression::Mul(Box::new(l), Box::new(r))
+    e
 }
 
 #[allow(unused_variables)]
@@ -19081,7 +19253,7 @@ fn __action44<'input>(
     (_, _, _): (usize, &'input str, usize),
     (_, r, _): (usize, expression::Expression, usize),
 ) -> expression::Expression {
-    expression::Expression::Div(Box::new(l), Box::new(r))
+    expression::Expression::Mul(Box::new(l), Box::new(r))
 }
 
 #[allow(unused_variables)]
@@ -19092,9 +19264,11 @@ fn __action44<'input>(
 )]
 fn __action45<'input>(
     input: &'input str,
-    (_, e, _): (usize, expression::Expression, usize),
+    (_, l, _): (usize, expression::Expression, usize),
+    (_, _, _): (usize, &'input str, usize),
+    (_, r, _): (usize, expression::Expression, usize),
 ) -> expression::Expression {
-    e
+    expression::Expression::Div(Box::new(l), Box::new(r))
 }
 
 #[allow(unused_variables)]
@@ -19105,9 +19279,7 @@ fn __action45<'input>(
 )]
 fn __action46<'input>(
     input: &'input str,
-    (_, _, _): (usize, &'input str, usize),
     (_, e, _): (usize, expression::Expression, usize),
-    (_, _, _): (usize, &'input str, usize),
 ) -> expression::Expression {
     e
 }
@@ -19120,6 +19292,21 @@ fn __action46<'input>(
 )]
 fn __action47<'input>(
     input: &'input str,
+    (_, _, _): (usize, &'input str, usize),
+    (_, e, _): (usize, expression::Expression, usize),
+    (_, _, _): (usize, &'input str, usize),
+) -> expression::Expression {
+    e
+}
+
+#[allow(unused_variables)]
+#[allow(
+    clippy::too_many_arguments,
+    clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits
+)]
+fn __action48<'input>(
+    input: &'input str,
     (_, __0, _): (usize, &'input str, usize),
 ) -> expression::Expression {
     expression::Expression::NullConstant
@@ -19131,7 +19318,7 @@ fn __action47<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action48<'input>(
+fn __action49<'input>(
     input: &'input str,
     (_, i, _): (usize, i32, usize),
 ) -> expression::Expression {
@@ -19144,7 +19331,7 @@ fn __action48<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action49<'input>(
+fn __action50<'input>(
     input: &'input str,
     (_, s, _): (usize, String, usize),
 ) -> expression::Expression {
@@ -19157,7 +19344,7 @@ fn __action49<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action50<'input>(
+fn __action51<'input>(
     input: &'input str,
     (_, t, _): (usize, String, usize),
 ) -> expression::Expression {
@@ -19170,7 +19357,7 @@ fn __action50<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action51<'input>(input: &'input str, (_, __0, _): (usize, &'input str, usize)) -> Value {
+fn __action52<'input>(input: &'input str, (_, __0, _): (usize, &'input str, usize)) -> Value {
     Value::Null
 }
 
@@ -19180,7 +19367,7 @@ fn __action51<'input>(input: &'input str, (_, __0, _): (usize, &'input str, usiz
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action52<'input>(input: &'input str, (_, i, _): (usize, i32, usize)) -> Value {
+fn __action53<'input>(input: &'input str, (_, i, _): (usize, i32, usize)) -> Value {
     Value::I32(i)
 }
 
@@ -19190,7 +19377,7 @@ fn __action52<'input>(input: &'input str, (_, i, _): (usize, i32, usize)) -> Val
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action53<'input>(input: &'input str, (_, s, _): (usize, String, usize)) -> Value {
+fn __action54<'input>(input: &'input str, (_, s, _): (usize, String, usize)) -> Value {
     Value::String(s)
 }
 
@@ -19200,7 +19387,7 @@ fn __action53<'input>(input: &'input str, (_, s, _): (usize, String, usize)) -> 
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action54<'input>(input: &'input str, (_, __0, _): (usize, &'input str, usize)) -> i32 {
+fn __action55<'input>(input: &'input str, (_, __0, _): (usize, &'input str, usize)) -> i32 {
     i32::from_str(__0).unwrap()
 }
 
@@ -19210,7 +19397,7 @@ fn __action54<'input>(input: &'input str, (_, __0, _): (usize, &'input str, usiz
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action55<'input>(input: &'input str, (_, __0, _): (usize, &'input str, usize)) -> String {
+fn __action56<'input>(input: &'input str, (_, __0, _): (usize, &'input str, usize)) -> String {
     String::from(&__0[1..__0.len() - 1].to_string())
 }
 
@@ -19220,7 +19407,7 @@ fn __action55<'input>(input: &'input str, (_, __0, _): (usize, &'input str, usiz
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action56<'input>(input: &'input str, (_, __0, _): (usize, &'input str, usize)) -> String {
+fn __action57<'input>(input: &'input str, (_, __0, _): (usize, &'input str, usize)) -> String {
     String::from(__0)
 }
 
@@ -19230,7 +19417,7 @@ fn __action56<'input>(input: &'input str, (_, __0, _): (usize, &'input str, usiz
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action57<'input>(
+fn __action58<'input>(
     input: &'input str,
     (_, mut v, _): (usize, alloc::vec::Vec<predicate::Term>, usize),
     (_, e, _): (usize, predicate::Term, usize),
@@ -19247,7 +19434,7 @@ fn __action57<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action58<'input>(
+fn __action59<'input>(
     input: &'input str,
     (_, mut v, _): (usize, alloc::vec::Vec<statement::FieldDefinition>, usize),
     (_, e, _): (usize, statement::FieldDefinition, usize),
@@ -19264,7 +19451,7 @@ fn __action58<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action59<'input>(
+fn __action60<'input>(
     input: &'input str,
     (_, mut v, _): (usize, alloc::vec::Vec<Value>, usize),
     (_, e, _): (usize, Value, usize),
@@ -19281,7 +19468,7 @@ fn __action59<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action60<'input>(
+fn __action61<'input>(
     input: &'input str,
     (_, mut v, _): (usize, alloc::vec::Vec<statement::SelectField>, usize),
     (_, e, _): (usize, statement::SelectField, usize),
@@ -19298,7 +19485,7 @@ fn __action60<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action61<'input>(
+fn __action62<'input>(
     input: &'input str,
     (_, mut v, _): (usize, alloc::vec::Vec<String>, usize),
     (_, e, _): (usize, String, usize),
@@ -19315,7 +19502,7 @@ fn __action61<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action62<'input>(
+fn __action63<'input>(
     input: &'input str,
     __lookbehind: &usize,
     __lookahead: &usize,
@@ -19329,7 +19516,7 @@ fn __action62<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action63<'input>(
+fn __action64<'input>(
     input: &'input str,
     (_, v, _): (usize, alloc::vec::Vec<String>, usize),
 ) -> alloc::vec::Vec<String> {
@@ -19342,7 +19529,7 @@ fn __action63<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action64<'input>(
+fn __action65<'input>(
     input: &'input str,
     (_, __0, _): (usize, String, usize),
     (_, _, _): (usize, &'input str, usize),
@@ -19356,7 +19543,7 @@ fn __action64<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action65<'input>(
+fn __action66<'input>(
     input: &'input str,
     __lookbehind: &usize,
     __lookahead: &usize,
@@ -19370,7 +19557,7 @@ fn __action65<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action66<'input>(
+fn __action67<'input>(
     input: &'input str,
     (_, v, _): (usize, alloc::vec::Vec<statement::SelectField>, usize),
 ) -> alloc::vec::Vec<statement::SelectField> {
@@ -19383,7 +19570,7 @@ fn __action66<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action67<'input>(
+fn __action68<'input>(
     input: &'input str,
     (_, __0, _): (usize, statement::SelectField, usize),
     (_, _, _): (usize, &'input str, usize),
@@ -19397,7 +19584,7 @@ fn __action67<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action68<'input>(
+fn __action69<'input>(
     input: &'input str,
     __lookbehind: &usize,
     __lookahead: &usize,
@@ -19411,7 +19598,7 @@ fn __action68<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action69<'input>(
+fn __action70<'input>(
     input: &'input str,
     (_, v, _): (usize, alloc::vec::Vec<Value>, usize),
 ) -> alloc::vec::Vec<Value> {
@@ -19424,7 +19611,7 @@ fn __action69<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action70<'input>(
+fn __action71<'input>(
     input: &'input str,
     (_, __0, _): (usize, Value, usize),
     (_, _, _): (usize, &'input str, usize),
@@ -19438,7 +19625,7 @@ fn __action70<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action71<'input>(
+fn __action72<'input>(
     input: &'input str,
     __lookbehind: &usize,
     __lookahead: &usize,
@@ -19452,7 +19639,7 @@ fn __action71<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action72<'input>(
+fn __action73<'input>(
     input: &'input str,
     (_, v, _): (usize, alloc::vec::Vec<statement::FieldDefinition>, usize),
 ) -> alloc::vec::Vec<statement::FieldDefinition> {
@@ -19465,7 +19652,7 @@ fn __action72<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action73<'input>(
+fn __action74<'input>(
     input: &'input str,
     (_, __0, _): (usize, statement::FieldDefinition, usize),
     (_, _, _): (usize, &'input str, usize),
@@ -19479,7 +19666,7 @@ fn __action73<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action74<'input>(
+fn __action75<'input>(
     input: &'input str,
     __lookbehind: &usize,
     __lookahead: &usize,
@@ -19493,7 +19680,7 @@ fn __action74<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action75<'input>(
+fn __action76<'input>(
     input: &'input str,
     (_, v, _): (usize, alloc::vec::Vec<predicate::Term>, usize),
 ) -> alloc::vec::Vec<predicate::Term> {
@@ -19506,7 +19693,7 @@ fn __action75<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action76<'input>(
+fn __action77<'input>(
     input: &'input str,
     (_, __0, _): (usize, predicate::Term, usize),
     (_, _, _): (usize, &'input str, usize),
@@ -19520,7 +19707,7 @@ fn __action76<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action77<'input>(
+fn __action78<'input>(
     input: &'input str,
     (_, __0, _): (usize, predicate::Term, usize),
 ) -> alloc::vec::Vec<predicate::Term> {
@@ -19533,7 +19720,7 @@ fn __action77<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action78<'input>(
+fn __action79<'input>(
     input: &'input str,
     (_, v, _): (usize, alloc::vec::Vec<predicate::Term>, usize),
     (_, e, _): (usize, predicate::Term, usize),
@@ -19551,7 +19738,7 @@ fn __action78<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action79<'input>(
+fn __action80<'input>(
     input: &'input str,
     (_, __0, _): (usize, statement::FieldDefinition, usize),
 ) -> alloc::vec::Vec<statement::FieldDefinition> {
@@ -19564,7 +19751,7 @@ fn __action79<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action80<'input>(
+fn __action81<'input>(
     input: &'input str,
     (_, v, _): (usize, alloc::vec::Vec<statement::FieldDefinition>, usize),
     (_, e, _): (usize, statement::FieldDefinition, usize),
@@ -19582,7 +19769,7 @@ fn __action80<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action81<'input>(
+fn __action82<'input>(
     input: &'input str,
     (_, __0, _): (usize, Value, usize),
 ) -> alloc::vec::Vec<Value> {
@@ -19595,7 +19782,7 @@ fn __action81<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action82<'input>(
+fn __action83<'input>(
     input: &'input str,
     (_, v, _): (usize, alloc::vec::Vec<Value>, usize),
     (_, e, _): (usize, Value, usize),
@@ -19613,7 +19800,7 @@ fn __action82<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action83<'input>(
+fn __action84<'input>(
     input: &'input str,
     (_, __0, _): (usize, statement::SelectField, usize),
 ) -> alloc::vec::Vec<statement::SelectField> {
@@ -19626,7 +19813,7 @@ fn __action83<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action84<'input>(
+fn __action85<'input>(
     input: &'input str,
     (_, v, _): (usize, alloc::vec::Vec<statement::SelectField>, usize),
     (_, e, _): (usize, statement::SelectField, usize),
@@ -19644,7 +19831,7 @@ fn __action84<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action85<'input>(
+fn __action86<'input>(
     input: &'input str,
     (_, __0, _): (usize, String, usize),
 ) -> alloc::vec::Vec<String> {
@@ -19657,7 +19844,7 @@ fn __action85<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action86<'input>(
+fn __action87<'input>(
     input: &'input str,
     (_, v, _): (usize, alloc::vec::Vec<String>, usize),
     (_, e, _): (usize, String, usize),
@@ -19675,16 +19862,16 @@ fn __action86<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action87<'input>(
+fn __action88<'input>(
     input: &'input str,
     __0: (usize, Value, usize),
     __1: (usize, &'input str, usize),
 ) -> alloc::vec::Vec<Value> {
     let __start0 = __0.0;
     let __end0 = __1.2;
-    let __temp0 = __action70(input, __0, __1);
+    let __temp0 = __action71(input, __0, __1);
     let __temp0 = (__start0, __temp0, __end0);
-    __action81(input, __temp0)
+    __action82(input, __temp0)
 }
 
 #[allow(unused_variables)]
@@ -19693,7 +19880,7 @@ fn __action87<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action88<'input>(
+fn __action89<'input>(
     input: &'input str,
     __0: (usize, alloc::vec::Vec<Value>, usize),
     __1: (usize, Value, usize),
@@ -19701,9 +19888,9 @@ fn __action88<'input>(
 ) -> alloc::vec::Vec<Value> {
     let __start0 = __1.0;
     let __end0 = __2.2;
-    let __temp0 = __action70(input, __1, __2);
+    let __temp0 = __action71(input, __1, __2);
     let __temp0 = (__start0, __temp0, __end0);
-    __action82(input, __0, __temp0)
+    __action83(input, __0, __temp0)
 }
 
 #[allow(unused_variables)]
@@ -19712,223 +19899,10 @@ fn __action88<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action89<'input>(input: &'input str, __0: (usize, Value, usize)) -> Vec<Value> {
+fn __action90<'input>(input: &'input str, __0: (usize, Value, usize)) -> Vec<Value> {
     let __start0 = __0.0;
     let __end0 = __0.0;
-    let __temp0 = __action68(input, &__start0, &__end0);
-    let __temp0 = (__start0, __temp0, __end0);
-    __action59(input, __temp0, __0)
-}
-
-#[allow(unused_variables)]
-#[allow(
-    clippy::too_many_arguments,
-    clippy::needless_lifetimes,
-    clippy::just_underscores_and_digits
-)]
-fn __action90<'input>(
-    input: &'input str,
-    __0: (usize, alloc::vec::Vec<Value>, usize),
-    __1: (usize, Value, usize),
-) -> Vec<Value> {
-    let __start0 = __0.0;
-    let __end0 = __0.2;
-    let __temp0 = __action69(input, __0);
-    let __temp0 = (__start0, __temp0, __end0);
-    __action59(input, __temp0, __1)
-}
-
-#[allow(unused_variables)]
-#[allow(
-    clippy::too_many_arguments,
-    clippy::needless_lifetimes,
-    clippy::just_underscores_and_digits
-)]
-fn __action91<'input>(
-    input: &'input str,
-    __0: (usize, statement::FieldDefinition, usize),
-    __1: (usize, &'input str, usize),
-) -> alloc::vec::Vec<statement::FieldDefinition> {
-    let __start0 = __0.0;
-    let __end0 = __1.2;
-    let __temp0 = __action73(input, __0, __1);
-    let __temp0 = (__start0, __temp0, __end0);
-    __action79(input, __temp0)
-}
-
-#[allow(unused_variables)]
-#[allow(
-    clippy::too_many_arguments,
-    clippy::needless_lifetimes,
-    clippy::just_underscores_and_digits
-)]
-fn __action92<'input>(
-    input: &'input str,
-    __0: (usize, alloc::vec::Vec<statement::FieldDefinition>, usize),
-    __1: (usize, statement::FieldDefinition, usize),
-    __2: (usize, &'input str, usize),
-) -> alloc::vec::Vec<statement::FieldDefinition> {
-    let __start0 = __1.0;
-    let __end0 = __2.2;
-    let __temp0 = __action73(input, __1, __2);
-    let __temp0 = (__start0, __temp0, __end0);
-    __action80(input, __0, __temp0)
-}
-
-#[allow(unused_variables)]
-#[allow(
-    clippy::too_many_arguments,
-    clippy::needless_lifetimes,
-    clippy::just_underscores_and_digits
-)]
-fn __action93<'input>(
-    input: &'input str,
-    __0: (usize, statement::FieldDefinition, usize),
-) -> Vec<statement::FieldDefinition> {
-    let __start0 = __0.0;
-    let __end0 = __0.0;
-    let __temp0 = __action71(input, &__start0, &__end0);
-    let __temp0 = (__start0, __temp0, __end0);
-    __action58(input, __temp0, __0)
-}
-
-#[allow(unused_variables)]
-#[allow(
-    clippy::too_many_arguments,
-    clippy::needless_lifetimes,
-    clippy::just_underscores_and_digits
-)]
-fn __action94<'input>(
-    input: &'input str,
-    __0: (usize, alloc::vec::Vec<statement::FieldDefinition>, usize),
-    __1: (usize, statement::FieldDefinition, usize),
-) -> Vec<statement::FieldDefinition> {
-    let __start0 = __0.0;
-    let __end0 = __0.2;
-    let __temp0 = __action72(input, __0);
-    let __temp0 = (__start0, __temp0, __end0);
-    __action58(input, __temp0, __1)
-}
-
-#[allow(unused_variables)]
-#[allow(
-    clippy::too_many_arguments,
-    clippy::needless_lifetimes,
-    clippy::just_underscores_and_digits
-)]
-fn __action95<'input>(
-    input: &'input str,
-    __0: (usize, String, usize),
-    __1: (usize, &'input str, usize),
-) -> alloc::vec::Vec<String> {
-    let __start0 = __0.0;
-    let __end0 = __1.2;
-    let __temp0 = __action64(input, __0, __1);
-    let __temp0 = (__start0, __temp0, __end0);
-    __action85(input, __temp0)
-}
-
-#[allow(unused_variables)]
-#[allow(
-    clippy::too_many_arguments,
-    clippy::needless_lifetimes,
-    clippy::just_underscores_and_digits
-)]
-fn __action96<'input>(
-    input: &'input str,
-    __0: (usize, alloc::vec::Vec<String>, usize),
-    __1: (usize, String, usize),
-    __2: (usize, &'input str, usize),
-) -> alloc::vec::Vec<String> {
-    let __start0 = __1.0;
-    let __end0 = __2.2;
-    let __temp0 = __action64(input, __1, __2);
-    let __temp0 = (__start0, __temp0, __end0);
-    __action86(input, __0, __temp0)
-}
-
-#[allow(unused_variables)]
-#[allow(
-    clippy::too_many_arguments,
-    clippy::needless_lifetimes,
-    clippy::just_underscores_and_digits
-)]
-fn __action97<'input>(input: &'input str, __0: (usize, String, usize)) -> Vec<String> {
-    let __start0 = __0.0;
-    let __end0 = __0.0;
-    let __temp0 = __action62(input, &__start0, &__end0);
-    let __temp0 = (__start0, __temp0, __end0);
-    __action61(input, __temp0, __0)
-}
-
-#[allow(unused_variables)]
-#[allow(
-    clippy::too_many_arguments,
-    clippy::needless_lifetimes,
-    clippy::just_underscores_and_digits
-)]
-fn __action98<'input>(
-    input: &'input str,
-    __0: (usize, alloc::vec::Vec<String>, usize),
-    __1: (usize, String, usize),
-) -> Vec<String> {
-    let __start0 = __0.0;
-    let __end0 = __0.2;
-    let __temp0 = __action63(input, __0);
-    let __temp0 = (__start0, __temp0, __end0);
-    __action61(input, __temp0, __1)
-}
-
-#[allow(unused_variables)]
-#[allow(
-    clippy::too_many_arguments,
-    clippy::needless_lifetimes,
-    clippy::just_underscores_and_digits
-)]
-fn __action99<'input>(
-    input: &'input str,
-    __0: (usize, statement::SelectField, usize),
-    __1: (usize, &'input str, usize),
-) -> alloc::vec::Vec<statement::SelectField> {
-    let __start0 = __0.0;
-    let __end0 = __1.2;
-    let __temp0 = __action67(input, __0, __1);
-    let __temp0 = (__start0, __temp0, __end0);
-    __action83(input, __temp0)
-}
-
-#[allow(unused_variables)]
-#[allow(
-    clippy::too_many_arguments,
-    clippy::needless_lifetimes,
-    clippy::just_underscores_and_digits
-)]
-fn __action100<'input>(
-    input: &'input str,
-    __0: (usize, alloc::vec::Vec<statement::SelectField>, usize),
-    __1: (usize, statement::SelectField, usize),
-    __2: (usize, &'input str, usize),
-) -> alloc::vec::Vec<statement::SelectField> {
-    let __start0 = __1.0;
-    let __end0 = __2.2;
-    let __temp0 = __action67(input, __1, __2);
-    let __temp0 = (__start0, __temp0, __end0);
-    __action84(input, __0, __temp0)
-}
-
-#[allow(unused_variables)]
-#[allow(
-    clippy::too_many_arguments,
-    clippy::needless_lifetimes,
-    clippy::just_underscores_and_digits
-)]
-fn __action101<'input>(
-    input: &'input str,
-    __0: (usize, statement::SelectField, usize),
-) -> Vec<statement::SelectField> {
-    let __start0 = __0.0;
-    let __end0 = __0.0;
-    let __temp0 = __action65(input, &__start0, &__end0);
+    let __temp0 = __action69(input, &__start0, &__end0);
     let __temp0 = (__start0, __temp0, __end0);
     __action60(input, __temp0, __0)
 }
@@ -19939,14 +19913,14 @@ fn __action101<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action102<'input>(
+fn __action91<'input>(
     input: &'input str,
-    __0: (usize, alloc::vec::Vec<statement::SelectField>, usize),
-    __1: (usize, statement::SelectField, usize),
-) -> Vec<statement::SelectField> {
+    __0: (usize, alloc::vec::Vec<Value>, usize),
+    __1: (usize, Value, usize),
+) -> Vec<Value> {
     let __start0 = __0.0;
     let __end0 = __0.2;
-    let __temp0 = __action66(input, __0);
+    let __temp0 = __action70(input, __0);
     let __temp0 = (__start0, __temp0, __end0);
     __action60(input, __temp0, __1)
 }
@@ -19957,16 +19931,211 @@ fn __action102<'input>(
     clippy::needless_lifetimes,
     clippy::just_underscores_and_digits
 )]
-fn __action103<'input>(
+fn __action92<'input>(
     input: &'input str,
-    __0: (usize, predicate::Term, usize),
+    __0: (usize, statement::FieldDefinition, usize),
     __1: (usize, &'input str, usize),
-) -> alloc::vec::Vec<predicate::Term> {
+) -> alloc::vec::Vec<statement::FieldDefinition> {
     let __start0 = __0.0;
     let __end0 = __1.2;
-    let __temp0 = __action76(input, __0, __1);
+    let __temp0 = __action74(input, __0, __1);
     let __temp0 = (__start0, __temp0, __end0);
-    __action77(input, __temp0)
+    __action80(input, __temp0)
+}
+
+#[allow(unused_variables)]
+#[allow(
+    clippy::too_many_arguments,
+    clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits
+)]
+fn __action93<'input>(
+    input: &'input str,
+    __0: (usize, alloc::vec::Vec<statement::FieldDefinition>, usize),
+    __1: (usize, statement::FieldDefinition, usize),
+    __2: (usize, &'input str, usize),
+) -> alloc::vec::Vec<statement::FieldDefinition> {
+    let __start0 = __1.0;
+    let __end0 = __2.2;
+    let __temp0 = __action74(input, __1, __2);
+    let __temp0 = (__start0, __temp0, __end0);
+    __action81(input, __0, __temp0)
+}
+
+#[allow(unused_variables)]
+#[allow(
+    clippy::too_many_arguments,
+    clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits
+)]
+fn __action94<'input>(
+    input: &'input str,
+    __0: (usize, statement::FieldDefinition, usize),
+) -> Vec<statement::FieldDefinition> {
+    let __start0 = __0.0;
+    let __end0 = __0.0;
+    let __temp0 = __action72(input, &__start0, &__end0);
+    let __temp0 = (__start0, __temp0, __end0);
+    __action59(input, __temp0, __0)
+}
+
+#[allow(unused_variables)]
+#[allow(
+    clippy::too_many_arguments,
+    clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits
+)]
+fn __action95<'input>(
+    input: &'input str,
+    __0: (usize, alloc::vec::Vec<statement::FieldDefinition>, usize),
+    __1: (usize, statement::FieldDefinition, usize),
+) -> Vec<statement::FieldDefinition> {
+    let __start0 = __0.0;
+    let __end0 = __0.2;
+    let __temp0 = __action73(input, __0);
+    let __temp0 = (__start0, __temp0, __end0);
+    __action59(input, __temp0, __1)
+}
+
+#[allow(unused_variables)]
+#[allow(
+    clippy::too_many_arguments,
+    clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits
+)]
+fn __action96<'input>(
+    input: &'input str,
+    __0: (usize, String, usize),
+    __1: (usize, &'input str, usize),
+) -> alloc::vec::Vec<String> {
+    let __start0 = __0.0;
+    let __end0 = __1.2;
+    let __temp0 = __action65(input, __0, __1);
+    let __temp0 = (__start0, __temp0, __end0);
+    __action86(input, __temp0)
+}
+
+#[allow(unused_variables)]
+#[allow(
+    clippy::too_many_arguments,
+    clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits
+)]
+fn __action97<'input>(
+    input: &'input str,
+    __0: (usize, alloc::vec::Vec<String>, usize),
+    __1: (usize, String, usize),
+    __2: (usize, &'input str, usize),
+) -> alloc::vec::Vec<String> {
+    let __start0 = __1.0;
+    let __end0 = __2.2;
+    let __temp0 = __action65(input, __1, __2);
+    let __temp0 = (__start0, __temp0, __end0);
+    __action87(input, __0, __temp0)
+}
+
+#[allow(unused_variables)]
+#[allow(
+    clippy::too_many_arguments,
+    clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits
+)]
+fn __action98<'input>(input: &'input str, __0: (usize, String, usize)) -> Vec<String> {
+    let __start0 = __0.0;
+    let __end0 = __0.0;
+    let __temp0 = __action63(input, &__start0, &__end0);
+    let __temp0 = (__start0, __temp0, __end0);
+    __action62(input, __temp0, __0)
+}
+
+#[allow(unused_variables)]
+#[allow(
+    clippy::too_many_arguments,
+    clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits
+)]
+fn __action99<'input>(
+    input: &'input str,
+    __0: (usize, alloc::vec::Vec<String>, usize),
+    __1: (usize, String, usize),
+) -> Vec<String> {
+    let __start0 = __0.0;
+    let __end0 = __0.2;
+    let __temp0 = __action64(input, __0);
+    let __temp0 = (__start0, __temp0, __end0);
+    __action62(input, __temp0, __1)
+}
+
+#[allow(unused_variables)]
+#[allow(
+    clippy::too_many_arguments,
+    clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits
+)]
+fn __action100<'input>(
+    input: &'input str,
+    __0: (usize, statement::SelectField, usize),
+    __1: (usize, &'input str, usize),
+) -> alloc::vec::Vec<statement::SelectField> {
+    let __start0 = __0.0;
+    let __end0 = __1.2;
+    let __temp0 = __action68(input, __0, __1);
+    let __temp0 = (__start0, __temp0, __end0);
+    __action84(input, __temp0)
+}
+
+#[allow(unused_variables)]
+#[allow(
+    clippy::too_many_arguments,
+    clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits
+)]
+fn __action101<'input>(
+    input: &'input str,
+    __0: (usize, alloc::vec::Vec<statement::SelectField>, usize),
+    __1: (usize, statement::SelectField, usize),
+    __2: (usize, &'input str, usize),
+) -> alloc::vec::Vec<statement::SelectField> {
+    let __start0 = __1.0;
+    let __end0 = __2.2;
+    let __temp0 = __action68(input, __1, __2);
+    let __temp0 = (__start0, __temp0, __end0);
+    __action85(input, __0, __temp0)
+}
+
+#[allow(unused_variables)]
+#[allow(
+    clippy::too_many_arguments,
+    clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits
+)]
+fn __action102<'input>(
+    input: &'input str,
+    __0: (usize, statement::SelectField, usize),
+) -> Vec<statement::SelectField> {
+    let __start0 = __0.0;
+    let __end0 = __0.0;
+    let __temp0 = __action66(input, &__start0, &__end0);
+    let __temp0 = (__start0, __temp0, __end0);
+    __action61(input, __temp0, __0)
+}
+
+#[allow(unused_variables)]
+#[allow(
+    clippy::too_many_arguments,
+    clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits
+)]
+fn __action103<'input>(
+    input: &'input str,
+    __0: (usize, alloc::vec::Vec<statement::SelectField>, usize),
+    __1: (usize, statement::SelectField, usize),
+) -> Vec<statement::SelectField> {
+    let __start0 = __0.0;
+    let __end0 = __0.2;
+    let __temp0 = __action67(input, __0);
+    let __temp0 = (__start0, __temp0, __end0);
+    __action61(input, __temp0, __1)
 }
 
 #[allow(unused_variables)]
@@ -19977,15 +20146,14 @@ fn __action103<'input>(
 )]
 fn __action104<'input>(
     input: &'input str,
-    __0: (usize, alloc::vec::Vec<predicate::Term>, usize),
-    __1: (usize, predicate::Term, usize),
-    __2: (usize, &'input str, usize),
+    __0: (usize, predicate::Term, usize),
+    __1: (usize, &'input str, usize),
 ) -> alloc::vec::Vec<predicate::Term> {
-    let __start0 = __1.0;
-    let __end0 = __2.2;
-    let __temp0 = __action76(input, __1, __2);
+    let __start0 = __0.0;
+    let __end0 = __1.2;
+    let __temp0 = __action77(input, __0, __1);
     let __temp0 = (__start0, __temp0, __end0);
-    __action78(input, __0, __temp0)
+    __action78(input, __temp0)
 }
 
 #[allow(unused_variables)]
@@ -19996,13 +20164,15 @@ fn __action104<'input>(
 )]
 fn __action105<'input>(
     input: &'input str,
-    __0: (usize, predicate::Term, usize),
-) -> Vec<predicate::Term> {
-    let __start0 = __0.0;
-    let __end0 = __0.0;
-    let __temp0 = __action74(input, &__start0, &__end0);
+    __0: (usize, alloc::vec::Vec<predicate::Term>, usize),
+    __1: (usize, predicate::Term, usize),
+    __2: (usize, &'input str, usize),
+) -> alloc::vec::Vec<predicate::Term> {
+    let __start0 = __1.0;
+    let __end0 = __2.2;
+    let __temp0 = __action77(input, __1, __2);
     let __temp0 = (__start0, __temp0, __end0);
-    __action57(input, __temp0, __0)
+    __action79(input, __0, __temp0)
 }
 
 #[allow(unused_variables)]
@@ -20013,14 +20183,31 @@ fn __action105<'input>(
 )]
 fn __action106<'input>(
     input: &'input str,
+    __0: (usize, predicate::Term, usize),
+) -> Vec<predicate::Term> {
+    let __start0 = __0.0;
+    let __end0 = __0.0;
+    let __temp0 = __action75(input, &__start0, &__end0);
+    let __temp0 = (__start0, __temp0, __end0);
+    __action58(input, __temp0, __0)
+}
+
+#[allow(unused_variables)]
+#[allow(
+    clippy::too_many_arguments,
+    clippy::needless_lifetimes,
+    clippy::just_underscores_and_digits
+)]
+fn __action107<'input>(
+    input: &'input str,
     __0: (usize, alloc::vec::Vec<predicate::Term>, usize),
     __1: (usize, predicate::Term, usize),
 ) -> Vec<predicate::Term> {
     let __start0 = __0.0;
     let __end0 = __0.2;
-    let __temp0 = __action75(input, __0);
+    let __temp0 = __action76(input, __0);
     let __temp0 = (__start0, __temp0, __end0);
-    __action57(input, __temp0, __1)
+    __action58(input, __temp0, __1)
 }
 
 #[allow(clippy::type_complexity, dead_code)]

--- a/src/parser/grammar.rs
+++ b/src/parser/grammar.rs
@@ -1,5 +1,5 @@
 // auto-generated: "lalrpop 0.22.0"
-// sha3: a1f95ca00eb9c07b7f582ed1db9e9677965a01724a15649f0c3d35ca728c20f4
+// sha3: 5cbdfea2e9abfaac60a9f8a247ba9b8903616225fdb4b4cd33a8e05be4e049b8
 use super::expression;
 use super::predicate;
 use super::statement;
@@ -18674,8 +18674,15 @@ fn __action7<'input>(
                             None => panic!("expression without alias"),
                         },
                     },
-                    statement::SelectField::Aggregation(af) => {
-                        output_fields.push(af.get_field_name().to_string());
+                    statement::SelectField::Aggregation(af, alias) => {
+                        let field_name = af.get_field_name().to_string();
+                        match alias {
+                            Some(a) => {
+                                output_fields.push(a.clone());
+                                extend_fields.push((expression::Expression::Field(field_name), a));
+                            }
+                            None => output_fields.push(field_name),
+                        }
                         aggregation_functions.push(af);
                     }
                 }
@@ -18760,7 +18767,7 @@ fn __action12<'input>(
     (_, _, _): (usize, &'input str, usize),
     (_, alias, _): (usize, String, usize),
 ) -> statement::SelectField {
-    statement::SelectField::Aggregation(a.with_alias(&alias))
+    statement::SelectField::Aggregation(a, Some(alias))
 }
 
 #[allow(unused_variables)]
@@ -18773,7 +18780,7 @@ fn __action13<'input>(
     input: &'input str,
     (_, a, _): (usize, AggregationFn, usize),
 ) -> statement::SelectField {
-    statement::SelectField::Aggregation(a)
+    statement::SelectField::Aggregation(a, None)
 }
 
 #[allow(unused_variables)]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -271,8 +271,8 @@ mod tests {
                 None,
                 Some(vec!["val".to_string()]),
                 None,
-                Vec::new(),
-                vec![AggregationFn::from(SumFn::new("val").with_alias("total"))],
+                vec![(Expression::Field("val".to_string()), "total".to_string())],
+                vec![AggregationFn::from(SumFn::new("val"))],
             ))
         );
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -6,6 +6,7 @@ pub mod statement;
 #[cfg(test)]
 mod tests {
     use crate::{
+        materialization::{aggregation_function::AggregationFn, sum_function::SumFn},
         parser::{
             expression::Expression,
             grammar,
@@ -254,6 +255,24 @@ mod tests {
                     ),
                     "b".to_string(),
                 ),],
+            ))
+        );
+    }
+
+    #[test]
+    fn test_select_aggregation_as_alias() {
+        assert_eq!(
+            grammar::StatementParser::new()
+                .parse("SELECT SUM(val) AS total FROM t GROUP BY val")
+                .unwrap(),
+            Statement::Query(QueryData::new_full(
+                Some(vec!["total".to_string()]),
+                vec!["t".to_string()],
+                None,
+                Some(vec!["val".to_string()]),
+                None,
+                Vec::new(),
+                vec![AggregationFn::from(SumFn::new("val").with_alias("total"))],
             ))
         );
     }

--- a/src/parser/statement.rs
+++ b/src/parser/statement.rs
@@ -1,6 +1,7 @@
 use crate::record::field::{Spec, Value};
 
 use super::{expression::Expression, predicate::Predicate};
+use crate::materialization::aggregation_function::AggregationFn;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum Statement {
@@ -9,15 +10,43 @@ pub enum Statement {
 }
 
 #[derive(Debug, PartialEq, Eq)]
+pub enum SelectField {
+    Expression(Expression, Option<String>),
+    Aggregation(AggregationFn),
+}
+
+#[derive(Debug, PartialEq, Eq)]
 pub struct QueryData {
     pub fields: Option<Vec<String>>, // None means all fields
     pub tables: Vec<String>,
     pub predicate: Option<Predicate>,
+    pub group_by: Option<Vec<String>>, // None means no grouping
     pub order_by: Option<Vec<String>>, // None means no ordering
     pub extend_fields: Vec<(Expression, String)>,
+    pub aggregation_functions: Vec<AggregationFn>,
 }
 
 impl QueryData {
+    pub fn new_full(
+        fields: Option<Vec<String>>,
+        tables: Vec<String>,
+        predicate: Option<Predicate>,
+        group_by: Option<Vec<String>>,
+        order_by: Option<Vec<String>>,
+        extend_fields: Vec<(Expression, String)>,
+        aggregation_functions: Vec<AggregationFn>,
+    ) -> Self {
+        QueryData {
+            fields,
+            tables,
+            predicate,
+            group_by,
+            order_by,
+            extend_fields,
+            aggregation_functions,
+        }
+    }
+
     pub fn new(fields: Vec<String>, tables: Vec<String>, predicate: Option<Predicate>) -> Self {
         QueryData::new_with_order_and_extend(fields, tables, predicate, None, vec![])
     }
@@ -32,13 +61,15 @@ impl QueryData {
         predicate: Option<Predicate>,
         order_by: Option<Vec<String>>,
     ) -> Self {
-        QueryData {
-            fields: Some(fields),
+        QueryData::new_full(
+            Some(fields),
             tables,
             predicate,
+            None,
             order_by,
-            extend_fields: Vec::new(),
-        }
+            Vec::new(),
+            Vec::new(),
+        )
     }
 
     pub fn new_all_with_order(
@@ -46,13 +77,15 @@ impl QueryData {
         predicate: Option<Predicate>,
         order_by: Option<Vec<String>>,
     ) -> Self {
-        QueryData {
-            fields: None,
+        QueryData::new_full(
+            None,
             tables,
             predicate,
+            None,
             order_by,
-            extend_fields: Vec::new(),
-        }
+            Vec::new(),
+            Vec::new(),
+        )
     }
 
     pub fn new_with_order_and_extend(
@@ -62,13 +95,15 @@ impl QueryData {
         order_by: Option<Vec<String>>,
         extend_fields: Vec<(Expression, String)>,
     ) -> Self {
-        QueryData {
-            fields: Some(fields),
+        QueryData::new_full(
+            Some(fields),
             tables,
             predicate,
+            None,
             order_by,
             extend_fields,
-        }
+            Vec::new(),
+        )
     }
 
     pub fn new_all_with_order_and_extend(
@@ -77,13 +112,15 @@ impl QueryData {
         order_by: Option<Vec<String>>,
         extend_fields: Vec<(Expression, String)>,
     ) -> Self {
-        QueryData {
-            fields: None,
+        QueryData::new_full(
+            None,
             tables,
             predicate,
+            None,
             order_by,
             extend_fields,
-        }
+            Vec::new(),
+        )
     }
 }
 

--- a/src/parser/statement.rs
+++ b/src/parser/statement.rs
@@ -12,7 +12,7 @@ pub enum Statement {
 #[derive(Debug, PartialEq, Eq)]
 pub enum SelectField {
     Expression(Expression, Option<String>),
-    Aggregation(AggregationFn),
+    Aggregation(AggregationFn, Option<String>),
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/src/planner/basic_query_planner.rs
+++ b/src/planner/basic_query_planner.rs
@@ -434,8 +434,8 @@ mod tests {
             None,
             Some(vec!["A".to_string()]),
             None,
-            Vec::new(),
-            vec![AggregationFn::from(SumFn::new("B").with_alias("total"))],
+            vec![(Expression::Field("B".to_string()), "total".to_string())],
+            vec![AggregationFn::from(SumFn::new("B"))],
         );
 
         let planner = BasicQueryPlanner::new(db.metadata_manager.clone());

--- a/src/planner/basic_query_planner.rs
+++ b/src/planner/basic_query_planner.rs
@@ -397,4 +397,60 @@ mod tests {
         tx.lock().unwrap().commit()?;
         Ok(())
     }
+
+    #[test]
+    fn test_group_by_alias_basic_query_planner() -> Result<(), TransactionError> {
+        let temp_dir = tempfile::tempdir().unwrap().into_path().join("directory");
+        let block_size = 256;
+        let num_buffers = 100;
+        let db = SimpleDB::new(temp_dir, block_size, num_buffers)?;
+
+        let tx = Arc::new(Mutex::new(db.new_transaction()?));
+        {
+            let mut md = db.metadata_manager.lock().unwrap();
+            let mut schema = Schema::new();
+            schema.add_i32_field("A");
+            schema.add_i32_field("B");
+            md.create_table("table1", &schema, tx.clone())?;
+        }
+
+        {
+            let layout = {
+                let md = db.metadata_manager.lock().unwrap();
+                md.get_layout("table1", tx.clone())?.unwrap()
+            };
+            let mut table_scan = TableScan::new(tx.clone(), "table1", Arc::new(layout))?;
+            table_scan.before_first()?;
+            for i in 0..50 {
+                table_scan.insert()?;
+                table_scan.set_i32("A", i / 5)?;
+                table_scan.set_i32("B", i)?;
+            }
+        }
+
+        let query = QueryData::new_full(
+            Some(vec!["A".to_string(), "total".to_string()]),
+            vec!["table1".to_string()],
+            None,
+            Some(vec!["A".to_string()]),
+            None,
+            Vec::new(),
+            vec![AggregationFn::from(SumFn::new("B").with_alias("total"))],
+        );
+
+        let planner = BasicQueryPlanner::new(db.metadata_manager.clone());
+        let mut plan = planner.create_plan(&query, tx.clone())?;
+
+        let mut scan = plan.open(tx.clone())?;
+        scan.before_first()?;
+        for i in 0..10 {
+            assert!(scan.next()?);
+            assert_eq!(scan.get_i32("A")?, Some(i));
+            assert_eq!(scan.get_i32("total")?, Some(25 * i + 10));
+        }
+        assert!(!scan.next()?);
+        drop(scan);
+        tx.lock().unwrap().commit()?;
+        Ok(())
+    }
 }

--- a/src/planner/heuristic_query_planner.rs
+++ b/src/planner/heuristic_query_planner.rs
@@ -391,8 +391,8 @@ mod tests {
             None,
             Some(vec!["A".to_string()]),
             None,
-            Vec::new(),
-            vec![AggregationFn::from(SumFn::new("B").with_alias("total"))],
+            vec![(Expression::Field("B".to_string()), "total".to_string())],
+            vec![AggregationFn::from(SumFn::new("B"))],
         );
 
         let planner = HeuristicQueryPlanner::new(db.metadata_manager.clone());

--- a/src/planner/heuristic_query_planner.rs
+++ b/src/planner/heuristic_query_planner.rs
@@ -170,6 +170,7 @@ mod tests {
     use crate::{
         db::SimpleDB,
         errors::ExecutionError,
+        materialization::{aggregation_function::AggregationFn, sum_function::SumFn},
         parser::{
             expression::Expression,
             predicate::{Predicate, Term},
@@ -299,6 +300,58 @@ mod tests {
         for i in 0..5 {
             assert!(scan.next()?);
             assert_eq!(scan.get_i32("B")?, Some(i + 1));
+        }
+        assert!(!scan.next()?);
+        drop(scan);
+        tx.lock().unwrap().commit()?;
+        Ok(())
+    }
+
+    #[test]
+    fn test_group_by_heuristic_query_planner() -> Result<(), ExecutionError> {
+        let temp_dir = tempfile::tempdir().unwrap().into_path().join("directory");
+        let block_size = 1024;
+        let num_buffers = 100;
+        let db = SimpleDB::new(temp_dir, block_size, num_buffers)?;
+        let tx = Arc::new(Mutex::new(db.new_transaction()?));
+
+        let table = "table1";
+        {
+            let mut md = db.metadata_manager.lock().unwrap();
+            let mut schema = Schema::new();
+            schema.add_i32_field("A");
+            schema.add_i32_field("B");
+            md.create_table(table, &schema, tx.clone())?;
+            md.create_index("IA", table, "A", tx.clone())?;
+        }
+
+        for i in 0..50 {
+            let update_command = format!("INSERT INTO {} (A, B) VALUES ({}, {})", table, i / 5, i);
+            db.planner
+                .lock()
+                .unwrap()
+                .execute_update(&update_command, tx.clone())?;
+        }
+
+        let query = QueryData::new_full(
+            Some(vec!["A".to_string(), "B".to_string()]),
+            vec![table.to_string()],
+            None,
+            Some(vec!["A".to_string()]),
+            None,
+            Vec::new(),
+            vec![AggregationFn::from(SumFn::new("B"))],
+        );
+
+        let planner = HeuristicQueryPlanner::new(db.metadata_manager.clone());
+        let mut plan = planner.create_plan(&query, tx.clone())?;
+
+        let mut scan = plan.open(tx.clone())?;
+        scan.before_first()?;
+        for i in 0..10 {
+            assert!(scan.next()?);
+            assert_eq!(scan.get_i32("A")?, Some(i));
+            assert_eq!(scan.get_i32("B")?, Some(25 * i + 10));
         }
         assert!(!scan.next()?);
         drop(scan);


### PR DESCRIPTION
Fix #127

## Summary
- add GROUP BY parsing and planning
- allow aggregation functions in SELECT lists
- implement GroupByPlan usage in query planners
- document exercise completion in README
- place GroupBy before ExtendPlan in planners

## Testing
- `cargo fmt`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6856954b10088329bdd03709020fe99c