### PR TITLE
Handle invalid table names gracefully

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -23,6 +23,9 @@ pub enum TransactionError {
 pub enum QueryError {
     #[error("ParseError: {0}")]
     ParseError(ParseError<usize, String, String>),
+
+    #[error("Table not found: {0}")]
+    TableNotFound(String),
 }
 
 impl From<ParseError<usize, Token<'_>, &str>> for QueryError {
@@ -66,6 +69,7 @@ mod tests {
                     }
                 );
             }
+            _ => panic!("Unexpected variant"),
         }
     }
 }

--- a/src/planner/basic_update_planner.rs
+++ b/src/planner/basic_update_planner.rs
@@ -132,6 +132,7 @@ impl UpdatePlanner for BasicUpdatePlanner {
 mod tests {
     use super::*;
     use crate::db::SimpleDB;
+    use crate::errors::ExecutionError;
 
     use crate::parser::{
         expression::Expression,
@@ -145,7 +146,7 @@ mod tests {
     use crate::record::field::Spec;
 
     #[test]
-    fn test_basic_update_planner() -> Result<(), TransactionError> {
+    fn test_basic_update_planner() -> Result<(), ExecutionError> {
         let temp_dir = tempfile::tempdir().unwrap().into_path().join("directory");
         let block_size = 256;
         let num_buffers = 100;

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -23,7 +23,7 @@ pub trait QueryPlanner: Send + Sync {
         &self,
         query: &QueryData,
         tx: Arc<Mutex<Transaction>>,
-    ) -> Result<Plan, TransactionError>;
+    ) -> Result<Plan, ExecutionError>;
 }
 
 pub trait UpdatePlanner: Send + Sync {


### PR DESCRIPTION
Fix #129

Adds a `TableNotFound` variant to `QueryError` and checks for table existence
when creating query plans. Query planners now return `ExecutionError` so that
invalid queries surface as errors instead of panics. Tests updated and new
coverage added for this case.

------
https://chatgpt.com/codex/tasks/task_e_6856c9bf77e88329b0fa10de10919d82