### PR TITLE
Ignore debug_print in coverage

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,9 @@
 use std::{env, path::PathBuf, process::Command};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Recognize Tarpaulin cfgs for conditional compilation without warnings
+    println!("cargo:rustc-check-cfg=cfg(tarpaulin)");
+    println!("cargo:rustc-check-cfg=cfg(tarpaulin_include)");
     let manifest_dir = env::var("CARGO_MANIFEST_DIR")?;
     let out_dir = PathBuf::from(&manifest_dir).join("src/proto");
     tonic_build::configure()

--- a/src/index/btree/btree_directory.rs
+++ b/src/index/btree/btree_directory.rs
@@ -138,6 +138,7 @@ impl BTreeDirectory {
     }
 
     #[allow(dead_code)]
+    #[cfg(not(tarpaulin_include))]
     pub(crate) fn debug_print(
         &self,
         btree_leaf_file_name: &str,


### PR DESCRIPTION
## Summary
- ignore `debug_print` in `BTreeDirectory` when measuring coverage
- avoid warnings by registering Tarpaulin cfg in `build.rs`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6857821088f48329a260510a05aff88d