### PR TITLE
Add verbose option

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -317,7 +317,16 @@ fn run_client<W: Write, E: ClientEditor>(
 
 fn main() -> Result<(), anyhow::Error> {
     let mut editor = DefaultEditor::new()?;
-    let db_url = std::env::args().nth(1);
+    let mut db_url = None;
+    let mut verbose = false;
+    for arg in std::env::args().skip(1) {
+        if arg == "--verbose" {
+            verbose = true;
+        } else {
+            db_url = Some(arg);
+        }
+    }
+    simpledb_rs::config::set_verbose(verbose);
     run_client(
         Driver::Embedded(EmbeddedDriver::new()),
         &mut editor,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,11 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+
+static VERBOSE: AtomicBool = AtomicBool::new(false);
+
+pub fn set_verbose(verbose: bool) {
+    VERBOSE.store(verbose, Ordering::SeqCst);
+}
+
+pub fn is_verbose() -> bool {
+    VERBOSE.load(Ordering::SeqCst)
+}

--- a/src/driver/embedded.rs
+++ b/src/driver/embedded.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use crate::{
+    config,
     db::SimpleDB,
     errors::ExecutionError,
     plan::{Plan, PlanControl},
@@ -178,6 +179,9 @@ impl EmbeddedConnectionImpl {
     }
 
     fn print_file_access_stats(&self) {
+        if !config::is_verbose() {
+            return;
+        }
         let mut file_manager = self.db.file_manager.lock().unwrap();
         let tx_write_count = file_manager.file_access_stats.write_count;
         let tx_read_count = file_manager.file_access_stats.read_count;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod buffer;
+pub mod config;
 pub mod db;
 pub mod driver;
 pub mod errors;


### PR DESCRIPTION
Fix #133

- introduce global verbose flag
- show transaction stats only when verbose
- parse `--verbose` in client binary

------
https://chatgpt.com/codex/tasks/task_e_6856e5c0776483299fe58e260f066262